### PR TITLE
Fix git clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```sh
 # Clone
-git clone git@github.com:reactioncommerce/styleguide.git
+git clone git@github.com:reactioncommerce/reaction-component-library.git
 
 cd styleguide
 


### PR DESCRIPTION
The git URL in the getting started guide now points to the right repo.