### PR TITLE
(fix): addcomponent script correct component path

### DIFF
--- a/.reaction/scripts/addcomponent.js
+++ b/.reaction/scripts/addcomponent.js
@@ -28,7 +28,7 @@ if (!componentName) {
   errorAndExit("You must include the name of the component to create as the first argument of this script");
 }
 
-const BASE_PATH = path.join(process.cwd(), "src/components");
+const BASE_PATH = path.join(process.cwd(), "package/src/components");
 const componentDirectory = path.join(BASE_PATH, componentName);
 
 function createComponentFile(name) {


### PR DESCRIPTION
## Issue
The addcomponent script was still pointing to the old components directory and would either error or create a component in the wrong place.

## Solution
Updated the script's output path from `src/components` to `package/sc/components`

## Test
Run `docker-compose up --build` to start the RC component lib
Run `docker-compose run --rm web node .reaction/scripts/addcomponent {component name}`
The new component should be added to the `package/src/components`