### PR TITLE
Add Price component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.2",
     "chalk": "1.1.3",
+    "check-prop-types": "^1.1.2",
     "composable-form-tests": "^0.2.0",
     "css-loader": "0.28.11",
     "dotenv": "4.0.0",

--- a/package/src/components/Price/v1/Price.js
+++ b/package/src/components/Price/v1/Price.js
@@ -1,0 +1,56 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { applyTheme } from "../../../utils";
+
+const Span = styled.span`
+  display: block;
+`;
+
+const Del = styled.del`
+  display: block;
+  color: ${applyTheme("color_disabled")};
+`;
+
+class Price extends Component {
+  static propTypes = {
+    /**
+     * A comparison price value, usually MSRP.
+     * This value is expected to have the currency symbol, i.e. $300.00
+     */
+    displayCompareAtPrice: PropTypes.string,
+    /**
+     * The product's price.
+     * This value is expected to have the currency symbol, i.e. $300.00
+     */
+    displayPrice: PropTypes.string.isRequired
+  }
+
+  renderCompareAtPrice = () => {
+    const { displayCompareAtPrice, displayPrice } = this.props;
+
+    // If there is no price difference, don't render compare at price.
+    if (displayPrice === displayCompareAtPrice) return null;
+
+    return (
+      <Del>
+        {displayCompareAtPrice}
+      </Del>
+    );
+  }
+
+  render() {
+    const { displayCompareAtPrice, displayPrice } = this.props;
+
+    return (
+      <div>
+        <Span>
+          {displayPrice}
+        </Span>
+        {displayCompareAtPrice ? this.renderCompareAtPrice() : null}
+      </div>
+    );
+  }
+}
+
+export default Price;

--- a/package/src/components/Price/v1/Price.md
+++ b/package/src/components/Price/v1/Price.md
@@ -1,0 +1,26 @@
+### Price
+
+#### Overview
+The `Price` component will be used anywhere a product's price is displayed.
+
+#### Basic usage without a compare at price.
+```jsx
+<div>
+  <Price displayPrice="$300.00" />
+</div>
+```
+
+#### Usage with a price and compare at price that are different.
+```jsx
+<div>
+  <Price displayPrice="$200.00" displayCompareAtPrice="$300.00" />
+</div>
+```
+
+#### What is displayed if the price and compare at price are the equal.
+The component expects string values of the prices to be strictly equal.
+```jsx
+<div>
+  <Price displayPrice="$300.00" displayCompareAtPrice="$300.00" />
+</div>
+```

--- a/package/src/components/Price/v1/Price.test.js
+++ b/package/src/components/Price/v1/Price.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import checkPropTypes from "check-prop-types";
+import Price from "./Price";
+
+test("Display error warning about required prop", () => {
+  const errorMessage = checkPropTypes(Price.propTypes, {});
+  expect(errorMessage).toMatchSnapshot();
+});
+
+test("Renders price without a compare at price", () => {
+  const component = renderer.create(<Price displayPrice="$300.00" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+
+test("Renders price with a compare at price", () => {
+  const component = renderer.create(<Price displayPrice="$300.00" displayCompareAtPrice="$400.00" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Renders price without a compare at price, due to the fact that the prices are equal.", () => {
+  const component = renderer.create(<Price displayPrice="$300.00" displayCompareAtPrice="$300.00" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/Price/v1/__snapshots__/Price.test.js.snap
+++ b/package/src/components/Price/v1/__snapshots__/Price.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Display error warning about required prop 1`] = `"Failed undefined type: The undefined \`displayPrice\` is marked as required in \`<<anonymous>>\`, but its value is \`undefined\`."`;
+
+exports[`Renders price with a compare at price 1`] = `
+.c0 {
+  display: block;
+}
+
+.c1 {
+  display: block;
+  color: #bfbfbf;
+}
+
+<div>
+  <span
+    className="c0"
+  >
+    $300.00
+  </span>
+  <del
+    className="c1"
+  >
+    $400.00
+  </del>
+</div>
+`;
+
+exports[`Renders price without a compare at price 1`] = `
+.c0 {
+  display: block;
+}
+
+<div>
+  <span
+    className="c0"
+  >
+    $300.00
+  </span>
+</div>
+`;
+
+exports[`Renders price without a compare at price, due to the fact that the prices are equal. 1`] = `
+.c0 {
+  display: block;
+}
+
+<div>
+  <span
+    className="c0"
+  >
+    $300.00
+  </span>
+</div>
+`;

--- a/package/src/components/Price/v1/index.js
+++ b/package/src/components/Price/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Price";

--- a/package/src/defaultComponentTheme.js
+++ b/package/src/defaultComponentTheme.js
@@ -152,6 +152,7 @@ const borderRadius = baseUnit(0.2);
 
 const defaultStyles = {
   rui_color_default: black55,
+  rui_color_disabled: black25,
   rui_color_error: red,
   rui_color_success: teal,
   rui_color_coolGrey: coolGrey,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -93,6 +93,11 @@ module.exports = {
           name: "Actions"
         }),
         generateSection({
+          componentNames: ["Price"],
+          content: "styleguide/src/sections/Product.md",
+          name: "Product"
+        }),
+        generateSection({
           componentNames: ["ErrorsBlock", "Field", "Select", "TextInput"],
           content: "styleguide/src/sections/Forms.md",
           name: "Forms"

--- a/styleguide/src/sections/Product.md
+++ b/styleguide/src/sections/Product.md
@@ -1,0 +1,1 @@
+TODO Write introduction to Cart

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,6 +1831,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+check-prop-types@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/check-prop-types/-/check-prop-types-1.1.2.tgz#c42df4fbdb509fbd4d8a102d113bb0ca01c21e67"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"


### PR DESCRIPTION
This component renders the price of the item in a cart. If there is a difference between the price of the item and the "compare at" price or "MSRP" price, the cart item price should indicate the comparable price crossed out and show the actual price below it.

Reference connected issue https://github.com/reactioncommerce/reaction-next-starterkit/issues/137 for more details.