### PR TITLE
Add StockWarning component

### DIFF
--- a/package/src/components/StockWarning/v1/StockWarning.js
+++ b/package/src/components/StockWarning/v1/StockWarning.js
@@ -1,0 +1,35 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { applyTheme } from "../../../utils";
+
+const Span = styled.span`
+  display: block;
+  color: ${applyTheme("color_error")};
+`;
+
+class StockWarning extends Component {
+  static propTypes = {
+    /**
+     * The product's current stock level
+     */
+    inventoryQuantity: PropTypes.number.isRequired,
+    /**
+     * When true, indicates that a product's inventory level has reached
+     * the low level threshold.
+     */
+    isLowInventoryQuantity: PropTypes.bool.isRequired
+  };
+
+  render() {
+    const { inventoryQuantity, isLowInventoryQuantity } = this.props;
+
+    if (!isLowInventoryQuantity) return null;
+
+    return (
+      <Span>Only { inventoryQuantity } in stock</Span>
+    );
+  }
+}
+
+export default StockWarning;

--- a/package/src/components/StockWarning/v1/StockWarning.md
+++ b/package/src/components/StockWarning/v1/StockWarning.md
@@ -1,0 +1,14 @@
+### StockWarning
+
+#### Overview
+The `StockWarning` displays a low inventory warning when the `isLowInventoryQuantity` prop is true.
+
+#### An inventory warning will be rendered when the `isLowInventoryQuantity` prop is `true`
+```jsx
+  <StockWarning inventoryQuantity={10} isLowInventoryQuantity={true} />
+```
+
+#### It's not rendered when a product has a normal inventory level
+```jsx
+  <StockWarning inventoryQuantity={10} isLowInventoryQuantity={false} />
+```

--- a/package/src/components/StockWarning/v1/StockWarning.test.js
+++ b/package/src/components/StockWarning/v1/StockWarning.test.js
@@ -1,0 +1,27 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import checkPropTypes from "check-prop-types";
+import StockWarning from "./StockWarning";
+
+test("Displays error warning about required props", () => {
+  const errorMessage = checkPropTypes(StockWarning.propTypes, {});
+  expect(errorMessage).toMatchSnapshot();
+});
+
+test("Renders stock warning when inventory is low", () => {
+  const component = renderer.create((
+    <StockWarning inventoryQuantity={10} isLowInventoryQuantity={true} />
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Renders nothing when stock level is normal", () => {
+  const component = renderer.create((
+    <StockWarning inventoryQuantity={10} isLowInventoryQuantity={false} />
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/StockWarning/v1/__snapshots__/StockWarning.test.js.snap
+++ b/package/src/components/StockWarning/v1/__snapshots__/StockWarning.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Displays error warning about required props 1`] = `"Failed undefined type: The undefined \`inventoryQuantity\` is marked as required in \`<<anonymous>>\`, but its value is \`undefined\`."`;
+
+exports[`Renders nothing when stock level is normal 1`] = `null`;
+
+exports[`Renders stock warning when inventory is low 1`] = `
+.c0 {
+  display: block;
+  color: #cd3f4c;
+}
+
+<span
+  className="c0"
+>
+  Only 
+  10
+   in stock
+</span>
+`;

--- a/package/src/components/StockWarning/v1/index.js
+++ b/package/src/components/StockWarning/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./StockWarning";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -93,7 +93,7 @@ module.exports = {
           name: "Actions"
         }),
         generateSection({
-          componentNames: ["Price"],
+          componentNames: ["Price", "StockWarning"],
           content: "styleguide/src/sections/Product.md",
           name: "Product"
         }),


### PR DESCRIPTION
The PR adds the `StockWarning` component that will render a warning when a product's inventory level reaches a low threshold.

See this issue for more details: https://github.com/reactioncommerce/reaction-next-starterkit/issues/136