### PR TITLE
chore(package.json): fix github repository and homepage link

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -2,8 +2,8 @@
   "name": "@reactioncommerce/components",
   "version": "0.2.0",
   "description": "Reaction Components",
-  "homepage": "https://github.com/reactioncommerce/styleguide",
-  "repository": "https://github.com/reactioncommerce/styleguide",
+  "homepage": "https://github.com/reactioncommerce/reaction-component-library",
+  "repository": "https://github.com/reactioncommerce/reaction-component-library",
   "author": {
     "name": "Reaction Commerce",
     "email": "engineering@reactioncommerce.com",


### PR DESCRIPTION
Updates the GitHub repository link in https://www.npmjs.com/package/@reactioncommerce/components. The https://www.npmjs.com/package/@reactioncommerce/components's GitHub.com link currently goes to a broken link.