### PR TITLE
chore(github): add PR template, bug report template, component request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Type: **breaking|critical|major|minor**
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/component_request.md
+++ b/.github/ISSUE_TEMPLATE/component_request.md
@@ -1,0 +1,46 @@
+---
+name: Component request
+about: Suggest a new component for this project
+
+---
+
+# Component Name
+
+## Overview / Summary
+### Summary description of UI component
+
+### Rationale for why this component is necessary
+
+### Expected use cases
+
+### Images / Designs of UI component in context
+
+### React State
+
+### Data Fetching
+
+### State Store
+
+### Routing / Query String
+
+### Render Criteria
+
+### Breakpoints
+#### Desktop, Tablet, Mobile
+
+## UI States
+#### Normal
+
+#### Empty
+
+#### Loading / retrieving data
+
+#### Processing / Waiting for response
+
+#### Error
+
+#### Active (e.g. button is depressed)
+
+#### Disabled
+
+#### Focus

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+Resolves #issueNumber  
+Impact: **breaking|critical|major|minor**  
+Type: **feature|bugfix|performance|test|style|refactor|docs|chore**
+
+<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->
+
+<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->
+
+## Component
+Description of the issue this PR is solving, why it's happening, and how to reproduce it. This may differ from the original ticket as you now have more information at your disposal.
+
+## Solution
+Summarize your solution to the problem. Please include short descriptions of any solutions you tested before arriving at your final solution. This will help reviewers know why you decided to solve this problem in this particular way and will speed up the review process.
+
+## Screenshots
+Include mobile screenshots as well.
+
+## Breaking changes
+You should almost never include "BREAKING CHANGES" because we’re duplicating components to avoid that. Consult with others before doing it.
+
+## Testing
+1. List the steps needed for testing your change in this section.
+2. Assume that testers already know how to start the app, and do the basic setup tasks.
+3. Be detailed enough that someone can work through it without being too granular
+
+More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 


### PR DESCRIPTION
Resolves #91  
Impact: **minor**  
Type: **chore**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Issue
PR and issues formats are not standardized.

## Solution
- Add a `pull_request_template.md` file in `.github` folder to create a PR template
- Add 2 issue request templates in `ISSUE_TEMPLATE` folder for a component request, and for bug reports
- ⚠️:  📦🚀Adds a note about semantic release on the PR template so people are alerted!

## Screenshots

<img width="783" alt="screen shot 2018-06-27 at 9 56 33 am" src="https://user-images.githubusercontent.com/3673236/41988262-66e32f64-79f0-11e8-8f9d-cec8106747f3.png">
