### PR TITLE
docs: document process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Resolves #issueNumber  
+Resolves #issueNumber
 Impact: **breaking|critical|major|minor**  
 Type: **feature|bugfix|performance|test|style|refactor|docs|chore**
 
@@ -7,13 +7,12 @@ Type: **feature|bugfix|performance|test|style|refactor|docs|chore**
 <!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->
 
 ## Component
-Description of the issue this PR is solving, why it's happening, and how to reproduce it. This may differ from the original ticket as you now have more information at your disposal.
-
-## Solution
-Summarize your solution to the problem. Please include short descriptions of any solutions you tested before arriving at your final solution. This will help reviewers know why you decided to solve this problem in this particular way and will speed up the review process.
+Description of the issue this component this PR adds. Also include, as necessary:
+- Any other components this component requires
+- Any NPM dependencies added
 
 ## Screenshots
-Include mobile screenshots as well.
+Include mobile and desktop screenshots.
 
 ## Breaking changes
 You should almost never include "BREAKING CHANGES" because we’re duplicating components to avoid that. Consult with others before doing it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 
 ## Creating and Modifying Components
 
-- [Writing a Component ticket](../.github/ISSUE_TEMPLATE/component-request.md)
+- [Writing a Component ticket](../.github/ISSUE_TEMPLATE/component_request.md)
 - [Creating a New Component](./creating-new-component.md)
 - [Creating a New Version of a Component](./creating-new-component-version.md)
 - [Component Development Guidelines](./component-development-guidelines.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,14 @@
 
 ## Creating and Modifying Components
 
+- [Writing a Component ticket](././.github/ISSUE_TEMPLATE/component-request.md)
 - [Creating a New Component](./creating-new-component.md)
 - [Creating a New Version of a Component](./creating-new-component-version.md)
 - [Component Development Guidelines](./component-development-guidelines.md)
+
+## Component Review process
+
+- [Reviewing Components](./reviewing-components.md)
 
 ## Architectural Decisions Records
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 
 ## Creating and Modifying Components
 
-- [Writing a Component ticket](././.github/ISSUE_TEMPLATE/component-request.md)
+- [Writing a Component ticket](../.github/ISSUE_TEMPLATE/component-request.md)
 - [Creating a New Component](./creating-new-component.md)
 - [Creating a New Version of a Component](./creating-new-component-version.md)
 - [Component Development Guidelines](./component-development-guidelines.md)

--- a/docs/reviewing-components.md
+++ b/docs/reviewing-components.md
@@ -1,0 +1,13 @@
+# Reviewing Components
+
+A Pull Request for a component will be reviewed by three groups:
+1. **Development** - Developer checks for code style, code tests and component functionality
+1. **Design** - Designer checks for design specs of the component itself.
+1. **Documentation** - Documentation checks for how the component and documentation render on the Component Library site.
+
+Reviewers should be able to view the component live in a Netlify deployed branch.
+
+After the component is approved, the NPM module will be released with semantic release.
+
+Once the component is published, developers can use the new component in any project, like the [Reaction Storefront Next.js Starter Kit](https://github.com/reactioncommerce/reaction-next-starterkit). Designers will then review the component again, to check that the component has been implemented to proper design usage guidelines.
+


### PR DESCRIPTION
Resolves #105   
Impact: **minor**  
Type: **docs**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Solution
- Add a link to the Component issue template
- Add 2 things to the PR template: Does this component require other components? Does this component add any NPM dependencies?
- Add a Component Review doc that goes over how a Component PR review should be checked off by Design, Dev and Doc before publishing.

## Testing + Review
1. Read the [docs](https://github.com/reactioncommerce/reaction-component-library/tree/105-machikoyasuda-docs-process/docs), with particular attention to [Component review process](https://github.com/reactioncommerce/reaction-component-library/blob/105-machikoyasuda-docs-process/docs/reviewing-components.md)
2. Does it make sense? Leave a comment with your thoughts below ⬇️ 