### PR TITLE
style bug: make markdown code snippets readable

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -77,8 +77,7 @@ module.exports = {
     maxWidth: 1000,
     color: {
       link: "#062a4e",
-      linkHover: "#fd8283",
-      codeBackground: "#233444"
+      linkHover: "#fd8283"
     },
     fontFamily: {
       base: [


### PR DESCRIPTION
Impact: **minor**  
Type: **style**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Issue

`tldr`: The Markdown code blocks are hard to read. This is a temporary bug fix to change the Markdown code backgrounds back to a light grey, to match the syntax highlighting style React Styleguidist (RSG) uses.

`the long story`: RSG uses highlight.js to highlight the Markdown code blocks, and also uses CodeMirror for all the code blocks in the Component section. The CodeMirror theme is configurable in `styleguide.config.js`*, but the Markdown theme is _not_. The Markdown highlight.js theme is hardcoded in their component here: https://github.com/styleguidist/react-styleguidist/blob/66be5011eb773d0107fea9d8e054968a737b5574/src/rsg-components/Markdown/Markdown.js#L18 at `tomorrow.css` which gets injected as inline-css on all pages:
<img width="682" alt="screen shot 2018-07-03 at 1 09 14 pm" src="https://user-images.githubusercontent.com/3673236/42242348-6494d948-7ec2-11e8-8ba3-b73d246c1271.png">

This is the theme currently hardcoded into RSG: http://jmblog.github.io/color-themes-for-highlightjs/tomorrow/

I thought I could simply add a link in `index.html` to the same highlight.js theme we use in docs, https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css, but the inline-css overrides that. It's harder to override. I will add a ticket for creating a new Markdown component with the highlight.js css overridden, but this will take more time. I think this fix is sufficient for now.

*CodeMirror is currently configured to `oceanic-next`: https://codemirror.net/demo/theme.html#oceanic-next - it's the closest I found to `atom-one-dark`, used in Docs.


## Screenshots
<img width="1440" alt="screen shot 2018-07-03 at 12 59 58 pm" src="https://user-images.githubusercontent.com/3673236/42241988-4d8b1d26-7ec1-11e8-8f0e-43cf8956ee06.png">

## Testing
1. Check that all code snippets are readable

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
