### PR TITLE
fix: hardcode serverPort to 4040

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -320,7 +320,7 @@ module.exports = {
   pagePerSection: true,
   showCode: true,
   showUsage: true,
-  serverPort: Number(process.env.PORT),
+  serverPort: 4040,
   assetsDir: "styleguide/src/assets/",
   template: "styleguide/src/index.html"
   // handlers(componentPath) {


### PR DESCRIPTION
## Issue

- Issue: Using `Number(process.env.PORT)` throws a bug in the CI, because CI does not have access to `process`.

## The fix

- Hardcode the `serverPort` to 4040.

## Test it

- The test deploy of this branch is :100:
https://app.netlify.com/sites/stoic-hodgkin-c0179e/deploys/5b4550163813f027affab0bc
