### PR TITLE
feat: add ShopLogo component

### DIFF
--- a/package/src/components/ShopLogo/v1/ShopLogo.js
+++ b/package/src/components/ShopLogo/v1/ShopLogo.js
@@ -1,0 +1,32 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+export default class ShopLogo extends Component {
+  static propTypes = {
+    /**
+     * The primary shop's logo url
+     */
+    shopLogoUrl: PropTypes.string,
+    /**
+     * The primary shop's name
+     */
+    shopName: PropTypes.string.isRequired
+  }
+
+  render() {
+    const { shopLogoUrl, shopName } = this.props;
+
+    return (
+      <div>
+        {
+          shopLogoUrl ? (
+            <img src={shopLogoUrl} alt={shopName} />
+          ) : (
+            shopName
+          )
+        }
+      </div>
+    );
+  }
+}
+

--- a/package/src/components/ShopLogo/v1/ShopLogo.md
+++ b/package/src/components/ShopLogo/v1/ShopLogo.md
@@ -1,0 +1,14 @@
+### ShopLogo
+
+#### Overview
+Renders a shop's logo if a logo URL is provided, otherwise, it will render the shop's name.
+
+#### Basic usage with a shop logo URL
+```jsx
+<ShopLogo shopLogoUrl="http://placehold.it/60" shopName="Reaction" />
+```
+
+#### Without a shop logo URL
+```jsx
+<ShopLogo shopName="Reaction" />
+```

--- a/package/src/components/ShopLogo/v1/ShopLogo.test.js
+++ b/package/src/components/ShopLogo/v1/ShopLogo.test.js
@@ -1,0 +1,12 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import ShopLogo from "./ShopLogo";
+
+test("basic snapshot", () => {
+  const component = renderer.create((
+    <ShopLogo shopLogoUrl="http://placehold.it/60" shopName="Reaction" />
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/ShopLogo/v1/__snapshots__/ShopLogo.test.js.snap
+++ b/package/src/components/ShopLogo/v1/__snapshots__/ShopLogo.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<div>
+  <img
+    alt="Reaction"
+    src="http://placehold.it/60"
+  />
+</div>
+`;

--- a/package/src/components/ShopLogo/v1/index.js
+++ b/package/src/components/ShopLogo/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ShopLogo";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -289,6 +289,11 @@ module.exports = {
           name: "Checkout"
         }),
         generateSection({
+          componentNames: ["ShopLogo"],
+          content: "styleguide/src/sections/General.md",
+          name: "General"
+        }),
+        generateSection({
           componentNames: ["Price", "StockWarning"],
           content: "styleguide/src/sections/Product.md",
           name: "Product"

--- a/styleguide/src/sections/General.md
+++ b/styleguide/src/sections/General.md
@@ -1,0 +1,2 @@
+TODO Write introduction General components
+


### PR DESCRIPTION
Resolves #104 
Impact: minor
Type: feature

## Component
This component is intended to be used to render a shops logo or name depending on the props provided. Further, I can be used in multiple places, such as the site header in the main layout to render the shop's logo, or in the checkout page.


## Breaking changes
N/A

## Testing
1. Verify component renders placeholder image or provided shop name.
