### PR TITLE
Add component styling conventions documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,10 @@
 - [Creating a New Version of a Component](./creating-new-component-version.md)
 - [Component Development Guidelines](./component-development-guidelines.md)
 
+## Component Styling Conventions
+
+- [Styling Conventions](./styling-conventions.md)
+
 ## Component Review process
 
 - [Reviewing Components](./reviewing-components.md)

--- a/docs/styling-conventions.md
+++ b/docs/styling-conventions.md
@@ -1,0 +1,12 @@
+# Component Styling Conventions
+
+### Summary
+By convention visual and text styles should be baked into each component. This means that a containing element should set the font-family, font-weight, font-size etc. This convention will make it easier to integrate components into the Reaction Starter Kit and other environments. Further, style values should be retrieved from the theme as seen in the example below.
+
+```
+const Del = styled.del`
+  color: ${applyTheme("color_disabled")};
+  font-family: ${applyTheme("font_family")};
+  font-size: ${applyTheme("font_size_small")};
+`;
+```


### PR DESCRIPTION
Resolves #144 
Impact: minor
Type: docs

## Summary
Add documentation on our conventions for styling components.