### PR TITLE
chore(deployment): build styleguide in styleguide/dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ node_modules
 reports/*
 **/package-lock.json
 dist
+
+styleguide/build/
+styleguide/favicon.ico
+styleguide/favicon.png
+styleguide/fonts/
+styleguide/index.html
+styleguide/manifest.json
+styleguide/reaction-design-system-logo.svg

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ For this project specifically:
 
 The `@reactioncommerce/components` package is automatically published by CI when commits are merged or pushed to the `master` branch. This is done using [semantic-release](https://www.npmjs.com/package/semantic-release), which also determines version bumps based on conventional Git commit messages.
 
+## Style Guide Publication
+
+The site is built by (`react-styleguidist`)[https://github.com/styleguidist/react-styleguidist] and automatically published by CI and Netlify when commits are pushed to pull requests and the `master` branch.
+
+Test the build locally by running `docker-compose run --rm web yarn run styleguide:build` and opening `styleguide/dist/index.html` in your browser.
+
 ## License
 
 Copyright © [GNU General Public License v3.0](./LICENSE.md)

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -332,6 +332,7 @@ module.exports = {
   showUsage: true,
   serverPort: Number(process.env.PORT),
   assetsDir: "styleguide/src/assets/",
+  styleguideDir: "styleguide/dist",
   template: "styleguide/src/index.html"
   // handlers(componentPath) {
   //   return defaultHandlers.concat(


### PR DESCRIPTION
Issue: #145 
Impact: **major**  -  because it changes the way we deploy and release
Type: **chore**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Issue

I'd like to be able to run `styleguide:build` locally to make sure it's working, make sure the build looks correct, without triggering Git. We have a few files that _are_ required in `styleguide/src`, so I want to selectively gitignore all of the other files. Instead of doing this by adding it to the gitignore, I am:

- Changing the `styleguide:build` output directory to `dist`. This directory is already gitignored.
- Now that this PR is already being preview-branch-deployed, the build directory will be changed from `styleguide/` to `styleguide/dist`.

## Screenshots

Now when you run `styleguide:build`, the app is built into `styleguide/dist`:

```sh
$ docker-compose run --rm web yarn run styleguide:build
yarn run v1.6.0
warning package.json: License should be a valid SPDX license expression
$ styleguidist build
Building style guide...
Style guide published to:
/usr/local/src/reaction-app/styleguide/dist
Done in 29.03s.
```

And the logs in Netlify for this PR build:

```sh
3:25:54 PM: $ styleguidist build
3:25:54 PM: Building style guide...
3:26:23 PM: Style guide published to:
3:26:23 PM: /opt/build/repo/styleguide/dist
3:26:24 PM: Done in 30.72s.
3:26:27 PM: Starting to deploy site from 'styleguide/dist'
3:26:27 PM: Starting post processing
3:26:27 PM: Post processing done
3:26:27 PM: Site is live
3:26:47 PM: Finished processing build request in 1m32.504795577s
```
## Testing
1. Run `docker-compose run --rm web yarn styleguide:build` and confirm files are built into `styleguide/dist`
2. Run `git status`
3. You not see any files tracked in Git