### PR TITLE
docs(#146): backfill docs with sections

### DIFF
--- a/.reaction/scripts/addcomponent.js
+++ b/.reaction/scripts/addcomponent.js
@@ -58,7 +58,7 @@ function createComponentTestFile(name) {
 function createComponentMarkdownFile(name) {
   const filePath = path.join(componentDirectory, "v1", `${name}.md`);
   fs.ensureFileSync(filePath);
-  fs.writeFileSync(filePath, `### ${name}
+  fs.writeFileSync(filePath, `### Overview\n#### Usage
 
 Document component here. See https://react-styleguidist.js.org/docs/documenting.html`);
 }

--- a/package/src/components/Button/v1/Button.md
+++ b/package/src/components/Button/v1/Button.md
@@ -1,86 +1,56 @@
-### Buttons Overview
+### Overview
 
 Buttons are used to enable a user to take an action. Buttons should clearly and simply communicate the action that will happen when they are pressed.
 
-#### General Usage
+#### Usage
 
 There are four types of buttons you can choose from, and which one you choose should be based on which type of action it causes.
 
-- The solid button is used for a primary action in a modal, card, large view and generally throughout.
-- The outline button is used for a secondary or dismissive action. The outline button should be paired with the solid button in cases such as dismissing a modal or canceling an action.
-- The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
-- The important button is used when there needs to be particular importance put on an action or in a view where there are multiple actions and more emphasis needs to be drawn to specific or most common action in a view.
+1. **Solid button**: The solid button is used for a primary action in a modal, card, large view and generally throughout.
+1. **Outline button**: The outline button is used for a secondary or dismissive action. The outline button should be paired with the solid button in cases such as dismissing a modal or canceling an action.
+1. **Danger button**: The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.
+1. **Important button**: The important button is used when there needs to be particular importance put on an action or in a view where there are multiple actions and more emphasis needs to be drawn to specific or most common action in a view.
+
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button title="Default" className="myBtn">Default</Button>
+  </div>
+    <div style={{ marginRight: "1rem" }}>
+    <Button title="Secondary" className="myBtn" actionType="secondary">Outline</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button title="Danger" className="myBtn" actionType="danger">Danger</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button title="Important" className="myBtn" actionType="important">Important</Button>
+  </div>
+</div>
+```
 
 And there are a couple possible variations:
 
-- Any of these button types can be rendered with less height using the "short" variant.
-- The default button can be rendered as text only (similar to a link) by using the "text" style variant. Use this in rare cases where having a solid or outline button for an action would be cluttered and visually confusing.
+- **Short**: Any of these button types can be rendered with less height using the "short" variant.
+- **Text-only**: The default button can be rendered as text only (similar to a link) by using the "text" style variant. Use this in rare cases where having a solid or outline button for an action would be cluttered and visually confusing.
+- **Waiting**: This disables clicks and shows a spinner to the right of the button content when `isWaiting` is set to `true`.
 
-#### Component Usage
+```jsx
+<div style={{ display: "flex" }}>
+  <div style={{ marginRight: "1rem" }}>
+    <Button title="Default" className="myBtn" isShortHeight>Default Short</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button title="Default" className="myBtn" isTextOnly>Default Text-Only</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button actionType="default" isWaiting={true}>Default Waiting</Button>
+  </div>
+</div>
+```
 
-The `Button` component can render with four different possible appearances, which are chosen based on the `actionType` prop value. You should choose the appropriate appearance based on what type of action will happen if you click it.
+#### Types and variations
 
-The actual colors of the appearance are defined by your theme. The examples here use our default theme. The theme properties used by the `Button` component are:
-
-- `rui_buttonBackgroundColor_danger_active`
-- `rui_buttonBackgroundColor_danger_hover`
-- `rui_buttonBackgroundColor_danger`
-- `rui_buttonBackgroundColor_default_active`
-- `rui_buttonBackgroundColor_default_hover`
-- `rui_buttonBackgroundColor_default`
-- `rui_buttonBackgroundColor_disabled`
-- `rui_buttonBackgroundColor_important_active`
-- `rui_buttonBackgroundColor_important_hover`
-- `rui_buttonBackgroundColor_important`
-- `rui_buttonBackgroundColor_secondary_active`
-- `rui_buttonBackgroundColor_secondary_hover`
-- `rui_buttonBackgroundColor_secondary`
-- `rui_buttonBackgroundColor_secondaryDanger_active`
-- `rui_buttonBackgroundColor_secondaryDanger_hover`
-- `rui_buttonBackgroundColor_secondaryDanger`
-- `rui_buttonBorderColor_danger_active`
-- `rui_buttonBorderColor_danger_hover`
-- `rui_buttonBorderColor_danger`
-- `rui_buttonBorderColor_default_active`
-- `rui_buttonBorderColor_default_hover`
-- `rui_buttonBorderColor_default`
-- `rui_buttonBorderColor_disabled`
-- `rui_buttonBorderColor_important_active`
-- `rui_buttonBorderColor_important_hover`
-- `rui_buttonBorderColor_important`
-- `rui_buttonBorderColor_secondary_active`
-- `rui_buttonBorderColor_secondary_hover`
-- `rui_buttonBorderColor_secondary`
-- `rui_buttonBorderColor_secondaryDanger_active`
-- `rui_buttonBorderColor_secondaryDanger_hover`
-- `rui_buttonBorderColor_secondaryDanger`
-- `rui_buttonBorderRadius`
-- `rui_buttonForegroundColor_danger_active`
-- `rui_buttonForegroundColor_danger_hover`
-- `rui_buttonForegroundColor_danger`
-- `rui_buttonForegroundColor_default_active`
-- `rui_buttonForegroundColor_default_hover`
-- `rui_buttonForegroundColor_default`
-- `rui_buttonForegroundColor_disabled`
-- `rui_buttonForegroundColor_important_active`
-- `rui_buttonForegroundColor_important_hover`
-- `rui_buttonForegroundColor_important`
-- `rui_buttonForegroundColor_secondary_active`
-- `rui_buttonForegroundColor_secondary_hover`
-- `rui_buttonForegroundColor_secondary`
-- `rui_buttonForegroundColor_secondaryDanger_active`
-- `rui_buttonForegroundColor_secondaryDanger_hover`
-- `rui_buttonForegroundColor_secondaryDanger`
-- `rui_buttonHorizontalPadding`
-- `rui_buttonMinimumWidth`
-- `rui_buttonTextOnlyColor_default_active`
-- `rui_buttonTextOnlyColor_default_hover`
-- `rui_buttonTextOnlyColor_default`
-- `rui_buttonTextOnlyColor_disabled`
-- `rui_buttonVerticalPadding`
-- `rui_buttonVerticalPaddingShort`
-
-#### Default Solid Button
+##### Default Solid Button
 
 The solid button is used for a primary action in a modal, card, large view and generally throughout. The solid button is the most common button and should be your first choice.
 
@@ -144,7 +114,7 @@ Combines `isTextOnly` with `isShortHeight`
 </div>
 ```
 
-#### Secondary Button
+##### Secondary Button
 
 The outline button style is used for a secondary or dismissive action. The outline button should be paired with the solid button in cases such as dismissing a modal or canceling an action.
 
@@ -176,7 +146,7 @@ To get a short button, use `isShortHeight` on your outline button.
 </div>
 ```
 
-#### Important Button
+##### Important Button
 
 The important button is used when there needs to be particular importance put on an action or in a view where there are multiple actions and more emphasis needs to be drawn to specific or most common action in a view.
 
@@ -208,7 +178,7 @@ To get a short button, use `isShortHeight` on your important button.
 </div>
 ```
 
-#### Danger Button
+##### Danger Button
 
 The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.  If a danger button is used to initiate a destructive action it should always trigger a confirmation modal.
 
@@ -240,7 +210,7 @@ To get a short button, use `isShortHeight` on your danger button.
 </div>
 ```
 
-#### Secondary Danger Button
+##### Secondary Danger Button
 
 The danger button is used for a destructive action that is difficult to recover from such as deleting information. The danger button should be used at the point that the destructive action actually takes place. For example, you can have a delete button as a secondary action on a page and in this case you would use a an outline button, the outline button would then trigger a modal confirmation, which is where you would use the danger button.  If a danger button is used to initiate a destructive action it should always trigger a confirmation modal.
 
@@ -274,7 +244,7 @@ To get a short button, use `isShortHeight` on your secondary danger outline butt
 </div>
 ```
 
-#### Waiting Button
+##### Waiting Button
 
 Any button style can have a "waiting" style added to it by passing `isWaiting` prop as `true`. This will also disable clicks and show a spinner to the right of the button content.
 
@@ -332,7 +302,7 @@ const onClick = () => { setState({ isWaiting: true }); setTimeout(() => { setSta
 </div>
 ```
 
-#### Full Width Button
+##### Full Width Button
 
 To make any button take up the full width of its container, add `fullWidth` prop.
 
@@ -357,3 +327,67 @@ const divStyles = {
   <Button className="myBtn" isWaiting={state.isWaiting} onClick={() => { setState({ isWaiting: true }); setTimeout(() => { setState({ isWaiting: false }); }, 3000); }}>Click to See Waiting</Button>
 </div>
 ```
+
+#### Component usage
+
+The `Button` component can render with four different possible appearances, which are chosen based on the `actionType` prop value. You should choose the appropriate appearance based on what type of action will happen if you click it.
+
+The actual colors of the appearance are defined by your theme. The examples here use our default theme. The theme properties used by the `Button` component are:
+
+- `rui_buttonBackgroundColor_danger_active`
+- `rui_buttonBackgroundColor_danger_hover`
+- `rui_buttonBackgroundColor_danger`
+- `rui_buttonBackgroundColor_default_active`
+- `rui_buttonBackgroundColor_default_hover`
+- `rui_buttonBackgroundColor_default`
+- `rui_buttonBackgroundColor_disabled`
+- `rui_buttonBackgroundColor_important_active`
+- `rui_buttonBackgroundColor_important_hover`
+- `rui_buttonBackgroundColor_important`
+- `rui_buttonBackgroundColor_secondary_active`
+- `rui_buttonBackgroundColor_secondary_hover`
+- `rui_buttonBackgroundColor_secondary`
+- `rui_buttonBackgroundColor_secondaryDanger_active`
+- `rui_buttonBackgroundColor_secondaryDanger_hover`
+- `rui_buttonBackgroundColor_secondaryDanger`
+- `rui_buttonBorderColor_danger_active`
+- `rui_buttonBorderColor_danger_hover`
+- `rui_buttonBorderColor_danger`
+- `rui_buttonBorderColor_default_active`
+- `rui_buttonBorderColor_default_hover`
+- `rui_buttonBorderColor_default`
+- `rui_buttonBorderColor_disabled`
+- `rui_buttonBorderColor_important_active`
+- `rui_buttonBorderColor_important_hover`
+- `rui_buttonBorderColor_important`
+- `rui_buttonBorderColor_secondary_active`
+- `rui_buttonBorderColor_secondary_hover`
+- `rui_buttonBorderColor_secondary`
+- `rui_buttonBorderColor_secondaryDanger_active`
+- `rui_buttonBorderColor_secondaryDanger_hover`
+- `rui_buttonBorderColor_secondaryDanger`
+- `rui_buttonBorderRadius`
+- `rui_buttonForegroundColor_danger_active`
+- `rui_buttonForegroundColor_danger_hover`
+- `rui_buttonForegroundColor_danger`
+- `rui_buttonForegroundColor_default_active`
+- `rui_buttonForegroundColor_default_hover`
+- `rui_buttonForegroundColor_default`
+- `rui_buttonForegroundColor_disabled`
+- `rui_buttonForegroundColor_important_active`
+- `rui_buttonForegroundColor_important_hover`
+- `rui_buttonForegroundColor_important`
+- `rui_buttonForegroundColor_secondary_active`
+- `rui_buttonForegroundColor_secondary_hover`
+- `rui_buttonForegroundColor_secondary`
+- `rui_buttonForegroundColor_secondaryDanger_active`
+- `rui_buttonForegroundColor_secondaryDanger_hover`
+- `rui_buttonForegroundColor_secondaryDanger`
+- `rui_buttonHorizontalPadding`
+- `rui_buttonMinimumWidth`
+- `rui_buttonTextOnlyColor_default_active`
+- `rui_buttonTextOnlyColor_default_hover`
+- `rui_buttonTextOnlyColor_default`
+- `rui_buttonTextOnlyColor_disabled`
+- `rui_buttonVerticalPadding`
+- `rui_buttonVerticalPaddingShort`

--- a/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.md
+++ b/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.md
@@ -1,9 +1,10 @@
-### CartEmptyMessage
-
-#### Overview
+### Overview
 The `CartEmptyMessage` displays when viewing an empty shopping cart.
 
-#### A cart empty message will be rendered when there are no items in your cart
+#### Usage 
+
+##### Default
+
 ```jsx
 const onClick = () => {};
 
@@ -13,7 +14,10 @@ const onClick = () => {};
   />
 ```
 
-#### It's possible to customize message and button text
+##### Custom cart and button message
+
+Pass in custom copy in `buttonText` and `messageText`.
+
 ```jsx
 const onClick = () => {};
 

--- a/package/src/components/CartItem/v1/CartItem.md
+++ b/package/src/components/CartItem/v1/CartItem.md
@@ -1,10 +1,13 @@
-### CartItem
+### Overview
 
-#### Overview
-This component will be used when there is a need to show an item that customer has added to their cart.
-It could be used in the future to show items that are within a "Wish List", "Saved for Later", or other customer generated lists of un-purchased products. There's potential that with a few modifications could be used to show Order Items, though the type and amount of information shown within an order item may be different enough to warrant a separate component.
+This component will be used when there is a need to show an item that customer has added to their cart. A CartItem displays an item's image, name, quantity, price and attributes. CartItem can also display a compare at price and stock quantity warning label. A CartItem allows users to change the quantity of the item and remove the item.
 
-#### Basic Usage
+#### Usage
+
+CartItem can be used in CartItems and also in MiniCart. It could be used in the future to show items that are within a "Wish List", "Saved for Later", or other customer generated lists of un-purchased products. There's potential that with a few modifications could be used to show Order Items, though the type and amount of information shown within an order item may be different enough to warrant a separate component.
+
+##### Default
+
 ```jsx
 const item = {
   _id: "123",
@@ -40,7 +43,7 @@ const item = {
 />
 ```
 
-#### Without Compare At Price
+##### Without Compare At Price
 ```jsx
 const item = {
   _id: "123",
@@ -73,7 +76,7 @@ const item = {
 />
 ```
 
-#### Without Stock Warning
+##### Without Stock Warning
 ```jsx
 const item = {
   _id: "123",
@@ -109,7 +112,7 @@ const item = {
 />
 ```
 
-#### In Mini Cart
+##### In Mini Cart
 ```jsx
 const item = {
   _id: "123",

--- a/package/src/components/CartItemDetail/v1/CartItemDetail.md
+++ b/package/src/components/CartItemDetail/v1/CartItemDetail.md
@@ -1,21 +1,22 @@
-### CartItemDetail
-
-#### Overview
+### Overview
 Display CartItem title and attributes.
 
-#### Basic Usage
+#### Usage
+
+It can be used in Cart or in Mini Cart.
+
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
 <CartItemDetail title="Amazing Product Title" productSlug="/product-slug" attributes={attributes} />
 ```
 
-#### With Product Vendor
+##### With Product Vendor
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
 <CartItemDetail title="Amazing Product Title" productSlug="/product-slug" productVendor="Patagonia" attributes={attributes} />
 ```
 
-#### In Mini Cart
+##### In Mini Cart
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
 <CartItemDetail title="Amazing Product Title" productSlug="/product-slug" productVendor="Patagonia" attributes={attributes} isMiniCart />

--- a/package/src/components/CartItems/v1/CartItems.md
+++ b/package/src/components/CartItems/v1/CartItems.md
@@ -1,9 +1,12 @@
-### CartItems
-
 ### Overview
-This component renders a list of items that are in a customers cart.
+This component renders a list of CartItems that are in a customers cart.
 
-#### Basic Usage
+#### Usage
+
+CartItems can be used in the Cart or the MiniCart.
+
+#### In Cart
+
 ```jsx
 const items = [{
   _id: "123",

--- a/package/src/components/CartSummary/v1/CartSummary.md
+++ b/package/src/components/CartSummary/v1/CartSummary.md
@@ -1,9 +1,12 @@
-### CartSummary
-
 ### Overview
-Displays a summary of the current current items in the cart.
+Displays a summary of the current current items in the cart, with cost and other optional information.
 
-#### Basic usage
+#### Usage
+
+The CartSummary displays item quantity, subtotal, shipping, tax and total. The cart can also display a free shipping message, calculated taxes and any applied discounts.
+
+##### Default 
+
 ```jsx
 <CartSummary
   displayShipping="$10.99"
@@ -13,7 +16,8 @@ Displays a summary of the current current items in the cart.
 />
 ```
 
-#### Renders summary with FREE shipping
+##### Display free shipping
+
 ```jsx
 <CartSummary
   displaySubtotal="$275.77"
@@ -23,7 +27,8 @@ Displays a summary of the current current items in the cart.
 />
 ```
 
-#### Renders summary with calculated taxes
+##### Display calculated taxes
+
 ```jsx
 <CartSummary
   displayShipping="$5.25"
@@ -34,7 +39,8 @@ Displays a summary of the current current items in the cart.
 />
 ```
 
-#### Renders summary with applied discount
+##### Display applied discount
+
 ```jsx
 <CartSummary
   displayDiscount="-$83.42"

--- a/package/src/components/Checkbox/v1/Checkbox.md
+++ b/package/src/components/Checkbox/v1/Checkbox.md
@@ -1,4 +1,4 @@
-# Overview
+### Overview
 
 Checkboxes can be checked, unchecked and disabled.
 
@@ -10,7 +10,7 @@ Checkboxes can be checked, unchecked and disabled.
 </div>
 ```
 
-## Usage
+#### Usage
 
 ##### Checkbox
 
@@ -23,7 +23,7 @@ Checkboxes can be checked, unchecked and disabled.
 - All labels should be written in sentence caps.
 - Labels should be left-aligned in forms.
 
-## Specs
+#### Specs
 
 ##### Checkbox
 

--- a/package/src/components/CheckoutAction/v1/CheckoutAction.md
+++ b/package/src/components/CheckoutAction/v1/CheckoutAction.md
@@ -1,7 +1,11 @@
-#### Overview
-The CheckoutActionComplete component will show when a checkout action has been completed. It is a summary of the information inside the completed action.
+### Overview
 
-#### Basic usage, `active` status
+The `CheckoutAction` component wraps the `CheckoutActionComplete` and `CheckoutActionIncomplete` components.
+
+#### Usage
+
+##### Default: `Active` status
+
 ```jsx
 const Address = (
   <div>
@@ -33,7 +37,7 @@ const Address = (
 </div>
 ```
 
-#### Basic usage, `complete` status
+##### Default: `Complete` status
 ```jsx
 const Address = (
   <div>
@@ -65,7 +69,7 @@ const Address = (
 </div>
 ```
 
-#### Basic usage, `incomplete` status
+##### Default: `Incomplete` status
 ```jsx
 const Address = (
   <div>
@@ -97,7 +101,8 @@ const Address = (
 </div>
 ```
 
-#### Passing in `label` or `stepNumber` props on an element to override default
+#### Override default `label` or `stepNumber`
+
 ```jsx
 const onClick = () => {};
 const Address = (

--- a/package/src/components/CheckoutActionComplete/v1/CheckoutActionComplete.md
+++ b/package/src/components/CheckoutActionComplete/v1/CheckoutActionComplete.md
@@ -1,9 +1,11 @@
-### CheckoutActionComplete
+### Overview
 
-#### Overview
-The CheckoutActionComplete component will show when a checkout action has been completed. It is a summary of the information inside the completed action.
+The `CheckoutActionComplete` component will show when a checkout action has been completed. It is a summary of the information inside the completed action.
 
-#### Basic usage
+#### Usage
+
+##### Default
+
 ```jsx
 const onClick = () => {};
 
@@ -26,7 +28,7 @@ const Address = (
 </div>
 ```
 
-#### Completed step without a step number
+##### Completed step without a step number
 ```jsx
 const onClick = () => {};
 

--- a/package/src/components/CheckoutActionIncomplete/v1/CheckoutActionIncomplete.md
+++ b/package/src/components/CheckoutActionIncomplete/v1/CheckoutActionIncomplete.md
@@ -1,14 +1,15 @@
-### CheckoutActionIncomplete
+### Overview
 
-#### Overview
 The `CheckoutActionIncomplete` component will be used to display an incomplete step in the checkout process.
 
-#### Basic usage
+#### Usage
+
+##### Default
 ```jsx
 <CheckoutActionIncomplete label="Shipping information" stepNumber={2}/>
 ```
 
-#### Without a step number
+##### Without a step number
 ```jsx
 <CheckoutActionIncomplete label="Shipping information" />
 ```

--- a/package/src/components/CheckoutEmailAddress/v1/CheckoutEmailAddress.md
+++ b/package/src/components/CheckoutEmailAddress/v1/CheckoutEmailAddress.md
@@ -1,9 +1,10 @@
-### CheckoutEmailAddress
-
 ### Overview
-Displays a customers email address inside the checkout flow
+Displays a customers email address inside the checkout flow.
 
-#### Basic usage when user has an account
+#### Usage
+
+##### Account user
+
 ```jsx
 <CheckoutEmailAddress
   emailAddress="account.email@example.com"
@@ -11,7 +12,8 @@ Displays a customers email address inside the checkout flow
 />
 ```
 
-#### Basic usage as a guest
+##### Guest user
+
 ```jsx
 <CheckoutEmailAddress
   emailAddress="guest.email@example.com"

--- a/package/src/components/CheckoutTopHat/v1/CheckoutTopHat.md
+++ b/package/src/components/CheckoutTopHat/v1/CheckoutTopHat.md
@@ -1,9 +1,9 @@
-### CheckoutTopHat
-
 ### Overview
-Displays a message in a "Top hat" at the top of the checkout page.
 
-#### Basic usage
+Displays a message at the top of the checkout page.
+
+#### Usage
+
 ```jsx
 <CheckoutTopHat
   checkoutMessage="Free Shipping + Free Returns"

--- a/package/src/components/ErrorsBlock/v1/ErrorsBlock.md
+++ b/package/src/components/ErrorsBlock/v1/ErrorsBlock.md
@@ -1,4 +1,4 @@
-### ErrorsBlock Overview
+### Overview
 
 ```jsx
 const errors = [{ name: "example", message: "This field is required" }];
@@ -7,6 +7,8 @@ const errors = [{ name: "example", message: "This field is required" }];
  <ErrorsBlock names={["example"]} errors={errors} />
 </Field>
 ```
+
+#### Usage
 
 ```jsx
 const errors = [{ name: "example", message: "This field is required" }, { name: "example", message: "Another error" }];

--- a/package/src/components/Field/v1/Field.md
+++ b/package/src/components/Field/v1/Field.md
@@ -1,12 +1,16 @@
-### Field Overview
+### Overview
+
+Fields can be required, with more than one line, and have help text and labels.
 
 ```jsx
 <div>
   <Field name="example" label="Label" helpText="Help text">
-    <TextInput name="example" placeholder="Hint" />
+    <TextInput name="example" placeholder="This field has help text" />
   </Field>
   <Field name="example" label="Label" helpText="Help text">
-    <TextInput name="example" placeholder="Hint" shouldAllowLineBreaks />
+    <TextInput name="example" placeholder="This field has help text" shouldAllowLineBreaks />
   </Field>
 </div>
 ```
+
+#### Usage

--- a/package/src/components/MiniCart/v1/MiniCart.md
+++ b/package/src/components/MiniCart/v1/MiniCart.md
@@ -1,4 +1,8 @@
-### MiniCart
+### Overview
+
+#### Usage
+
+##### Default
 
 ```jsx
 const checkout = {
@@ -64,6 +68,8 @@ const components = {
 
 <MiniCart cart={{ checkout, items }} components={components} />
 ```
+
+##### Scrolling
 
 ```jsx
 const checkout = {

--- a/package/src/components/MiniCartSummary/v1/MiniCartSummary.md
+++ b/package/src/components/MiniCartSummary/v1/MiniCartSummary.md
@@ -1,16 +1,19 @@
-### MiniCartSummary
-
 ### Overview
-Displays a summary of the current current items in the mini cart view. This version of the cart summary is intended to be displayed when a user hovers over the cart icon in the main navigation.
 
-#### Basic usage, only renders subtotal
+Displays a summary of the current current items in the Mini Cart view. This version of the cart summary is intended to be displayed when a user hovers over the cart icon in the main navigation.
+
+#### Usage
+
+##### Default
+
 ```jsx
 <MiniCartSummary
   displaySubtotal="$275.77"
 />
 ```
 
-#### Render subtotal + taxes
+##### Subtotal and taxes
+
 ```jsx
 <MiniCartSummary
   displaySubtotal="$275.77"

--- a/package/src/components/Price/v1/Price.md
+++ b/package/src/components/Price/v1/Price.md
@@ -1,31 +1,36 @@
-### Price
-
-#### Overview
+### Overview
 The `Price` component will be used anywhere a product's price is displayed.
 
-#### Basic usage without a compare at price.
+#### Usage
+
+##### Default, without a Compare At price
+
 ```jsx
 <div>
   <Price displayPrice="$300.00" />
 </div>
 ```
 
-#### Usage with a price and compare at price that are different.
+##### With a price and Compare At price that are different
+
 ```jsx
 <div>
   <Price displayPrice="$200.00" displayCompareAtPrice="$300.00" />
 </div>
 ```
 
-#### What is displayed if the price and compare at price are the equal.
+##### With a  price and Compare At price are the equal
+
 The component expects string values of the prices to be strictly equal.
+
 ```jsx
 <div>
   <Price displayPrice="$300.00" displayCompareAtPrice="$300.00" />
 </div>
 ```
 
-#### Usage with the price below the compare at price.
+##### With the price below the Compare At price
+
 ```jsx
 <div>
   <Price displayPrice="$200.00" displayCompareAtPrice="$300.00" hasPriceBottom />

--- a/package/src/components/QuantityInput/v1/QuantityInput.md
+++ b/package/src/components/QuantityInput/v1/QuantityInput.md
@@ -1,13 +1,13 @@
-### QuantityInput
+### Overview
 
-#### Overview
 The `QuantityInput` component currently is built with [material-ui](https://material-ui.com/) components.
  * [TextField](https://material-ui.com/demos/text-fields/)
  * [InputAdornment](https://material-ui.com/api/input-adornment/)
  * [ButtonBase](https://material-ui.com/api/button-base/)
  * [withStyles](https://material-ui.com/customization/overrides/)
 
-#### Basic Usage
+#### Usage
+
 ```jsx
 <QuantityInput value={3} onChange={(value => console.log("QuantityInput changed", value))} />
 ```

--- a/package/src/components/Select/v1/Select.md
+++ b/package/src/components/Select/v1/Select.md
@@ -1,10 +1,12 @@
-### Select Overview
+### Overview
 
 Selects are form elements that allow the user to choose a single value from a set of options.
 
-#### Choosing a Select style
+#### Usage
 
 There are two basic types of selects: simple and searchable.
+
+##### Simple select
 
 The simple select can be used in cases where there are fewer than 10 options.
 
@@ -17,6 +19,8 @@ const options = [
 
 <Select options={options} />
 ```
+
+##### Searchable select
 
 A searchable select should be used when there are more than 10 options or when the options are not known until the user starts typing.
 
@@ -46,7 +50,7 @@ const options = [
 
 A select can be in one of three states: normal, invalid, or valid. Normal state is as shown previously
 
-##### Invalid State
+##### Invalid state
 
 When used within a form, a selected value might be deemed invalid, either because the user has not selected a value or because the user has selected a value that is not allowed based on other information entered in the same form. In this case, one or more error objects can be passed in the `errors` prop and will cause the select to appear as invalid.
 
@@ -60,7 +64,7 @@ const options = [
 <Select name="flavor" options={options} errors={[{ name: "flavor", message: "Please choose one" }]} />
 ```
 
-##### Valid State
+##### Valid state
 
 When used within a form, a selected value might be deemed valid after its value has been checked. If the `errors` prop is empty and the `hasBeenValidated` prop is true and there is a selected value, the select will appear valid.
 

--- a/package/src/components/ShopLogo/v1/ShopLogo.md
+++ b/package/src/components/ShopLogo/v1/ShopLogo.md
@@ -1,14 +1,16 @@
-### ShopLogo
-
-#### Overview
+### Overview
 Renders a shop's logo if a logo URL is provided, otherwise, it will render the shop's name.
 
-#### Basic usage with a shop logo URL
+#### Usage
+
+##### Default
+
 ```jsx
 <ShopLogo shopLogoUrl="http://placehold.it/60" shopName="Reaction" />
 ```
 
-#### Without a shop logo URL
+##### Without a logo
+
 ```jsx
 <ShopLogo shopName="Reaction" />
 ```

--- a/package/src/components/StockWarning/v1/StockWarning.md
+++ b/package/src/components/StockWarning/v1/StockWarning.md
@@ -1,14 +1,16 @@
-### StockWarning
-
-#### Overview
+### Overview
 The `StockWarning` displays a low inventory warning when the `isLowInventoryQuantity` prop is true.
 
-#### An inventory warning will be rendered when the `isLowInventoryQuantity` prop is `true`
+#### Usage
+
+An inventory warning will be rendered when the `isLowInventoryQuantity` prop is `true`, and does not render when a product has a normal inventory level.
+
+##### Low inventory
 ```jsx
   <StockWarning inventoryQuantity={10} isLowInventoryQuantity={true} />
 ```
 
-#### It's not rendered when a product has a normal inventory level
+##### Regular inventory
 ```jsx
   <StockWarning inventoryQuantity={10} isLowInventoryQuantity={false} />
 ```

--- a/package/src/components/TextInput/v1/TextInput.md
+++ b/package/src/components/TextInput/v1/TextInput.md
@@ -1,56 +1,19 @@
-### TextInput Overview
+### Overview
 
-#### General Usage
+#### Usage
 The `TextInput` component is used for collecting string form values.
 
-#### Component Usage
-There are two types of text inputs to choose from.
- - The single line text input for single line form values.
- - The multi line text input for multi line form values.
+There are two types of text inputs to choose from:
+- **Single-line input**: used for single-line inputs.
+- **Multi-line input**: used for longer inputs.
 
 Text inputs also have two styles of inputs.
- - The default input style to be used on light backgrounds.
- - The dark input style to be used on dark backgrounds.
+ - **Default input style**: used on light backgrounds.
+ - **Dark input style**: used on dark backgrounds.
 
-##### Default Theme
-The text input theme styles are broken out into three groups
+#### Types
 
-Input Styles
- - `rui_inputBackgroundColor_default`
- - `rui_inputBackgroundColor_dark `
- - `rui_inputBorderColor_default `
- - `rui_inputBorderColor_focus `
- - `rui_inputBorderColor_error `
- - `rui_inputBorderColor_success `
- - `rui_inputBorderRadius `
- - `rui_inputColor_default `
- - `rui_inputColor_disabled `
- - `rui_inputColor_error `
- - `rui_inputColor_success `
- - `rui_inputPlaceholderColor `
- - `rui_inputFontFamily `
- - `rui_inputFontSize `
- - `rui_inputLineHeight `
- - `rui_inputVerticalPadding `
- - `rui_inputHorizontalPadding `
- - `rui_iconTop `
- - `rui_iconRight `
-
-Textarea Styles
- - `rui_textareaHeight`
- - `rui_textareaLineHeight `
- - `rui_textareaIconPadding `
- - `rui_textareaIconRight `
- - `rui_textareaIconTop `
-
-Input Icon Styles
- - `rui_inputIconColor_default`
- - `rui_inputIconColor_disabled`
- - `rui_inputIconColor_error`
- - `rui_inputIconColor_success`
- - `rui_inputIconTextPadding`
-
-#### Single line, text input.
+##### Single line
 Default text input used in the majority of instances. It can be defined as one of four input types `"text"`, `"email"`, `"password"`, `"url"`.
 
 ```jsx
@@ -59,8 +22,8 @@ Default text input used in the majority of instances. It can be defined as one o
 </div>
 ```
 
-#### Multi line text input
-To enable the multi line text input pass the `shouldAllowLineBreaks` prop.
+##### Multi-line
+To enable the multi-line text input, pass the `shouldAllowLineBreaks` prop.
 
 ```jsx
 <div style={{ width: "50%" }}>
@@ -68,39 +31,47 @@ To enable the multi line text input pass the `shouldAllowLineBreaks` prop.
 </div>
 ```
 
-#### Input styles
-Text input on white and text input on grey or dark backgrounds. The dark background style is applied by adding the `isOnDarkBackground` prop to the component. Use `dark` text input when the background is grey or dark. When a grey background is used to create hierarchy and sections a white text field is use.
+#### Styles
+
+By default, text inputs are white with dark text on grey backgrounds.
+
+##### Default: Light background
 
 ```jsx
 const TwoColumnExamples = require("../../../../../styleguide/src/components/TwoColumnExamples").default;
 
-<TwoColumnExamples hasDarkRightBackground>
-  <TextInput name="example" placeholder="Hint" />
-  <TextInput name="example" placeholder="Hint" isOnDarkBackground />
+<TwoColumnExamples>
+  <TextInput name="example" placeholder="I am a multi-line text input on default light background." shouldAllowLineBreaks/>
+  <TextInput name="example" placeholder="I am a single-line text input on default light background." />
 </TwoColumnExamples>
 ```
+
+##### Dark background
+
+The dark background style is applied by adding the `isOnDarkBackground` prop to the component. Use `dark` text input when the background is grey or dark. When a grey background is used to create hierarchy and sections a white text field is use.
 
 ```jsx
 const TwoColumnExamples = require("../../../../../styleguide/src/components/TwoColumnExamples").default;
 
-<TwoColumnExamples hasDarkRightBackground>
-  <TextInput name="multi-line" placeholder="Hint" shouldAllowLineBreaks />
-  <TextInput name="multi-line" placeholder="Hint" isOnDarkBackground shouldAllowLineBreaks />
+<TwoColumnExamples hasDarkRightBackground hasDarkLeftBackground>
+  <TextInput name="multi-line" placeholder="I am a multi-line text input on a dark background." isOnDarkBackground shouldAllowLineBreaks />
+  <TextInput name="multi-line" placeholder="I am a single-line text input on dark background." isOnDarkBackground />
 </TwoColumnExamples>
 ```
 
-#### Input states
-Text inputs have 8 basic states.
- - Idle unfilled
- - Idle filled
- - Focused unfilled
- - Focused filled
- - Saved<sup>*</sup> *not yet implemented*
- - Valid
- - Invalid
- - Read Only / Disabled
+#### States
+Text inputs have 8 basic states:
 
-Idle Unfilled / Focused Unfilled
+1. Idle unfilled
+1. Idle filled
+1. Focused unfilled
+1. Focused filled
+1. Saved - *Not yet implemented*
+1. Valid
+1. Invalid
+1. Read Only / Disabled
+
+##### Idle Unfilled / Focused Unfilled
 
 When a user has clicked, pressed or tabbed into an input, it’s in focused state.
 
@@ -122,7 +93,7 @@ const TwoColumnExamples = require("../../../../../styleguide/src/components/TwoC
 </TwoColumnExamples>
 ```
 
-Idle Filled / Focused Filled
+##### Idle Filled / Focused Filled
 
 When a field has been filled in by the user, and has been unfocused it shows idle and filled in. When a user has filled in a text input and clicked back into the text field it is shown as focused and has an icon button that allows the user to quickly clear the whole field and edit it from scratch.
 
@@ -144,7 +115,7 @@ const TwoColumnExamples = require("../../../../../styleguide/src/components/TwoC
 </TwoColumnExamples>
 ```
 
-Valid
+##### Valid
 
 When information is required and/or needs to be formatted in a specific way the text input should be validated. When it’s successful the field shows a success state. Passing the `hasBeenValidated` prop to the input will enabled the valid state.
 
@@ -166,7 +137,7 @@ const TwoColumnExamples = require("../../../../../styleguide/src/components/TwoC
 </TwoColumnExamples>
 ```
 
-Invalid
+##### Invalid
 
 When information is required and/or needs to be formatted in a specific way the text input should be validated. When a input can't be validated the input is highlighted with error styling. Passing an `errors` array to the input to enabled the invalid state.
 
@@ -188,7 +159,7 @@ const TwoColumnExamples = require("../../../../../styleguide/src/components/TwoC
 </TwoColumnExamples>
 ```
 
-Read Only / Disabled
+##### Read Only / Disabled
 
 A disabled input is used when an action needs to be taken before the input can be enabled. A user is unable to input information into a disabled input. Pass the `isReadOnly` prop to enabled read only / disabled state.
 
@@ -258,3 +229,42 @@ const svg = <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1
   <TextInput name="example" placeholder="Hint" icon={svg} isOnDarkBackground />
 </TwoColumnExamples>
 ```
+
+#### Component usage
+
+The text input theme styles are broken out into three groups
+
+Input Styles
+ - `rui_inputBackgroundColor_default`
+ - `rui_inputBackgroundColor_dark `
+ - `rui_inputBorderColor_default `
+ - `rui_inputBorderColor_focus `
+ - `rui_inputBorderColor_error `
+ - `rui_inputBorderColor_success `
+ - `rui_inputBorderRadius `
+ - `rui_inputColor_default `
+ - `rui_inputColor_disabled `
+ - `rui_inputColor_error `
+ - `rui_inputColor_success `
+ - `rui_inputPlaceholderColor `
+ - `rui_inputFontFamily `
+ - `rui_inputFontSize `
+ - `rui_inputLineHeight `
+ - `rui_inputVerticalPadding `
+ - `rui_inputHorizontalPadding `
+ - `rui_iconTop `
+ - `rui_iconRight `
+
+Textarea Styles
+ - `rui_textareaHeight`
+ - `rui_textareaLineHeight `
+ - `rui_textareaIconPadding `
+ - `rui_textareaIconRight `
+ - `rui_textareaIconTop `
+
+Input Icon Styles
+ - `rui_inputIconColor_default`
+ - `rui_inputIconColor_disabled`
+ - `rui_inputIconColor_error`
+ - `rui_inputIconColor_success`
+ - `rui_inputIconTextPadding`

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -92,11 +92,11 @@ module.exports = {
       text: 16,
       small: 14,
       h1: 40,
-      h2: 31,
-      h3: 25,
-      h4: 20,
-      h5: 18,
-      h6: 16
+      h2: 40,
+      h3: 40,
+      h4: 25,
+      h5: 20,
+      h6: 18
     }
   },
   styles: {
@@ -163,11 +163,18 @@ module.exports = {
     Heading: {
       heading1: {
         fontFamily: "PostGrotesk-Medium",
+        marginTop: "20px"
+      },
+      heading2: {
+        fontFamily: "PostGrotesk-Medium",
+      },
+      heading3: {
+        fontFamily: "PostGrotesk-Medium",
         color: "#052a4e",
         marginBottom: "30px",
         marginTop: "40px"
       },
-      heading2: {
+      heading4: {
         fontFamily: "PostGrotesk-Regular",
         color: "#052a4e",
         marginBottom: "30px",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -171,7 +171,7 @@ module.exports = {
         marginTop: "20px"
       },
       heading2: {
-        fontFamily: "PostGrotesk-Medium",
+        fontFamily: "PostGrotesk-Medium"
       },
       heading3: {
         fontFamily: "PostGrotesk-Medium",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -100,6 +100,11 @@ module.exports = {
     }
   },
   styles: {
+    Text: {
+      strong: {
+        fontFamily: ["'PostGrotesk-Bold'", "-apple-system", "sans-serif"]
+      }
+    },
     StyleGuide: {
       content: {
         maxWidth: "initial",
@@ -305,7 +310,6 @@ module.exports = {
         {
           name: "Using Components",
           content: "styleguide/src/sections/InstallingandImporting.md"
-          // description: ""
         }
       ]
     },
@@ -318,7 +322,7 @@ module.exports = {
           name: "Actions"
         }),
         generateSection({
-          componentNames: ["Field", "Select", "TextInput", "QuantityInput", "ErrorsBlock", "Checkbox"],
+          componentNames: ["Field", "Select", "TextInput", "QuantityInput", "Checkbox", "ErrorsBlock"],
           content: "styleguide/src/sections/Forms.md",
           name: "Forms"
         })
@@ -328,16 +332,6 @@ module.exports = {
       name: "Storefront Components",
       sections: [
         generateSection({
-          componentNames: ["CartEmptyMessage", "CartSummary", "CartItem", "CartItems", "CartItemDetail", "MiniCartSummary", "MiniCart"],
-          content: "styleguide/src/sections/Cart.md",
-          name: "Cart"
-        }),
-        generateSection({
-          componentNames: ["CheckoutAction", "CheckoutActionComplete", "CheckoutActionIncomplete", "CheckoutEmailAddress", "CheckoutTopHat"],
-          content: "styleguide/src/sections/Checkout.md",
-          name: "Checkout"
-        }),
-        generateSection({
           componentNames: ["ShopLogo"],
           content: "styleguide/src/sections/General.md",
           name: "General"
@@ -346,6 +340,21 @@ module.exports = {
           componentNames: ["Price", "StockWarning"],
           content: "styleguide/src/sections/Product.md",
           name: "Product"
+        }),
+        generateSection({
+          componentNames: ["CartItem", "CartItems", "CartItemDetail", "CartSummary", "CartEmptyMessage"],
+          content: "styleguide/src/sections/Cart.md",
+          name: "Cart"
+        }),
+        generateSection({
+          componentNames: ["MiniCart", "MiniCartSummary"],
+          content: "styleguide/src/sections/Cart.md",
+          name: "Cart"
+        }),
+        generateSection({
+          componentNames: ["CheckoutAction", "CheckoutActionComplete", "CheckoutActionIncomplete", "CheckoutEmailAddress", "CheckoutTopHat"],
+          content: "styleguide/src/sections/Checkout.md",
+          name: "Checkout"
         })
       ]
     }

--- a/styleguide/src/styles.css
+++ b/styleguide/src/styles.css
@@ -17,11 +17,6 @@ body {
  * or any of the HTML elements they render. (In general, only style .rsg--* classes here.)
  */
 
-/* Do not add default h2 margins to the component name headings */
-header > div > h2 {
-  margin: 0 !important;
-}
-
 .columns {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Resolves #146
Impact: **minor**  
Type: **docs**

## Component
- Docs: Adds `### Overview` and `#### Usage` to all pages
- Docs: Reorganizes sidebar and adds a MiniCart section
- Chore: Changes the `addcomponent` script to make a new Markdown file with this template:
```
### Overview

#### Usage
```

## Screenshots
Docs look all better!

## Breaking changes
no

## Testing
1. run `docker-compose run --rm web node .reaction/scripts/addcomponent MyComponentNew`
2. Check the template to see if it matches:

```
### Overview

#### Usage
```