### PR TITLE
style: make paragraph, list width 60%

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -105,6 +105,22 @@ module.exports = {
         fontFamily: ["'PostGrotesk-Bold'", "-apple-system", "sans-serif"]
       }
     },
+    Para: {
+      para: {
+        width: "60%"
+      }
+    },
+    List: {
+      list: {
+        width: "60%"
+      },
+      ordered: {
+        width: "60%"
+      },
+      unordered: {
+        width: "60%"
+      }
+    },
     StyleGuide: {
       content: {
         maxWidth: "initial",


### PR DESCRIPTION
Resolves #169  
Impact: **minor**  
Type: **style**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Changes
Make the text measure 60% for paragraphs, unordered lists and ordered lists.

## Screenshots

<img width="1440" alt="screen shot 2018-07-30 at 11 06 31 am" src="https://user-images.githubusercontent.com/3673236/43414776-a5f2b82a-93e8-11e8-9fea-6faae3014deb.png">
<img width="1440" alt="screen shot 2018-07-30 at 11 06 37 am" src="https://user-images.githubusercontent.com/3673236/43414777-a6207800-93e8-11e8-9c01-3eeeaf7d73df.png">
