### PR TITLE
refactor: update cart.checkout.summary props in MiniCart

### DIFF
--- a/package/src/components/MiniCart/v1/MiniCart.js
+++ b/package/src/components/MiniCart/v1/MiniCart.js
@@ -51,18 +51,18 @@ class MiniCart extends Component {
          */
         summary: PropTypes.shape({
           /**
-           * Checkout summary subtotal info
+           * Checkout summary item total info
            */
-          subtotal: PropTypes.shape({
+          itemTotal: PropTypes.shape({
             /**
-             * Checkout summary subtotal display amount
+             * Checkout summary item total display amount
              */
             displayAmount: PropTypes.string
           }),
           /**
            * Checkout summary tax info
            */
-          tax: PropTypes.shape({
+          taxTotal: PropTypes.shape({
             /**
              * Checkout summary tax display amount
              */

--- a/package/src/components/MiniCart/v1/MiniCart.js
+++ b/package/src/components/MiniCart/v1/MiniCart.js
@@ -130,7 +130,7 @@ class MiniCart extends Component {
           <CartItemsComponent items={items} components={components} {...props} isMiniCart />
         </Items>
         <Footer count={items.length}>
-          <CartSummaryComponent displaySubtotal={summary.subtotal.displayAmount} />
+          <CartSummaryComponent displaySubtotal={summary.itemTotal.displayAmount} />
           <CartCheckoutButtonComponent components={{ Button: ButtonComponent }} />
           <span>Shipping and tax calculated in checkout</span>
         </Footer>

--- a/package/src/components/MiniCart/v1/MiniCart.md
+++ b/package/src/components/MiniCart/v1/MiniCart.md
@@ -7,10 +7,10 @@
 ```jsx
 const checkout = {
   summary: {
-    subtotal: {
+    itemTotal: {
       displayAmount: "$25.00"
     },
-    tax: {
+    taxTotal: {
       displayAmount: "$2.50"
     }
   }
@@ -74,10 +74,10 @@ const components = {
 ```jsx
 const checkout = {
   summary: {
-    subtotal: {
+    itemTotal: {
       displayAmount: "$25.00"
     },
-    tax: {
+    taxTotal: {
       displayAmount: "$2.50"
     }
   }

--- a/package/src/components/MiniCart/v1/MiniCart.test.js
+++ b/package/src/components/MiniCart/v1/MiniCart.test.js
@@ -4,10 +4,10 @@ import MiniCart from "./MiniCart";
 
 const mockCheckout = {
   summary: {
-    subtotal: {
+    itemTotal: {
       displayAmount: "$25.00"
     },
-    tax: {
+    taxTotal: {
       displayAmount: "$2.50"
     }
   }


### PR DESCRIPTION
Resolves #173
Impact: **minor** 
Type: **refactor**

## Component

- Updates `subtotal` and `tax` to match their new names in the GraphQL Cart schema, `itemTotal` and `taxTotal`.

## Screenshots
Include mobile and desktop screenshots.

## Breaking changes

Changes some prop names, but this is the first time the component is being used on the `reaction-next-starterkit` so there's no need to make a copy.

## Testing

1. Verify the component renders in docs
