### PR TITLE
chore: install node modules in package directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       args:
         BUILD_ENV: "development"
-    command: sh -c "yarn install && yarn start"
+    command: sh -c "yarn install && (cd package && yarn install) && yarn start"
     env_file:
       - ./.env
     environment:


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Updates

Install node_modules in `package` directory on `docker-compose up`

## Testing
1. `rm -rf node_modules package/node_modules`
2. `docker-compose up`
3. Ensure `node_modules` and `package/node_modules` exists
4. Visit styleguide docs and ensure it loads