### PR TITLE
fix: add font-family to component

### DIFF
--- a/package/src/components/MiniCartSummary/v1/MiniCartSummary.js
+++ b/package/src/components/MiniCartSummary/v1/MiniCartSummary.js
@@ -6,6 +6,7 @@ import { applyTheme } from "../../../utils";
 const Table = styled.table`
   width: 100%;
   padding: 0.5rem;
+  font-family: ${applyTheme("font_family")};
 `;
 
 const Td = styled.td`


### PR DESCRIPTION
Resolves #167 
Impact: **minor**  
Type: **bugfix**

## Issue
The MIniCartSummary component did not have a `font-family` attached to it. Locally in the component library, it was displaying correctly as the whole library is the correct font, however, when it was imported into the starterkit, the font was incorrect.

## Component
MiniCartSummary

## Breaking changes
none.

## Testing
1. See the the font is updated in the component library
1. Link this PR's version of the component library to the starterkit: [Instructions](https://github.com/reactioncommerce/reaction-next-starterkit/pull/199)
1. Start up starterkit locally following the instructions linked above
1. Hover over the cart icon on starterkit
1. See that the `MiniCartSummary` area has the correct font
