### PR TITLE
fix(quantityinput): disable ripple, touchripple from buttons

### DIFF
--- a/package/src/components/MiniCartSummary/v1/__snapshots__/MiniCartSummary.test.js.snap
+++ b/package/src/components/MiniCartSummary/v1/__snapshots__/MiniCartSummary.test.js.snap
@@ -4,6 +4,7 @@ exports[`Renders only subtotal + computed taxes 1`] = `
 .c0 {
   width: 100%;
   padding: 0.5rem;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
 }
 
 .c1 {
@@ -55,6 +56,7 @@ exports[`Renders only subtotal 1`] = `
 .c0 {
   width: 100%;
   padding: 0.5rem;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
 }
 
 .c1 {

--- a/package/src/components/QuantityInput/v1/QuantityInput.js
+++ b/package/src/components/QuantityInput/v1/QuantityInput.js
@@ -59,7 +59,7 @@ class QuantityInput extends Component {
 
   static defaultProps = {
     classes: {},
-    onChange() {}
+    onChange() { }
   };
 
   constructor(props) {
@@ -123,6 +123,8 @@ class QuantityInput extends Component {
                 variant="outlined"
                 onClick={this.handleDecrementButton}
                 className={incrementButton}
+                disableRipple={true}
+                disableTouchRipple={true}
               >
                 <Minus style={{ fontSize: "14px" }} />
               </ButtonBase>
@@ -135,6 +137,8 @@ class QuantityInput extends Component {
                 color="default"
                 onClick={this.handleIncrementButton}
                 className={incrementButton}
+                disableRipple={true}
+                disableTouchRipple={true}
               >
                 <Plus style={{ fontSize: "14px" }} />
               </ButtonBase>

--- a/package/src/components/QuantityInput/v1/QuantityInput.js
+++ b/package/src/components/QuantityInput/v1/QuantityInput.js
@@ -123,8 +123,8 @@ class QuantityInput extends Component {
                 variant="outlined"
                 onClick={this.handleDecrementButton}
                 className={incrementButton}
-                disableRipple={true}
-                disableTouchRipple={true}
+                disableRipple
+                disableTouchRipple
               >
                 <Minus style={{ fontSize: "14px" }} />
               </ButtonBase>

--- a/package/src/components/QuantityInput/v1/__snapshots__/QuantityInput.test.js.snap
+++ b/package/src/components/QuantityInput/v1/__snapshots__/QuantityInput.test.js.snap
@@ -48,9 +48,6 @@ exports[`basic snapshot 1`] = `
             />
           </g>
         </svg>
-        <span
-          className="MuiTouchRipple-root-34"
-        />
       </button>
     </div>
     <input
@@ -114,9 +111,6 @@ exports[`basic snapshot 1`] = `
             />
           </g>
         </svg>
-        <span
-          className="MuiTouchRipple-root-34"
-        />
       </button>
     </div>
   </div>


### PR DESCRIPTION
Resolves #157 
Impact: **minor**  
Type: **bugfix|style**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
- Remove ripple and touchRipple from buttons on QuantityInput

## Testing
1. Test + and - button on Mobile, Desktop, Firefox, Chrome

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
