### PR TITLE
fix(phonenumberinput): add height/width to size clear button

### DIFF
--- a/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
+++ b/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
@@ -76,9 +76,9 @@ const StyledInput = styled.input`
 const IconWrapper = styled.div`
   box-sizing: border-box;
   color: ${applyValidationColor("inputIconColor")};
-  fill: currentColor;
   margin-left: ${applyTheme("inputHorizontalPadding")};
-
+  height: ${applyTheme("inputIconWrapperSize")};
+  width: ${applyTheme("inputIconWrapperSize")};
   position: relative;
   right: ${applyTextareaVariant(applyTheme("textareaIconRight"), 0)};
   top: ${applyTextareaVariant(applyTheme("textareaIconTop"), 0)};
@@ -228,10 +228,10 @@ class PhoneNumberInput extends Component {
     iconClearAccessibilityText: "Clear",
     isOnDarkBackground: false,
     isReadOnly: false,
-    onChange() {},
-    onChanging() {},
-    onIconClick() {},
-    onSubmit() {},
+    onChange() { },
+    onChanging() { },
+    onIconClick() { },
+    onSubmit() { },
     shouldConvertEmptyStringToNull: true,
     shouldTrimValue: true,
     type: "text"

--- a/package/src/components/PhoneNumberInput/v1/__snapshots__/PhoneNumberInput.test.js.snap
+++ b/package/src/components/PhoneNumberInput/v1/__snapshots__/PhoneNumberInput.test.js.snap
@@ -65,8 +65,9 @@ exports[`basic snapshot 1`] = `
 .c2 {
   box-sizing: border-box;
   color: #737373;
-  fill: currentColor;
   margin-left: 0.625rem;
+  height: 1.429em;
+  width: 1.429em;
   position: relative;
   right: 0;
   top: 0;


### PR DESCRIPTION
Resolves #191 
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
- PhoneNumberInput in Firefox

## Screenshots
<img width="1440" alt="screen shot 2018-08-06 at 3 52 15 pm" src="https://user-images.githubusercontent.com/3673236/43744848-d2816870-9990-11e8-808b-1abe6639b888.png">

## Breaking changes
none

## Testing
1. Test PhoneNumberInput in Firefox
2. Test AddressBook's PhoneNumberInput in Firefox

