### PR TITLE
fix: updated PhoneNumberInput wrapper context

### DIFF
--- a/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
+++ b/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
@@ -228,10 +228,10 @@ class PhoneNumberInput extends Component {
     iconClearAccessibilityText: "Clear",
     isOnDarkBackground: false,
     isReadOnly: false,
-    onChange() { },
-    onChanging() { },
-    onIconClick() { },
-    onSubmit() { },
+    onChange() {},
+    onChanging() {},
+    onIconClick() {},
+    onSubmit() {},
     shouldConvertEmptyStringToNull: true,
     shouldTrimValue: true,
     type: "text"
@@ -470,4 +470,8 @@ class PhoneNumberInput extends Component {
   }
 }
 
-export default withComponents(PhoneNumberInput);
+const WrappedPhoneNumberInput = withComponents(PhoneNumberInput);
+
+WrappedPhoneNumberInput.isFormInput = true;
+
+export default WrappedPhoneNumberInput;


### PR DESCRIPTION
Resolves #193 
Impact: **minor**  
Type: **bugfix**

## Issue
The PhoneNumberInput needed `isFormInput` property added to it's`withComponents` context wrapper.

## Testing
1. Go to the bottom of the AddressForm page, fill out and submit the form.
2. You should see the address in the console and no validation error on the phone field.