### PR TITLE
Labels accessibility fix

### DIFF
--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash.uniqueid";
 import { Form } from "reacto-form";
 import styled from "styled-components";
 import { withComponents } from "@reactioncommerce/components-context";
@@ -166,6 +167,8 @@ class AddressForm extends Component {
 
   _form = null;
 
+  uniqueInstanceIdentifier = uniqueId("AddressForm_");
+
   handleCancel = () => {
     const { onCancel } = this.props;
     onCancel();
@@ -187,6 +190,17 @@ class AddressForm extends Component {
       regions,
       validator
     } = this.props;
+
+    const countryInputId = `country_${this.uniqueInstanceIdentifier}`;
+    const firstNameInputId = `firstName_${this.uniqueInstanceIdentifier}`;
+    const lastNameInputId = `lastName_${this.uniqueInstanceIdentifier}`;
+    const address1InputId = `address1_${this.uniqueInstanceIdentifier}`;
+    const address2InputId = `address2_${this.uniqueInstanceIdentifier}`;
+    const cityInputId = `city_${this.uniqueInstanceIdentifier}`;
+    const regionInputId = `region_${this.uniqueInstanceIdentifier}`;
+    const postalInputId = `postal_${this.uniqueInstanceIdentifier}`;
+    const phoneInputId = `phone_${this.uniqueInstanceIdentifier}`;
+
     return (
       <Form
         ref={(formEl) => {
@@ -200,71 +214,78 @@ class AddressForm extends Component {
       >
         <Grid>
           <ColFull>
-            <Field name="country" label="Country" isRequired>
+            <Field name="country" label="Country" labelFor={countryInputId} isRequired>
               <Select
+                id={countryInputId}
+                isSearchable
                 name="country"
                 onChange={this.props.onCountryChange}
                 options={countries}
                 placeholder="Country"
-                isSearchable
               />
               <ErrorsBlock names={["country"]} />
             </Field>
           </ColFull>
 
           <ColHalf>
-            <Field name="firstName" label="First Name" isRequired>
-              <TextInput name="firstName" placeholder="First Name" />
+            <Field name="firstName" label="First Name" labelFor={firstNameInputId} isRequired>
+              <TextInput id={firstNameInputId} name="firstName" placeholder="First Name" />
               <ErrorsBlock names={["firstName"]} />
             </Field>
           </ColHalf>
           <ColHalf>
-            <Field name="lastName" label="Last Name" isRequired>
-              <TextInput name="lastName" placeholder="Last Name" />
+            <Field name="lastName" label="Last Name" labelFor={lastNameInputId} isRequired>
+              <TextInput id={lastNameInputId} name="lastName" placeholder="Last Name" />
               <ErrorsBlock names={["lastName"]} />
             </Field>
           </ColHalf>
 
           <ColFull>
-            <Field name="address1" label="Address" isRequired>
-              <TextInput name="address1" placeholder="Address" />
+            <Field name="address1" label="Address" labelFor={address1InputId} isRequired>
+              <TextInput id={address1InputId} name="address1" placeholder="Address" />
               <ErrorsBlock names={["address1"]} />
             </Field>
           </ColFull>
 
           <ColFull>
-            <Field name="address2" label="Address Line 2" isOptional>
-              <TextInput name="address2" placeholder="Address Line 2 (Optional)" />
+            <Field name="address2" label="Address Line 2" labelFor={address2InputId} isOptional>
+              <TextInput id={address2InputId} name="address2" placeholder="Address Line 2 (Optional)" />
             </Field>
           </ColFull>
 
           <ColFull>
-            <Field name="city" label="City">
-              <TextInput name="city" placeholder="City" />
+            <Field name="city" label="City" labelFor={cityInputId}>
+              <TextInput id={cityInputId} name="city" placeholder="City" />
               <ErrorsBlock names={["city"]} />
             </Field>
           </ColFull>
 
           <ColHalf>
-            <Field name="region" label="Region" isRequired>
+            <Field name="region" label="Region" labelFor={regionInputId} isRequired>
               {regions && regions.length > 1 ? (
-                <Select name="region" options={regions} placeholder="Region" isSearchable />
+                <Select
+                  id={regionInputId}
+                  isSearchable
+                  name="region"
+                  options={regions}
+                  placeholder="Region"
+                />
               ) : (
-                <TextInput name="region" placeholder="Region" />
+                <TextInput id={regionInputId} name="region" placeholder="Region" />
               )}
               <ErrorsBlock names={["region"]} />
             </Field>
           </ColHalf>
           <ColHalf>
-            <Field name="postal" label="Postal Code" isRequired>
-              <TextInput name="postal" placeholder="Postal Code" />
+            <Field name="postal" label="Postal Code" labelFor={postalInputId} isRequired>
+              <TextInput id={postalInputId} name="postal" placeholder="Postal Code" />
               <ErrorsBlock names={["postal"]} />
             </Field>
           </ColHalf>
 
           <ColFull>
-            <Field name="phone" label="Phone" isRequired>
-              <PhoneNumberInput name="phone" placeholder="Phone" />
+            <Field name="phone" label="Phone" labelFor={phoneInputId} isRequired>
+              <PhoneNumberInput id={phoneInputId} name="phone" placeholder="Phone" />
               <ErrorsBlock names={["phone"]} />
             </Field>
           </ColFull>

--- a/package/src/components/ErrorsBlock/v1/ErrorsBlock.md
+++ b/package/src/components/ErrorsBlock/v1/ErrorsBlock.md
@@ -8,12 +8,12 @@ const TwoColumnExamples = require("../../../../../styleguide/src/components/TwoC
 const errors = [{ name: "example", message: "This field is required" }];
 
 <TwoColumnExamples hasDarkRightBackground>
-    <Field name="example" label="Label" errors={errors}>
-        <TextInput name="example" errors={errors} placeholder="I'm a single-line input."/>
+    <Field name="example" label="Label" labelFor="exampleInput1" errors={errors}>
+        <TextInput id="exampleInput1" name="example" errors={errors} placeholder="I'm a single-line input."/>
         <ErrorsBlock names={["example"]} errors={errors} />
     </Field>
-    <Field name="example" label="Label" errors={errors}>
-        <TextInput name="example" errors={errors} placeholder="I'm a multi-line input with a dark background." shouldAllowLineBreaks />
+    <Field name="example" label="Label" labelFor="exampleInput2" errors={errors}>
+        <TextInput id="exampleInput2" name="example" errors={errors} placeholder="I'm a multi-line input with a dark background." shouldAllowLineBreaks />
         <ErrorsBlock names={["example"]} errors={errors} shouldShowIcon />
     </Field>
 </TwoColumnExamples>
@@ -29,8 +29,8 @@ Pass `shouldShowIcon` to show an icon before each error message.
 
 ```jsx
 const errors = [{ name: "example", message: "This field is required" }, { name: "example", message: "Another error" }];
-<Field name="example" label="Label" errors={errors}>
- <TextInput name="example" errors={errors} shouldAllowLineBreaks />
+<Field name="example" label="Label" labelFor="exampleInput3" errors={errors}>
+ <TextInput id="exampleInput3" name="example" errors={errors} shouldAllowLineBreaks />
  <ErrorsBlock names={["example"]} errors={errors} shouldShowIcon />
 </Field>
 ```

--- a/package/src/components/Field/v1/Field.md
+++ b/package/src/components/Field/v1/Field.md
@@ -4,11 +4,11 @@ Fields can be required, with more than one line, and have help text and labels.
 
 ```jsx
 <div>
-  <Field name="example" label="Label" helpText="Help text">
-    <TextInput name="example" placeholder="This field has help text" />
+  <Field name="example" label="Label" helpText="Help text" labelFor="input1">
+    <TextInput id="input1" name="example" placeholder="This field has help text" />
   </Field>
-  <Field name="example" label="Label" helpText="Help text">
-    <TextInput name="example" placeholder="This field has help text" shouldAllowLineBreaks />
+  <Field name="example" label="Label" helpText="Help text" labelFor="input2">
+    <TextInput id="input2" name="example" placeholder="This field has help text" shouldAllowLineBreaks />
   </Field>
 </div>
 ```
@@ -17,7 +17,7 @@ Fields can be required, with more than one line, and have help text and labels.
 
 ##### Optional Field
 ```jsx
-<Field name="example" label="Label" isOptional>
-  <TextInput name="example" placeholder="This field has help text" />
+<Field name="example" label="Label" labelFor="input3" isOptional>
+  <TextInput id="input3" name="example" placeholder="This field has help text" />
 </Field>
 ```

--- a/package/src/components/Field/v1/__snapshots__/Field.test.js.snap
+++ b/package/src/components/Field/v1/__snapshots__/Field.test.js.snap
@@ -86,6 +86,7 @@ exports[`renders with help text 1`] = `
   >
     <input
       className="c2"
+      id={undefined}
       maxLength={undefined}
       name="test"
       onBlur={[Function]}
@@ -202,6 +203,7 @@ exports[`renders with label 1`] = `
   >
     <input
       className="c3"
+      id={undefined}
       maxLength={undefined}
       name="test"
       onBlur={[Function]}
@@ -297,6 +299,7 @@ exports[`renders with no help text 1`] = `
   >
     <input
       className="c2"
+      id={undefined}
       maxLength={undefined}
       name="test"
       onBlur={[Function]}
@@ -392,6 +395,7 @@ exports[`renders with no label 1`] = `
   >
     <input
       className="c2"
+      id={undefined}
       maxLength={undefined}
       name="test"
       onBlur={[Function]}

--- a/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
+++ b/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
@@ -170,6 +170,12 @@ class PhoneNumberInput extends Component {
      */
     iconClearAccessibilityText: PropTypes.string,
     /**
+     * This should be used only for connecting the input with a label. Generate a
+     * globally unique ID string and pass it to this prop and the `labelFor` prop
+     * of `Field`.
+     */
+    id: PropTypes.string,
+    /**
      * Enable when using the input on a dark background, disabled by default
      */
     isOnDarkBackground: PropTypes.bool,
@@ -428,9 +434,10 @@ class PhoneNumberInput extends Component {
   render() {
     const {
       className,
-      isOnDarkBackground,
       errors,
       hasBeenValidated,
+      id,
+      isOnDarkBackground,
       isReadOnly,
       maxLength,
       name,
@@ -450,17 +457,18 @@ class PhoneNumberInput extends Component {
       >
         <StyledInput
           className={className}
-          isOnDarkBackground={isOnDarkBackground}
           errors={errors}
           hasBeenValidated={hasBeenValidated}
-          readOnly={isReadOnly}
+          id={id}
+          isOnDarkBackground={isOnDarkBackground}
           maxLength={maxLength}
           name={name}
-          onKeyPress={this.onKeyPress}
           onBlur={this.onInputBlur}
           onChange={this.onChange}
           onFocus={this.onInputFocus}
+          onKeyPress={this.onKeyPress}
           placeholder={placeholder}
+          readOnly={isReadOnly}
           type={type}
           value={value}
         />

--- a/package/src/components/PhoneNumberInput/v1/__snapshots__/PhoneNumberInput.test.js.snap
+++ b/package/src/components/PhoneNumberInput/v1/__snapshots__/PhoneNumberInput.test.js.snap
@@ -83,6 +83,7 @@ exports[`basic snapshot 1`] = `
 >
   <input
     className="c1"
+    id={undefined}
     maxLength={undefined}
     name={undefined}
     onBlur={[Function]}

--- a/package/src/components/Select/v1/Select.js
+++ b/package/src/components/Select/v1/Select.js
@@ -26,6 +26,7 @@ const supportedPassthroughProps = [
   "getOptionLabel",
   "getOptionValue",
   "hideSelectedOptions",
+  "id",
   "inputValue",
   "isClearable",
   "isLoading",

--- a/package/src/components/TextInput/v1/TextInput.js
+++ b/package/src/components/TextInput/v1/TextInput.js
@@ -216,6 +216,12 @@ class TextInput extends Component {
      */
     iconClearAccessibilityText: PropTypes.string,
     /**
+     * This should be used only for connecting the input with a label. Generate a
+     * globally unique ID string and pass it to this prop and the `labelFor` prop
+     * of `Field`.
+     */
+    id: PropTypes.string,
+    /**
      * Enable when using the input on a dark background, disabled by default
      */
     isOnDarkBackground: PropTypes.bool,
@@ -512,15 +518,16 @@ class TextInput extends Component {
 
   render() {
     const {
-      shouldAllowLineBreaks,
       className,
-      isOnDarkBackground,
       errors,
       hasBeenValidated,
+      id,
+      isOnDarkBackground,
       isReadOnly,
       maxLength,
       name,
       placeholder,
+      shouldAllowLineBreaks,
       type
     } = this.props;
     const { isButtonFocused, isInputFocused, value } = this.state;
@@ -532,17 +539,18 @@ class TextInput extends Component {
         <div style={{ position: "relative" }}>
           <StyledTextarea
             className={className}
-            isOnDarkBackground={isOnDarkBackground}
             errors={errors}
-            hasBeenValidated={hasBeenValidated}
             fieldIsDirty={this.isDirty()}
-            readOnly={isReadOnly}
+            hasBeenValidated={hasBeenValidated}
+            id={id}
+            isOnDarkBackground={isOnDarkBackground}
             maxLength={maxLength}
             name={name}
             onBlur={this.onInputBlur}
             onChange={this.onChange}
             onFocus={this.onInputFocus}
             placeholder={placeholder}
+            readOnly={isReadOnly}
             value={value}
           />
           {this.showClearButton() ? this.renderClearButton() : null}
@@ -561,17 +569,18 @@ class TextInput extends Component {
       >
         <StyledInput
           className={className}
-          isOnDarkBackground={isOnDarkBackground}
           errors={errors}
           hasBeenValidated={hasBeenValidated}
-          readOnly={isReadOnly}
+          id={id}
+          isOnDarkBackground={isOnDarkBackground}
           maxLength={maxLength}
           name={name}
-          onKeyPress={this.onKeyPress}
           onBlur={this.onInputBlur}
           onChange={this.onChange}
           onFocus={this.onInputFocus}
+          onKeyPress={this.onKeyPress}
           placeholder={placeholder}
+          readOnly={isReadOnly}
           type={type}
           value={value}
         />

--- a/package/src/components/TextInput/v1/__snapshots__/TextInput.test.js.snap
+++ b/package/src/components/TextInput/v1/__snapshots__/TextInput.test.js.snap
@@ -67,6 +67,7 @@ exports[`renders 1`] = `
 >
   <input
     className="c1"
+    id={undefined}
     maxLength={undefined}
     name="test"
     onBlur={[Function]}
@@ -148,6 +149,7 @@ exports[`renders textarea 1`] = `
 >
   <input
     className="c1"
+    id={undefined}
     maxLength={undefined}
     name="test"
     onBlur={[Function]}
@@ -229,6 +231,7 @@ exports[`renders textarea with props 1`] = `
 >
   <input
     className="CLASSNAME c1"
+    id={undefined}
     maxLength={20}
     name="test"
     onBlur={[Function]}
@@ -310,6 +313,7 @@ exports[`renders with props 1`] = `
 >
   <input
     className="CLASSNAME c1"
+    id={undefined}
     maxLength={20}
     name="test"
     onBlur={[Function]}


### PR DESCRIPTION
Resolves #192 
Impact: **minor**  
Type: **bugfix**

## Changes
- TextInput, PhoneNumberInput, and Select now accept and pass along an `id` prop
- AddressForm uses the above change to add `id` and `for` to HTML for accessibility. Clicking the labels on that form no focuses the related input. (This doesn't seem to work with react-select package, but that would be an issue for them to fix.)
- The Field and ErrorsBlock markdown examples now show proper use of id/labelFor props

## Breaking changes
None

## Testing
Verify the changes and that the linked issue is fixed.
- https://deploy-preview-202--stoic-hodgkin-c0179e.netlify.com/#!/Field
- https://deploy-preview-202--stoic-hodgkin-c0179e.netlify.com/#!/PhoneNumberInput
- https://deploy-preview-202--stoic-hodgkin-c0179e.netlify.com/#!/ErrorsBlock
- https://deploy-preview-202--stoic-hodgkin-c0179e.netlify.com/#!/AddressForm