### PR TITLE
add font-family to CartEmptyMessage style

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -77,7 +77,7 @@
   "peerDependencies": {
     "@reactioncommerce/components-context": "^1.0.0",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
+    "react": "^16.4.2",
     "reacto-form": "^0.0.2",
     "styled-components": "^3.3.3"
   }

--- a/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
+++ b/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
@@ -12,7 +12,7 @@ const EmptyButton = styled.div`
 const EmptyMessage = styled.div`
   color: ${applyTheme("color_coolGrey500")};
   display: flex;
-  font-size: ${applyTheme("cartEmptyMessageFontSize")};
+  font-size: ${applyTheme("font_size_default")};
   font-family: ${applyTheme("font_family")};
   justify-content: center;
   letter-spacing: ${applyTheme("cartEmptyMessageLetterSpacing")};

--- a/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
+++ b/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
@@ -13,6 +13,7 @@ const EmptyMessage = styled.div`
   color: ${applyTheme("color_coolGrey500")};
   display: flex;
   font-size: ${applyTheme("cartEmptyMessageFontSize")};
+  font-family: ${applyTheme("font_family")};
   justify-content: center;
   letter-spacing: ${applyTheme("cartEmptyMessageLetterSpacing")};
   margin-bottom: ${applyTheme("cartEmptyMessageMarginBottom")};

--- a/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
+++ b/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
@@ -15,8 +15,8 @@ const EmptyMessage = styled.div`
   font-size: ${applyTheme("font_size_default")};
   font-family: ${applyTheme("font_family")};
   justify-content: center;
-  letter-spacing: ${applyTheme("cartEmptyMessageLetterSpacing")};
-  margin-bottom: ${applyTheme("cartEmptyMessageMarginBottom")};
+  letter-spacing: 0.01875rem;
+  margin-bottom: 3.375rem;
 `;
 
 class CartEmptyMessage extends Component {

--- a/package/src/components/CartEmptyMessage/v1/__snapshots__/CartEmptyMessage.test.js.snap
+++ b/package/src/components/CartEmptyMessage/v1/__snapshots__/CartEmptyMessage.test.js.snap
@@ -9,6 +9,7 @@ Array [
   display: -ms-flexbox;
   display: flex;
   font-size: 16;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -136,6 +137,7 @@ Array [
   display: -ms-flexbox;
   display: flex;
   font-size: 16;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/package/src/components/CartEmptyMessage/v1/__snapshots__/CartEmptyMessage.test.js.snap
+++ b/package/src/components/CartEmptyMessage/v1/__snapshots__/CartEmptyMessage.test.js.snap
@@ -8,7 +8,7 @@ Array [
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 16;
+  font-size: 16px;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -136,7 +136,7 @@ Array [
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 16;
+  font-size: 16px;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   -webkit-box-pack: center;
   -webkit-justify-content: center;

--- a/package/src/components/MiniCartSummary/v1/__snapshots__/MiniCartSummary.test.js.snap
+++ b/package/src/components/MiniCartSummary/v1/__snapshots__/MiniCartSummary.test.js.snap
@@ -4,6 +4,7 @@ exports[`Renders only subtotal + computed taxes 1`] = `
 .c0 {
   width: 100%;
   padding: 0.5rem;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
 }
 
 .c1 {
@@ -55,6 +56,7 @@ exports[`Renders only subtotal 1`] = `
 .c0 {
   width: 100%;
   padding: 0.5rem;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
 }
 
 .c1 {

--- a/package/src/defaultComponentTheme.js
+++ b/package/src/defaultComponentTheme.js
@@ -401,7 +401,6 @@ export default {
   ...labelStyles,
   ...helpTextStyles,
   ...errorsBlockStyles,
-  ...cartEmptyMessage,
   ...checkoutActions,
   ...checkbox
 };

--- a/package/src/defaultComponentTheme.js
+++ b/package/src/defaultComponentTheme.js
@@ -362,12 +362,6 @@ const errorsBlockStyles = {
   rui_errorsBlockIconMargin: `0 ${baseUnit(0.5)} 0 0`
 };
 
-// cartEmptyMessage
-const cartEmptyMessage = {
-  rui_cartEmptyMessageFontSize: baseFontSize,
-  rui_cartEmptyMessageLetterSpacing: `${baseUnit(0.03)}`,
-  rui_cartEmptyMessageMarginBottom: `${baseUnit(5.4)}`
-};
 
 // checkoutActionComplete
 const checkoutActions = {


### PR DESCRIPTION
Related to https://github.com/reactioncommerce/reaction-next-starterkit/issues/207
Impact: **minor**  
Type: **style**


## Testing
1. Follow [these instructions](https://github.com/reactioncommerce/reaction-next-starterkit#testing-reaction-component-library-components-in-the-starterkit) to get this version of the Component Library in the starterkit
1. Start the `fix-207-kieckhafer-emptyCartMessage` branch of the starterkit (or master if https://github.com/reactioncommerce/reaction-next-starterkit/pull/220 is merged)
1. See that the correct font is used for the Cart Empty Message text
