### PR TITLE
fix: added babel-polyfill to fix IE11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "dependencies": {
     "@reactioncommerce/components-context": "1.0.0",
+    "babel-polyfill": "^6.26.0",
     "prop-types": "15.6.2",
     "react": "16.4.2",
     "react-dom": "16.4.2",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -387,7 +387,7 @@ module.exports = {
       ]
     }
   ],
-  require: [path.join(__dirname, "styleguide/src/styles.css")],
+  require: ["babel-polyfill", path.join(__dirname, "styleguide/src/styles.css")],
   webpackConfig: {
     devtool: "source-map",
     module: {

--- a/styleguide/src/appComponents.js
+++ b/styleguide/src/appComponents.js
@@ -1,4 +1,3 @@
-import "babel-polyfill";
 import React from "react";
 import Button from "../../package/src/components/Button/v1";
 import CartItem from "../../package/src/components/CartItem/v1";

--- a/styleguide/src/appComponents.js
+++ b/styleguide/src/appComponents.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import React from "react";
 import Button from "../../package/src/components/Button/v1";
 import CartItem from "../../package/src/components/CartItem/v1";


### PR DESCRIPTION
Resolves #207 
Impact: **minor**  
Type: **bugfix**

## Work
Added [babl-poyfill](https://babeljs.io/docs/en/babel-polyfill/) to styleguide for IE11 support.

## Testing
1. Start the component lib and view it in IE11
2. Component pages should now be loading

