### PR TITLE
#212: Create Link component

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "styleguide/dist"
   ],
   "jest": {
-    "testEnvironment": "node",
     "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.{js,jsx}",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "styleguide/dist"
   ],
   "jest": {
+    "testEnvironment": "node",
     "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.{js,jsx}",

--- a/package/src/components/Link/v1/Link.js
+++ b/package/src/components/Link/v1/Link.js
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { preventAccidentalDoubleClick } from "../../../utils";
+
+class Link extends Component {
+  static propTypes = {
+    /**
+     * The contents of the link, such as text, icons, or any combination of React and HTML components
+     */
+    children: PropTypes.node.isRequired,
+    /**
+     * The URL the link should navigate to
+     */
+    href: PropTypes.string.isRequired,
+    /**
+     * Called with a single event parameter when a user clicks the link
+     */
+    onClick: PropTypes.func.isRequired
+  };
+
+  static defaultProps = {
+    onClick(event) {
+      window.location = event.currentTarget.getAttribute("href");
+    }
+  };
+
+  onClick = preventAccidentalDoubleClick((event) => {
+    event.preventDefault();
+    this.props.onClick(event);
+  });
+
+  render() {
+    const { children, href } = this.props;
+    return (
+      <a href={href} onClick={this.onClick}>{children}</a>
+    );
+  }
+}
+
+export default Link;

--- a/package/src/components/Link/v1/Link.js
+++ b/package/src/components/Link/v1/Link.js
@@ -15,17 +15,14 @@ class Link extends Component {
     /**
      * Called with a single event parameter when a user clicks the link
      */
-    onClick: PropTypes.func.isRequired
+    onClick: PropTypes.func
   };
 
   static defaultProps = {
-    onClick(event) {
-      window.location = event.currentTarget.getAttribute("href");
-    }
+    onClick() {}
   };
 
   onClick = preventAccidentalDoubleClick((event) => {
-    event.preventDefault();
     this.props.onClick(event);
   });
 

--- a/package/src/components/Link/v1/Link.md
+++ b/package/src/components/Link/v1/Link.md
@@ -12,7 +12,7 @@ Simple text link without onClick handler:
 Link with image and custom onClick handler:
 
 ```jsx
-<Link href="http://google.com" onClick={(event) => alert("clicked")}>
-  <img src="/reaction-design-system-logo.svg" width="200" height="200" />
+<Link href="http://google.com" onClick={() => alert("clicked")}>
+  <img src="/reaction-design-system-logo.svg" width="200" height="200" alt="Reaction Design System Logo" />
 </Link>
 ```

--- a/package/src/components/Link/v1/Link.md
+++ b/package/src/components/Link/v1/Link.md
@@ -1,0 +1,18 @@
+### Overview
+Renders a link with an onClick handler and text, icons, or any combination of React and HTML components
+
+#### Usage
+
+Simple text link without onClick handler:
+
+```jsx
+<Link href="http://google.com">Click here</Link>
+```
+
+Link with image and custom onClick handler:
+
+```jsx
+<Link href="http://google.com" onClick={(event) => alert("clicked")}>
+  <img src="/reaction-design-system-logo.svg" width="200" height="200" />
+</Link>
+```

--- a/package/src/components/Link/v1/Link.test.js
+++ b/package/src/components/Link/v1/Link.test.js
@@ -1,0 +1,15 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Link from "./Link";
+
+test("basic snapshot", () => {
+  const component = renderer.create(
+    <Link href="http://google.com" onClick={(event) => alert("clicked")}>
+      <img src="/reaction-design-system-logo.svg" width="200" height="200" />
+    </Link>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/Link/v1/Link.test.js
+++ b/package/src/components/Link/v1/Link.test.js
@@ -1,15 +1,35 @@
 import React from "react";
-import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
+import renderer from "react-test-renderer";
 import Link from "./Link";
 
-test("basic snapshot", () => {
-  const component = renderer.create(
-    <Link href="http://google.com" onClick={(event) => alert("clicked")}>
-      <img src="/reaction-design-system-logo.svg" width="200" height="200" />
+test("Link component with image snapshot", () => {
+  const component = renderer.create((
+    <Link href="http://google.com">
+      <img src="/reaction-design-system-logo.svg" width="200" height="200" alt="Reaction Design System Logo" />
     </Link>
-  );
+  ));
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+test("Link component with text snapshot", () => {
+  const component = renderer.create((
+    <Link href="http://google.com">Click here</Link>
+  ));
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Link component with onClick hander", () => {
+  const testClickHandler = jest.fn();
+  const component = shallow((
+    <Link href="http://google.com" onClick={testClickHandler} />
+  ));
+
+  component.find("a").simulate("click");
+
+  expect(testClickHandler).toHaveBeenCalled();
 });

--- a/package/src/components/Link/v1/__snapshots__/Link.test.js.snap
+++ b/package/src/components/Link/v1/__snapshots__/Link.test.js.snap
@@ -1,14 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot 1`] = `
+exports[`Link component with image snapshot 1`] = `
 <a
   href="http://google.com"
   onClick={[Function]}
 >
   <img
+    alt="Reaction Design System Logo"
     height="200"
     src="/reaction-design-system-logo.svg"
     width="200"
   />
+</a>
+`;
+
+exports[`Link component with text snapshot 1`] = `
+<a
+  href="http://google.com"
+  onClick={[Function]}
+>
+  Click here
 </a>
 `;

--- a/package/src/components/Link/v1/__snapshots__/Link.test.js.snap
+++ b/package/src/components/Link/v1/__snapshots__/Link.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<a
+  href="http://google.com"
+  onClick={[Function]}
+>
+  <img
+    height="200"
+    src="/reaction-design-system-logo.svg"
+    width="200"
+  />
+</a>
+`;

--- a/package/src/components/Link/v1/index.js
+++ b/package/src/components/Link/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Link";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -345,7 +345,7 @@ module.exports = {
       name: "Base Components",
       sections: [
         generateSection({
-          componentNames: ["Button"],
+          componentNames: ["Button", "Link"],
           content: "styleguide/src/sections/Actions.md",
           name: "Actions"
         }),

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -61,7 +61,15 @@ if (fs.statSync(componentsDir).isDirectory()) {
 //   return { content, name, sections };
 // }
 
-// This one renders only version 1 for now
+/**
+ * @name generateSection
+ * @summary generates an object that builds a section in the styleguide
+ * @param {Object} options - Function parameters
+ * @param {[String]} componentNames - Array of strings of component names
+ * @param {String} name - Name of section
+ * @param {String} content - path to markdown content file
+ * @returns {Object} with content, name, components keys
+ */
 function generateSection({ componentNames, name, content }) {
   const components = componentNames.map((componentName) =>
     Object.keys(componentTree[componentName]).map((version) => componentTree[componentName][version])[0]);


### PR DESCRIPTION
Resolves #212 
Impact: **minor**  
Type: **feature**

## Component
This PR adds a simple Link component to the library.

## Screenshots

Image link:
![image-link](https://user-images.githubusercontent.com/849570/44043334-a50f746c-9ef0-11e8-85af-83e3c2f75fab.jpg)

Text link:
![text-link](https://user-images.githubusercontent.com/849570/44043351-a91a29da-9ef0-11e8-8662-8d3cc5bc5b7f.jpg)


## Breaking changes
None

## Testing
1. Confirm component appears under Base Components -> Actions in docs
2. Text link w/ no onClick handler - confirm it brings you to google.com
3. Test link w/ image & onClick handler - confirm it shows an alert
