### PR TITLE
feat: Cart summary style updates and dense layout

### DIFF
--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -3,14 +3,11 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { applyTheme } from "../../../utils";
 
-const Surface = styled.div`
-  background-color: ${props => props.isDense ? "transparent" : applyTheme("color_black02")(props)};
-  padding: ${props => props.isDense ? "0" : "1rem"};
-`
-
 const Table = styled.table`
   width: 100%;
-  border-collapse: collapse;
+  border-spacing: 0;
+  background-color: ${props => props.isDense ? "transparent" : applyTheme("color_black02")(props)};
+  padding: ${props => props.isDense ? "0" : "1rem"};
 `;
 
 const Th = styled.th`
@@ -141,32 +138,30 @@ class CartSummary extends Component {
     const discount = displayDiscount && this.renderDiscount();
 
     return (
-      <Surface isDense={isDense}>
-        <Table>
-          {header}
-          <tbody>
-            <tr>
-              <Td isDense={isDense}>Item total</Td>
-              <TdValue isDense={isDense}>{displaySubtotal}</TdValue>
-            </tr>
-            <tr>
-              <Td isDense={isDense}>Shipping</Td>
-              <TdValue isDense={isDense}>{shipping}</TdValue>
-            </tr>
-            {discount}
-            <tr>
-              <Td isDense={isDense}>Tax</Td>
-              <TdValue isDense={isDense}>{tax}</TdValue>
-            </tr>
-            <tr>
-              <Td isDense={isDense} isBorder>Order total</Td>
-              <TdValue isDense={isDense} isBorder>
-                <Total>{displayTotal}</Total>
-              </TdValue>
-            </tr>
-          </tbody>
-        </Table>
-      </Surface>
+      <Table isDense={isDense}>
+        {header}
+        <tbody>
+          <tr>
+            <Td isDense={isDense}>Item total</Td>
+            <TdValue isDense={isDense}>{displaySubtotal}</TdValue>
+          </tr>
+          <tr>
+            <Td isDense={isDense}>Shipping</Td>
+            <TdValue isDense={isDense}>{shipping}</TdValue>
+          </tr>
+          {discount}
+          <tr>
+            <Td isDense={isDense}>Tax</Td>
+            <TdValue isDense={isDense}>{tax}</TdValue>
+          </tr>
+          <tr>
+            <Td isDense={isDense} isBorder>Order total</Td>
+            <TdValue isDense={isDense} isBorder>
+              <Total>{displayTotal}</Total>
+            </TdValue>
+          </tr>
+        </tbody>
+      </Table>
     );
   }
 }

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -6,8 +6,8 @@ import { applyTheme } from "../../../utils";
 const Table = styled.table`
   width: 100%;
   border-spacing: 0;
-  background-color: ${props => props.isDense ? "transparent" : applyTheme("color_black02")(props)};
-  padding: ${props => props.isDense ? "0" : "1rem"};
+  background-color: ${(props) => (props.isDense ? "transparent" : applyTheme("color_black02")(props))};
+  padding: ${(props) => (props.isDense ? "0" : "1rem")};
 `;
 
 const Th = styled.th`
@@ -24,10 +24,10 @@ const Thr = styled.th`
 
 const Td = styled.td`
   font-family: ${applyTheme("font_family")};
-  padding: ${props => props.isDense ? "0.5rem 0" : "1rem 0"};
+  padding: ${(props) => (props.isDense ? "0.5rem 0" : "1rem 0")};
   color: ${applyTheme("color_coolGrey400")};
-  border-top: ${props => props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial" };
-  border-bottom: ${props => props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial"};
+  border-top: ${(props) => (props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial")};
+  border-bottom: ${(props) => (props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial")};
 `;
 
 const TdValue = Td.extend`
@@ -88,10 +88,11 @@ class CartSummary extends Component {
      * Quantity of products in shopping cart
      */
     itemsQuantity: PropTypes.number
-  };
+  }
 
   renderHeader() {
     const { itemsQuantity } = this.props;
+    const itemsLabel = itemsQuantity >= 0 ? `${itemsQuantity} items` : null;
 
     return (
       <thead>
@@ -99,10 +100,10 @@ class CartSummary extends Component {
           <Th>
             <Title>Cart Summary</Title>
           </Th>
-          <Thr>{itemsQuantity >= 0 && `${itemsQuantity} items`}</Thr>
+          <Thr>{itemsLabel}</Thr>
         </tr>
       </thead>
-    )
+    );
   }
 
   renderDiscount() {
@@ -116,9 +117,7 @@ class CartSummary extends Component {
         </TdValue>
       </tr>
     );
-  };
-
-  tdComponent
+  }
 
   render() {
     const {
@@ -128,8 +127,7 @@ class CartSummary extends Component {
       displayTax,
       displayTotal,
       isDense,
-      isFreeShipping,
-      itemsQuantity
+      isFreeShipping
     } = this.props;
 
     const shipping = isFreeShipping ? "FREE" : displayShipping;

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -26,8 +26,8 @@ const Td = styled.td`
   font-family: ${applyTheme("font_family")};
   padding: ${props => props.isDense ? "0.5rem 0" : "1rem 0"};
   color: ${applyTheme("color_coolGrey400")};
-  border-top: ${props => props.isBorder ? `1px solid ${applyTheme("color_black10")(props)}` : "initial" };
-  border-bottom: ${props => props.isBorder ? `1px solid ${applyTheme("color_black10")(props)}` : "initial"};
+  border-top: ${props => props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial" };
+  border-bottom: ${props => props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial"};
 `;
 
 const TdValue = Td.extend`
@@ -155,8 +155,8 @@ class CartSummary extends Component {
             <TdValue isDense={isDense}>{tax}</TdValue>
           </tr>
           <tr>
-            <Td isDense={isDense} isBorder>Order total</Td>
-            <TdValue isDense={isDense} isBorder>
+            <Td isDense={isDense} isBordered>Order total</Td>
+            <TdValue isDense={isDense} isBordered>
               <Total>{displayTotal}</Total>
             </TdValue>
           </tr>

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -134,7 +134,7 @@ class CartSummary extends Component {
         </thead>
         <tbody>
           <tr>
-            <Td>Subtotal</Td>
+            <Td>Item total</Td>
             <TdValue>{displaySubtotal}</TdValue>
           </tr>
           <tr>
@@ -147,7 +147,7 @@ class CartSummary extends Component {
             <TdValue>{tax}</TdValue>
           </tr>
           <tr>
-            <TdBorder>Total</TdBorder>
+            <TdBorder>Order total</TdBorder>
             <TdValueBorder>
               <Total>{displayTotal}</Total>
             </TdValueBorder>

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -87,7 +87,7 @@ class CartSummary extends Component {
     /**
      * Quantity of products in shopping cart
      */
-    itemsQuantity: PropTypes.number.isRequired
+    itemsQuantity: PropTypes.number
   };
 
   renderHeader() {

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -99,7 +99,7 @@ class CartSummary extends Component {
           <Th>
             <Title>Cart Summary</Title>
           </Th>
-          <Thr>{itemsQuantity} items</Thr>
+          <Thr>{itemsQuantity >= 0 && `${itemsQuantity} items`}</Thr>
         </tr>
       </thead>
     )

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -34,6 +34,16 @@ const Td = styled.td`
   color: ${applyTheme("color_coolGrey400")};
 `;
 
+const TdBorder = Td.extend`
+  border-top: 1px solid ${applyTheme("color_black10")};
+  border-bottom: 1px solid ${applyTheme("color_black10")};
+`;
+
+const TdValueBorder = TdValue.extend`
+  border-top: 1px solid ${applyTheme("color_black10")};
+  border-bottom: 1px solid ${applyTheme("color_black10")};
+`;
+
 const Title = styled.span`
   font-family: ${applyTheme("font_family")};
   font-weight: ${applyTheme("font_weight_bold")};
@@ -137,10 +147,10 @@ class CartSummary extends Component {
             <TdValue>{tax}</TdValue>
           </tr>
           <tr>
-            <Td>Total</Td>
-            <TdValue>
+            <TdBorder>Total</TdBorder>
+            <TdValueBorder>
               <Total>{displayTotal}</Total>
-            </TdValue>
+            </TdValueBorder>
           </tr>
         </tbody>
       </Table>

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -3,10 +3,14 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { applyTheme } from "../../../utils";
 
+const Surface = styled.div`
+  background-color: ${props => props.isDense ? "transparent" : applyTheme("color_black02")(props)};
+  padding: ${props => props.isDense ? "0" : "1rem"};
+`
+
 const Table = styled.table`
   width: 100%;
-  background-color: ${applyTheme("color_black02")};
-  padding: 1rem;
+  border-collapse: collapse;
 `;
 
 const Th = styled.th`
@@ -21,27 +25,18 @@ const Thr = styled.th`
   font-weight: normal;
 `;
 
-const TdValue = styled.td`
-  font-family: ${applyTheme("font_family")};
-  text-align: right;
-  padding: 1rem 0;
-  color: ${applyTheme("color_coolGrey500")};
-`;
-
 const Td = styled.td`
   font-family: ${applyTheme("font_family")};
-  padding: 1rem 0;
+  padding: ${props => props.isDense ? "0.5rem 0" : "1rem 0"};
   color: ${applyTheme("color_coolGrey400")};
+  border-top: ${props => props.isBorder ? `1px solid ${applyTheme("color_black10")(props)}` : "initial" };
+  border-bottom: ${props => props.isBorder ? `1px solid ${applyTheme("color_black10")(props)}` : "initial"};
 `;
 
-const TdBorder = Td.extend`
-  border-top: 1px solid ${applyTheme("color_black10")};
-  border-bottom: 1px solid ${applyTheme("color_black10")};
-`;
-
-const TdValueBorder = TdValue.extend`
-  border-top: 1px solid ${applyTheme("color_black10")};
-  border-bottom: 1px solid ${applyTheme("color_black10")};
+const TdValue = Td.extend`
+  font-family: ${applyTheme("font_family")};
+  text-align: right;
+  color: ${applyTheme("color_coolGrey500")};
 `;
 
 const Title = styled.span`
@@ -85,6 +80,10 @@ class CartSummary extends Component {
      */
     displayTotal: PropTypes.string.isRequired,
     /**
+     * Dense layout with a transparent background color
+     */
+    isDense: PropTypes.bool,
+    /**
      * If a product qualifies for free shipping, display "FREE" for shipping method
      */
     isFreeShipping: PropTypes.bool,
@@ -94,18 +93,35 @@ class CartSummary extends Component {
     itemsQuantity: PropTypes.number.isRequired
   };
 
-  renderDiscount = () => {
-    const { displayDiscount } = this.props;
+  renderHeader() {
+    const { itemsQuantity } = this.props;
+
+    return (
+      <thead>
+        <tr>
+          <Th>
+            <Title>Cart Summary</Title>
+          </Th>
+          <Thr>{itemsQuantity} items</Thr>
+        </tr>
+      </thead>
+    )
+  }
+
+  renderDiscount() {
+    const { displayDiscount, isDense } = this.props;
 
     return (
       <tr>
-        <Td>Promo code applied</Td>
-        <TdValue>
+        <Td isDense={isDense}>Promo code applied</Td>
+        <TdValue isDense={isDense}>
           <Discount>{displayDiscount}</Discount>
         </TdValue>
       </tr>
     );
   };
+
+  tdComponent
 
   render() {
     const {
@@ -114,46 +130,43 @@ class CartSummary extends Component {
       displaySubtotal,
       displayTax,
       displayTotal,
+      isDense,
       isFreeShipping,
       itemsQuantity
     } = this.props;
 
     const shipping = isFreeShipping ? "FREE" : displayShipping;
     const tax = displayTax || "-";
+    const header = !isDense && this.renderHeader();
     const discount = displayDiscount && this.renderDiscount();
 
     return (
-      <Table>
-        <thead>
-          <tr>
-            <Th>
-              <Title>Cart Summary</Title>
-            </Th>
-            <Thr>{itemsQuantity} items</Thr>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <Td>Item total</Td>
-            <TdValue>{displaySubtotal}</TdValue>
-          </tr>
-          <tr>
-            <Td>Shipping</Td>
-            <TdValue>{shipping}</TdValue>
-          </tr>
-          {discount}
-          <tr>
-            <Td>Tax</Td>
-            <TdValue>{tax}</TdValue>
-          </tr>
-          <tr>
-            <TdBorder>Order total</TdBorder>
-            <TdValueBorder>
-              <Total>{displayTotal}</Total>
-            </TdValueBorder>
-          </tr>
-        </tbody>
-      </Table>
+      <Surface isDense={isDense}>
+        <Table>
+          {header}
+          <tbody>
+            <tr>
+              <Td isDense={isDense}>Item total</Td>
+              <TdValue isDense={isDense}>{displaySubtotal}</TdValue>
+            </tr>
+            <tr>
+              <Td isDense={isDense}>Shipping</Td>
+              <TdValue isDense={isDense}>{shipping}</TdValue>
+            </tr>
+            {discount}
+            <tr>
+              <Td isDense={isDense}>Tax</Td>
+              <TdValue isDense={isDense}>{tax}</TdValue>
+            </tr>
+            <tr>
+              <Td isDense={isDense} isBorder>Order total</Td>
+              <TdValue isDense={isDense} isBorder>
+                <Total>{displayTotal}</Total>
+              </TdValue>
+            </tr>
+          </tbody>
+        </Table>
+      </Surface>
     );
   }
 }

--- a/package/src/components/CartSummary/v1/CartSummary.md
+++ b/package/src/components/CartSummary/v1/CartSummary.md
@@ -5,7 +5,7 @@ Displays a summary of the current current items in the cart, with cost and other
 
 The CartSummary displays item quantity, subtotal, shipping, tax and total. The cart can also display a free shipping message, calculated taxes and any applied discounts.
 
-##### Default 
+##### Default
 
 ```jsx
 <CartSummary
@@ -49,5 +49,16 @@ The CartSummary displays item quantity, subtotal, shipping, tax and total. The c
   displayTotal="$288.64"
   itemsQuantity={3}
   displayTax="$7.62"
+/>
+```
+
+##### Dense layout
+
+```jsx
+<CartSummary
+  displayShipping="$10.99"
+  displaySubtotal="$275.77"
+  displayTotal="$286.10"
+  isDense
 />
 ```

--- a/package/src/components/CartSummary/v1/__snapshots__/CartSummary.test.js.snap
+++ b/package/src/components/CartSummary/v1/__snapshots__/CartSummary.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Displays a summary of the current items in the cart 1`] = `
 .c0 {
   width: 100%;
+  border-spacing: 0;
   background-color: #fafafa;
   padding: 1rem;
 }
@@ -19,17 +20,42 @@ exports[`Displays a summary of the current items in the cart 1`] = `
   font-weight: normal;
 }
 
-.c5 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
-  text-align: right;
-  padding: 1rem 0;
-  color: #3c3c3c;
-}
-
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
   color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+}
+
+.c6 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.c5 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
+}
+
+.c7 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
 }
 
 .c2 {
@@ -38,7 +64,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
   color: #3c3c3c;
 }
 
-.c6 {
+.c8 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-weight: 700;
   color: #3c3c3c;
@@ -61,8 +87,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
       <th
         className="c3"
       >
-        3
-         items
+        3 items
       </th>
     </tr>
   </thead>
@@ -71,7 +96,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
       <td
         className="c4"
       >
-        Subtotal
+        Item total
       </td>
       <td
         className="c5"
@@ -105,15 +130,15 @@ exports[`Displays a summary of the current items in the cart 1`] = `
     </tr>
     <tr>
       <td
-        className="c4"
+        className="c6"
       >
-        Total
+        Order total
       </td>
       <td
-        className="c5"
+        className="c7"
       >
         <span
-          className="c6"
+          className="c8"
         >
           $300.424
         </span>
@@ -126,6 +151,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
 exports[`Displays a summary with FREE shipping 1`] = `
 .c0 {
   width: 100%;
+  border-spacing: 0;
   background-color: #fafafa;
   padding: 1rem;
 }
@@ -142,17 +168,42 @@ exports[`Displays a summary with FREE shipping 1`] = `
   font-weight: normal;
 }
 
-.c5 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
-  text-align: right;
-  padding: 1rem 0;
-  color: #3c3c3c;
-}
-
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
   color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+}
+
+.c6 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.c5 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
+}
+
+.c7 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
 }
 
 .c2 {
@@ -161,7 +212,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
   color: #3c3c3c;
 }
 
-.c6 {
+.c8 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-weight: 700;
   color: #3c3c3c;
@@ -184,8 +235,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
       <th
         className="c3"
       >
-        3
-         items
+        3 items
       </th>
     </tr>
   </thead>
@@ -194,7 +244,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
       <td
         className="c4"
       >
-        Subtotal
+        Item total
       </td>
       <td
         className="c5"
@@ -228,15 +278,15 @@ exports[`Displays a summary with FREE shipping 1`] = `
     </tr>
     <tr>
       <td
-        className="c4"
+        className="c6"
       >
-        Total
+        Order total
       </td>
       <td
-        className="c5"
+        className="c7"
       >
         <span
-          className="c6"
+          className="c8"
         >
           $300.424
         </span>
@@ -249,6 +299,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
 exports[`Displays a summary with applied discount 1`] = `
 .c0 {
   width: 100%;
+  border-spacing: 0;
   background-color: #fafafa;
   padding: 1rem;
 }
@@ -265,17 +316,42 @@ exports[`Displays a summary with applied discount 1`] = `
   font-weight: normal;
 }
 
-.c5 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
-  text-align: right;
-  padding: 1rem 0;
-  color: #3c3c3c;
-}
-
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
   color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+}
+
+.c7 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.c5 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
+}
+
+.c8 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
 }
 
 .c2 {
@@ -290,7 +366,7 @@ exports[`Displays a summary with applied discount 1`] = `
   font-weight: 700;
 }
 
-.c7 {
+.c9 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-weight: 700;
   color: #3c3c3c;
@@ -313,8 +389,7 @@ exports[`Displays a summary with applied discount 1`] = `
       <th
         className="c3"
       >
-        3
-         items
+        3 items
       </th>
     </tr>
   </thead>
@@ -323,7 +398,7 @@ exports[`Displays a summary with applied discount 1`] = `
       <td
         className="c4"
       >
-        Subtotal
+        Item total
       </td>
       <td
         className="c5"
@@ -373,15 +448,15 @@ exports[`Displays a summary with applied discount 1`] = `
     </tr>
     <tr>
       <td
-        className="c4"
+        className="c7"
       >
-        Total
+        Order total
       </td>
       <td
-        className="c5"
+        className="c8"
       >
         <span
-          className="c7"
+          className="c9"
         >
           $300.424
         </span>
@@ -394,6 +469,7 @@ exports[`Displays a summary with applied discount 1`] = `
 exports[`Displays a summary with calculated taxes 1`] = `
 .c0 {
   width: 100%;
+  border-spacing: 0;
   background-color: #fafafa;
   padding: 1rem;
 }
@@ -410,17 +486,42 @@ exports[`Displays a summary with calculated taxes 1`] = `
   font-weight: normal;
 }
 
-.c5 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
-  text-align: right;
-  padding: 1rem 0;
-  color: #3c3c3c;
-}
-
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
   color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+}
+
+.c6 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.c5 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: initial;
+  border-bottom: initial;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
+}
+
+.c7 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding: 1rem 0;
+  color: #3c5d6f;
+  border-top: 1px solid #e6e6e6;
+  border-bottom: 1px solid #e6e6e6;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  text-align: right;
+  color: #3c3c3c;
 }
 
 .c2 {
@@ -429,7 +530,7 @@ exports[`Displays a summary with calculated taxes 1`] = `
   color: #3c3c3c;
 }
 
-.c6 {
+.c8 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-weight: 700;
   color: #3c3c3c;
@@ -452,8 +553,7 @@ exports[`Displays a summary with calculated taxes 1`] = `
       <th
         className="c3"
       >
-        3
-         items
+        3 items
       </th>
     </tr>
   </thead>
@@ -462,7 +562,7 @@ exports[`Displays a summary with calculated taxes 1`] = `
       <td
         className="c4"
       >
-        Subtotal
+        Item total
       </td>
       <td
         className="c5"
@@ -496,15 +596,15 @@ exports[`Displays a summary with calculated taxes 1`] = `
     </tr>
     <tr>
       <td
-        className="c4"
+        className="c6"
       >
-        Total
+        Order total
       </td>
       <td
-        className="c5"
+        className="c7"
       >
         <span
-          className="c6"
+          className="c8"
         >
           $300.424
         </span>


### PR DESCRIPTION
Resolves #214
Impact: **minor**  
Type: **feature**

## Component

### Cart Summary

New design: https://app.zeplin.io/project/5afc82f5e8d73e250ff9d855/screen/5ada4347eda5814422ce39e2

- Update line-item labels. 
  - `Subtotal` => `Item total`
  - `Total` => `Order total`
- Add borders around `Order total` row
- Add an option for a dense layout with a transparent background

## Screenshots

![cartsummary_ _reaction_design_system](https://user-images.githubusercontent.com/42217/44059963-df87ff44-9f07-11e8-812f-8b3c76e38799.png)

## Breaking changes

none

## Testing

1. Open the docs to the CartSummary component docs
2. See the updates mentioned in the `Component` section
