### PR TITLE
fix: checkbox style fixes

### DIFF
--- a/package/src/components/Checkbox/v1/Checkbox.js
+++ b/package/src/components/Checkbox/v1/Checkbox.js
@@ -15,8 +15,11 @@ const checkboxIconSVG = encodeURIComponent(`<svg aria-hidden='true' role='img' x
 /* eslint-enable quotes */
 /* eslint-enable max-len */
 
+// Opacity: 0 hides the default input and position: absolute removes it
+// from the flow so that it doesn't push the styled checkbox to the right.
 const StyledInput = styled.input`
   opacity: 0;
+  position: absolute;
   + label::after {
     content: " ";
   }
@@ -50,6 +53,7 @@ const StyledLabel = styled.label`
   font-size: ${applyTheme("checkboxLabelFontSize")};
   font-family: ${applyTheme("font_family")};
   padding-left: ${applyTheme("checkboxLabelSpacing")};
+  line-height: ${applyTheme("checkboxHeightAndWidth")};
   &:hover {
     cursor: pointer;
   }
@@ -110,6 +114,8 @@ class Checkbox extends Component {
     onChanging() { },
     value: undefined
   };
+
+  static isFormInput = true;
 
   constructor(props) {
     super(props);

--- a/package/src/components/Checkbox/v1/Checkbox.md
+++ b/package/src/components/Checkbox/v1/Checkbox.md
@@ -7,6 +7,9 @@ Checkboxes can be checked, unchecked and disabled.
   <Checkbox name="example-checked" label="Checked" value={true} />
   <Checkbox name="example-unchecked" label="Unchecked" />
   <Checkbox name="example-disabled" label="Disabled" isReadOnly />
+  <div style={{width: 300}}>
+    <Checkbox name="example-disabled" label="This one demonstrates what happens when a really long label wraps" />
+  </div>
 </div>
 ```
 
@@ -29,30 +32,33 @@ Checkboxes can be checked, unchecked and disabled.
 
 The checkbox is a styled `::before` pseudoelement on `<input>`. The native `<input>` is hidden with an `opacity` set to `0`.
 
-|Property     |Style               |
-|-------------|:------------------:|
-|Cursor       |Pointer             |
-|Height       |`@base-unit(2)`     |
-|Width        |`@base-unit(2)`     |
-|Border       |`2px @cool-grey-500`|
-|Border radius|`2px @cool-grey-500`|
+|Property     |Style                         |
+|-------------|:----------------------------:|
+|Cursor       |Pointer                       |
+|Height       |`140% of label font size`     |
+|Width        |`140% of label font size`     |
+|Border       |`2px @cool-grey-500`          |
+|Border radius|`2px @cool-grey-500`          |
 
 ##### Checkbox check
 
 The checkbox's check icon an `::after` pseudoelement on `<input>`, with a `content` set to FontAwesome's [check](https://fontawesome.com/icons/check?style=solid) as an SVG.
 
-|Property     |Style               |
-|-------------|:------------------:|
-|Color        |`@cool-grey-500`    |
-|Icon size    |`0.875rem`          |
+|Property     |Style                       |
+|-------------|:--------------------------:|
+|Color        |`@cool-grey-500`            |
+|Icon size    |`87.5% of label font size`  |
+|Top          |`25% of label font size`    |
+|Left         |`30% of label font size`    |
 
 ##### Label
 
-|Property     |Style               |
-|-------------|:------------------:|
-|Cursor       |Pointer             |
-|Font size    |`@rui-label-text`   |
-|Color        |`@cool-grey-500    `|
+|Property     |Style                     |
+|-------------|:------------------------:|
+|Cursor       |Pointer                   |
+|Font size    |`@rui-label-text`         |
+|Line height  |`140% of label font size` |
+|Color        |`@cool-grey-500`          |
 
 ##### Disabled
 
@@ -64,7 +70,7 @@ The checkbox's check icon an `::after` pseudoelement on `<input>`, with a `conte
 
 ##### Structure
 
-|Property                   |Spacing        |
-|---------------------------|:-------------:|
-|Between checkbox and label |`@base-unit(1)`|
-|Vertical                   |`@base-unit(2)`|
+|Property                   |Spacing                  |
+|---------------------------|:-----------------------:|
+|Between checkbox and label |`220% of label font size`|
+|Vertical                   |`17px`                   |

--- a/package/src/components/Checkbox/v1/__snapshots__/Checkbox.test.js.snap
+++ b/package/src/components/Checkbox/v1/__snapshots__/Checkbox.test.js.snap
@@ -1,102 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders with props 1`] = `
-.c0 {
-  margin-bottom: 1.25rem;
-}
-
-.c1 {
-  opacity: 0;
-}
-
-.c1 + label::after {
-  content: " ";
-}
-
-.c1:checked + label::after {
-  background-image: url("data:image/svg+xml; utf8,%3Csvg%20aria-hidden%3D'true'%20role%3D'img'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20512%20512'%3E%3Cpath%20fill%3D'%233c3c3c'%20d%3D'M173.898%20439.404l-166.4-166.4c-9.997-9.997-9.997-26.206%200-36.204l36.203-36.204c9.997-9.998%2026.207-9.998%2036.204%200L192%20312.69%20432.095%2072.596c9.997-9.997%2026.207-9.997%2036.204%200l36.203%2036.204c9.997%209.997%209.997%2026.206%200%2036.204l-294.4%20294.401c-9.998%209.997-26.207%209.997-36.204-.001z'%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
-  display: inline-block;
-  position: absolute;
-  width: 0.875em;
-  height: 0.875em;
-  top: 3px;
-  left: 4px;
-}
-
-.c1:focus + label::before {
-  outline: rgb(59,153,252) auto 5px;
-}
-
-.c1:disabled + label {
-  opacity: .5;
-}
-
-.c1:disabled + label::before {
-  background: #e6e6e6;
-  opacity: .5;
-}
-
-.c1:disabled + label:hover {
-  cursor: not-allowed;
-}
-
-.c2 {
-  position: relative;
-  display: inline-block;
-  font-size: 14px;
-  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
-  padding-left: 1.875rem;
-}
-
-.c2:hover {
-  cursor: pointer;
-}
-
-.c2::before,
-.c2::after {
-  position: absolute;
-}
-
-.c2::before {
-  content: " ";
-  display: inline-block;
-  height: 1.25rem;
-  width: 1.25rem;
-  border: 2px solid #3c3c3c;
-  border-radius: 2px;
-  box-sizing: border-box;
-  left: 0;
-  top: -1px;
-}
-
-<div
-  className="c0"
->
-  <input
-    checked={false}
-    className="c1"
-    disabled={false}
-    id="Checkbox_1"
-    onChange={[Function]}
-    type="checkbox"
-    value="true"
-  />
-  <label
-    className="c2"
-    htmlFor="Checkbox_1"
-  >
-    Label
-  </label>
-</div>
-`;
-
 exports[`renders disabled 1`] = `
 .c0 {
-  margin-bottom: 1.25rem;
+  margin-bottom: 17px;
 }
 
 .c1 {
   opacity: 0;
+  position: absolute;
 }
 
 .c1 + label::after {
@@ -109,8 +20,8 @@ exports[`renders disabled 1`] = `
   position: absolute;
   width: 0.875em;
   height: 0.875em;
-  top: 3px;
-  left: 4px;
+  top: 0.25em;
+  left: 0.3em;
 }
 
 .c1:focus + label::before {
@@ -135,7 +46,8 @@ exports[`renders disabled 1`] = `
   display: inline-block;
   font-size: 14px;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
-  padding-left: 1.875rem;
+  padding-left: 2.2em;
+  line-height: 1.4em;
 }
 
 .c2:hover {
@@ -150,13 +62,13 @@ exports[`renders disabled 1`] = `
 .c2::before {
   content: " ";
   display: inline-block;
-  height: 1.25rem;
-  width: 1.25rem;
+  height: 1.4em;
+  width: 1.4em;
   border: 2px solid #3c3c3c;
   border-radius: 2px;
   box-sizing: border-box;
   left: 0;
-  top: -1px;
+  top: 0;
 }
 
 <div
@@ -176,6 +88,98 @@ exports[`renders disabled 1`] = `
     htmlFor="Checkbox_2"
   >
     Disabled
+  </label>
+</div>
+`;
+
+exports[`renders with props 1`] = `
+.c0 {
+  margin-bottom: 17px;
+}
+
+.c1 {
+  opacity: 0;
+  position: absolute;
+}
+
+.c1 + label::after {
+  content: " ";
+}
+
+.c1:checked + label::after {
+  background-image: url("data:image/svg+xml; utf8,%3Csvg%20aria-hidden%3D'true'%20role%3D'img'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20512%20512'%3E%3Cpath%20fill%3D'%233c3c3c'%20d%3D'M173.898%20439.404l-166.4-166.4c-9.997-9.997-9.997-26.206%200-36.204l36.203-36.204c9.997-9.998%2026.207-9.998%2036.204%200L192%20312.69%20432.095%2072.596c9.997-9.997%2026.207-9.997%2036.204%200l36.203%2036.204c9.997%209.997%209.997%2026.206%200%2036.204l-294.4%20294.401c-9.998%209.997-26.207%209.997-36.204-.001z'%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+  display: inline-block;
+  position: absolute;
+  width: 0.875em;
+  height: 0.875em;
+  top: 0.25em;
+  left: 0.3em;
+}
+
+.c1:focus + label::before {
+  outline: rgb(59,153,252) auto 5px;
+}
+
+.c1:disabled + label {
+  opacity: .5;
+}
+
+.c1:disabled + label::before {
+  background: #e6e6e6;
+  opacity: .5;
+}
+
+.c1:disabled + label:hover {
+  cursor: not-allowed;
+}
+
+.c2 {
+  position: relative;
+  display: inline-block;
+  font-size: 14px;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  padding-left: 2.2em;
+  line-height: 1.4em;
+}
+
+.c2:hover {
+  cursor: pointer;
+}
+
+.c2::before,
+.c2::after {
+  position: absolute;
+}
+
+.c2::before {
+  content: " ";
+  display: inline-block;
+  height: 1.4em;
+  width: 1.4em;
+  border: 2px solid #3c3c3c;
+  border-radius: 2px;
+  box-sizing: border-box;
+  left: 0;
+  top: 0;
+}
+
+<div
+  className="c0"
+>
+  <input
+    checked={false}
+    className="c1"
+    disabled={false}
+    id="Checkbox_1"
+    onChange={[Function]}
+    type="checkbox"
+    value="true"
+  />
+  <label
+    className="c2"
+    htmlFor="Checkbox_1"
+  >
+    Label
   </label>
 </div>
 `;

--- a/package/src/components/Checkbox/v1/index.js
+++ b/package/src/components/Checkbox/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Checkbox";

--- a/package/src/defaultComponentTheme.js
+++ b/package/src/defaultComponentTheme.js
@@ -387,22 +387,22 @@ const checkoutActions = {
 
 // checkbox
 const checkbox = {
-  rui_checkboxHeightAndWidth: `${baseUnit(2)}`,
+  rui_checkboxHeightAndWidth: "1.4em",
   rui_checkboxLeftSpacing: "0",
-  rui_checkboxTopSpacing: "-1px",
+  rui_checkboxTopSpacing: "0",
   rui_checkboxBorderColor: coolGrey500,
   rui_checkboxBorderRadius: "2px",
   rui_checkboxBorderWidth: "2px",
   rui_checkboxFocusStyle: "rgb(59, 153, 252) auto 5px",
   rui_checkboxDisabledColor: black10,
   rui_checkboxDisabledOpacity: ".5",
-  rui_checkboxLabelSpacing: `${baseUnit(3)}`,
+  rui_checkboxLabelSpacing: "2.2em",
   rui_checkboxLabelFontSize: fontSize14,
   rui_checkboxIconColor: coolGrey500,
   rui_checkboxIconSize: "0.875em",
-  rui_checkboxIconLeftSpacing: "4px",
-  rui_checkboxIconTopSpacing: "3px",
-  rui_checkboxVerticalSpacing: `${baseUnit(2)}`
+  rui_checkboxIconLeftSpacing: "0.3em",
+  rui_checkboxIconTopSpacing: "0.25em",
+  rui_checkboxVerticalSpacing: "17px"
 };
 
 // selectableItem

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -363,7 +363,7 @@ module.exports = {
           name: "Content"
         }),
         generateSection({
-          componentNames: ["Field", "Select", "TextInput", "QuantityInput", "PhoneNumberInput", "Checkbox", "ErrorsBlock"],
+          componentNames: ["Checkbox", "ErrorsBlock", "Field", "PhoneNumberInput", "QuantityInput", "Select", "TextInput"],
           content: "styleguide/src/sections/Forms.md",
           name: "Forms"
         })
@@ -383,7 +383,7 @@ module.exports = {
           name: "Product"
         }),
         generateSection({
-          componentNames: ["CartItem", "CartItems", "CartItemDetail", "CartEmptyMessage", "CartSummary", "MiniCart", "MiniCartSummary"],
+          componentNames: ["CartEmptyMessage", "CartItem", "CartItems", "CartItemDetail", "CartSummary", "MiniCart", "MiniCartSummary"],
           content: "styleguide/src/sections/Cart.md",
           name: "Cart"
         }),


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Changes
When I pulled the Checkbox into the Reaction Meteor app, it did not display correctly. This was mostly due to using `rems`. I've switched it to using ems and pixels as appropriate. For most values, em makes sense because as the font size of the checkbox label increases, it looks best if the checkbox increases proportionally.

Also adds `isFormInput = true` static property on `Checkbox`. Without this, it does not work correctly within a ReactoForm form.

## Breaking changes
None

## Testing
Verify that the Checkbox component looks good in various browsers and if you play with the `font-size` of the label and the `html` root, everything continues to look good.