### PR TITLE
bug: add minicart checkout button `onCheckoutButtonClick` event

### DIFF
--- a/package/src/components/MiniCart/v1/MiniCart.js
+++ b/package/src/components/MiniCart/v1/MiniCart.js
@@ -109,6 +109,10 @@ class MiniCart extends Component {
      */
     onChangeCartItemQuantity: PropTypes.func,
     /**
+     * On default checkout button click. Not used if a custom button is supplied by `components.cartCheckoutButton`
+     */
+    onCheckoutButtonClick: PropTypes.func,
+    /**
      * On remove item from cart handler
      */
     onRemoveItemFromCart: PropTypes.func
@@ -116,6 +120,7 @@ class MiniCart extends Component {
 
   static defaultProps = {
     onChangeCartItemQuantity() {},
+    onCheckoutButtonClick() {},
     onRemoveItemFromCart() {}
   };
 
@@ -129,6 +134,7 @@ class MiniCart extends Component {
         MiniCartSummary,
         ...components
       },
+      onCheckoutButtonClick,
       ...props
     } = this.props;
     return (
@@ -138,7 +144,7 @@ class MiniCart extends Component {
         </Items>
         <Footer count={items.length}>
           <MiniCartSummary components={components} displaySubtotal={summary.itemTotal.displayAmount} />
-          {cartCheckoutButton || <Button actionType="important" components={components} isFullWidth>Checkout</Button>}
+          {cartCheckoutButton || <Button actionType="important" components={components} isFullWidth onClick={onCheckoutButtonClick}>Checkout</Button>}
           <span>Shipping and tax calculated in checkout</span>
         </Footer>
       </Cart>

--- a/package/src/components/MiniCart/v1/MiniCart.md
+++ b/package/src/components/MiniCart/v1/MiniCart.md
@@ -55,7 +55,7 @@ const items = [
   quantity: 1
 }];
 
-<MiniCart cart={{ checkout, items }} />
+<MiniCart cart={{ checkout, items }} onCheckoutButtonClick={() => alert("Checkout!")} />
 ```
 
 ##### Scrolling
@@ -144,5 +144,5 @@ const items = [{
   quantity: 1
 }];
 
-<MiniCart cart={{ checkout, items }} />
+<MiniCart cart={{ checkout, items }}  onCheckoutButtonClick={() => alert("Checkout!")} />
 ```


### PR DESCRIPTION
Resolves #232
Impact: **minor**  
Type: **bugfix/feature**

## Component

Add event prop `onCheckoutButtonClick` for the supplied checkout button in the MiniCart component. This will allow you to add an event to the default button without having to supply your own.

## Breaking changes

none

## Testing
1. Open the docs to the MiniCart page
2. Click the checkout button
3. See the alert
