### PR TITLE
style(mobile): #236 - improve mobile design

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -115,18 +115,30 @@ module.exports = {
     },
     Para: {
       para: {
-        width: "60%"
+        "width": "60%",
+        "@media screen and (max-width: 800px)": {
+          width: "100%"
+        }
       }
     },
     List: {
       list: {
-        width: "60%"
+        "width": "60%",
+        "@media screen and (max-width: 800px)": {
+          width: "100%"
+        }
       },
       ordered: {
-        width: "60%"
+        "width": "60%",
+        "@media screen and (max-width: 800px)": {
+          width: "100%"
+        }
       },
       unordered: {
-        width: "60%"
+        "width": "60%",
+        "@media screen and (max-width: 800px)": {
+          width: "100%"
+        }
       }
     },
     StyleGuide: {
@@ -140,7 +152,7 @@ module.exports = {
         "maxWidth": "initial",
         "padding": "0 80px",
         "@media screen and (max-width: 800px)": {
-          padding: [0, 16]
+          padding: "0 16px"
         }
       },
       sidebar: {
@@ -231,9 +243,13 @@ module.exports = {
     },
     ReactComponent: {
       header: {
-        backgroundColor: "#fffbcc",
-        margin: "0 -80px 40px -80px",
-        padding: "20px 80px 40px 80px"
+        "backgroundColor": "#fffbcc",
+        "margin": "0 -80px 40px -80px",
+        "padding": "20px 80px 40px 80px",
+        "@media screen and (max-width: 800px)": {
+          margin: "0 -16px 40px -16px",
+          padding: "20px"
+        }
       }
     },
     SectionHeading: {
@@ -243,6 +259,8 @@ module.exports = {
         "pointerEvents": "none",
         "fontFamily": ["Overpass Mono", "Menlo", "monospace"],
         "fontSize": "50px",
+        "word-wrap": "break-word",
+        "hyphens": "auto",
         "&:hover, &:active": {
           cursor: "text",
           pointerEvents: "none",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -130,9 +130,18 @@ module.exports = {
       }
     },
     StyleGuide: {
+      hasSidebar: {
+        "paddingLeft": "320px",
+        "@media screen and (max-width: 800px)": {
+          paddingLeft: 0
+        }
+      },
       content: {
-        maxWidth: "initial",
-        padding: "0 80px"
+        "maxWidth": "initial",
+        "padding": "0 80px",
+        "@media screen and (max-width: 800px)": {
+          padding: [0, 16]
+        }
       },
       sidebar: {
         "backgroundColor": "#f7fdff",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -135,10 +135,16 @@ module.exports = {
         padding: "0 80px"
       },
       sidebar: {
-        backgroundColor: "#f7fdff",
-        border: [["#a7edff", "solid"]],
-        borderWidth: [[0, 2, 0, 0]],
-        paddingLeft: 25
+        "backgroundColor": "#f7fdff",
+        "border": [["#a7edff", "solid"]],
+        "borderWidth": [[0, 2, 0, 0]],
+        "paddingLeft": 25,
+        "@media screen and (max-width: 800px)": {
+          position: "static",
+          width: "auto",
+          borderWidth: [[1, 0, 0, 0]],
+          paddingBottom: "4px"
+        }
       },
       logo: {
         borderBottom: [[0]],


### PR DESCRIPTION
Resolves #236
Impact: **minor**  
Type: **style**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
- Updated style for mobile and tablet-width viewing
- On mobile, the long name of a component will be hyphenated
- On mobile, the x-axis should not scroll
- On tablet, the sidebar should be shown at the bottom

## Screenshots
<img width="1440" alt="screen shot 2018-08-17 at 2 59 49 pm" src="https://user-images.githubusercontent.com/3673236/44290803-551e1e80-a22f-11e8-9aae-061c9b97b58b.png">

## Testing
1. Check at 50% width on desktop
2. Check on mobile device
3. Test a component with a long name