### PR TITLE
Feat 234 nnnnat commercial field

### DIFF
--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -333,7 +333,7 @@ class AddressForm extends Component {
                 <Checkbox
                   id={isCommercialInputId}
                   name="isCommercial"
-                  label="Is a commercial address."
+                  label="This is a commercial address."
                   isReadOnly={isSaving}
                 />
               </Field>

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -327,7 +327,7 @@ class AddressForm extends Component {
             </Field>
           </ColFull>
 
-          {shouldShowIsCommercialField ? (
+          {shouldShowIsCommercialField &&
             <ColFull>
               <Field name="isCommercial" labelFor={isCommercialInputId}>
                 <Checkbox
@@ -337,10 +337,7 @@ class AddressForm extends Component {
                   isReadOnly={isSaving}
                 />
               </Field>
-            </ColFull>
-          ) : (
-            ""
-          )}
+            </ColFull>}
         </Grid>
       </Form>
     );

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -34,6 +34,11 @@ class AddressForm extends Component {
      */
     components: PropTypes.shape({
       /**
+       * Pass either the Reaction Field component or your own component that is
+       * compatible with ReactoForm.
+       */
+      Checkbox: CustomPropTypes.component.isRequired,
+      /**
        * Pass either the Reaction ErrorsBlock component or your own component that is
        * compatible with ReactoForm.
        */
@@ -123,6 +128,10 @@ class AddressForm extends Component {
       value: PropTypes.string
     })),
     /**
+     * Should the AddressForm show the "Is Commercial Address" field.
+     */
+    shouldShowIsCommercialField: PropTypes.bool,
+    /**
      * Validator method
      */
     validator: PropTypes.func,
@@ -135,6 +144,7 @@ class AddressForm extends Component {
       country: PropTypes.string,
       city: PropTypes.string,
       firstName: PropTypes.string,
+      isCommercial: PropTypes.bool,
       lastName: PropTypes.string,
       postal: PropTypes.string,
       region: PropTypes.string,
@@ -168,7 +178,8 @@ class AddressForm extends Component {
       lastName: "",
       postal: "",
       region: "",
-      phone: ""
+      phone: "",
+      isCommercial: false
     }
   };
 
@@ -196,14 +207,15 @@ class AddressForm extends Component {
   render() {
     const {
       value,
-      components: { ErrorsBlock, Field, TextInput, Select, PhoneNumberInput },
+      components: { Checkbox, ErrorsBlock, Field, TextInput, Select, PhoneNumberInput },
       countries,
       errors,
       isSaving,
       name,
       regions,
       validator,
-      onChange
+      onChange,
+      shouldShowIsCommercialField
     } = this.props;
 
     const countryInputId = `country_${this.uniqueInstanceIdentifier}`;
@@ -215,6 +227,7 @@ class AddressForm extends Component {
     const regionInputId = `region_${this.uniqueInstanceIdentifier}`;
     const postalInputId = `postal_${this.uniqueInstanceIdentifier}`;
     const phoneInputId = `phone_${this.uniqueInstanceIdentifier}`;
+    const isCommercialInputId = `isCommercial_${this.uniqueInstanceIdentifier}`;
 
     return (
       <Form
@@ -267,7 +280,12 @@ class AddressForm extends Component {
 
           <ColFull>
             <Field name="address2" label="Address Line 2" labelFor={address2InputId} isOptional>
-              <TextInput id={address2InputId} name="address2" placeholder="Address Line 2 (Optional)" isReadOnly={isSaving} />
+              <TextInput
+                id={address2InputId}
+                name="address2"
+                placeholder="Address Line 2 (Optional)"
+                isReadOnly={isSaving}
+              />
             </Field>
           </ColFull>
 
@@ -308,6 +326,21 @@ class AddressForm extends Component {
               <ErrorsBlock names={["phone"]} />
             </Field>
           </ColFull>
+
+          {shouldShowIsCommercialField ? (
+            <ColFull>
+              <Field name="isCommercial" labelFor={isCommercialInputId}>
+                <Checkbox
+                  id={isCommercialInputId}
+                  name="isCommercial"
+                  label="Is a commercial address."
+                  isReadOnly={isSaving}
+                />
+              </Field>
+            </ColFull>
+          ) : (
+            ""
+          )}
         </Grid>
       </Form>
     );

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -337,7 +337,8 @@ class AddressForm extends Component {
                   isReadOnly={isSaving}
                 />
               </Field>
-            </ColFull>}
+            </ColFull>
+          }
         </Grid>
       </Form>
     );

--- a/package/src/components/AddressForm/v1/AddressForm.md
+++ b/package/src/components/AddressForm/v1/AddressForm.md
@@ -110,6 +110,28 @@ const errors = [{ message: "error message", name: "address1"}];
  />
 ```
 
+#### Is commercial address field
+Some `fulfillmentMethods` will charge a different shipping rate if shipping to a commercial address.
+```jsx
+const countries = [
+  { value: "US", label: "United States" },
+  { value: "DE", label: "Germany" },
+  { value: "NU", label: "Nigeria" }
+];
+
+const regions = [
+  { value: "LA", label: "Louisiana" },
+  { value: "CA", label: "California" }
+];
+
+<AddressForm
+  countries={countries}
+  regions={regions}
+  onSubmit={(address) => console.log(address)}
+  shouldShowIsCommercialField
+ />
+```
+
 #### Address Form Implementation Example
 Simple `AddressForm` implementation example. Bind to the form element via a `ref` method that can be used by any `Button` to trigger `submit` & `validate` form methods.
 

--- a/package/src/components/AddressForm/v1/__snapshots__/AddressForm.test.js.snap
+++ b/package/src/components/AddressForm/v1/__snapshots__/AddressForm.test.js.snap
@@ -87,6 +87,7 @@ exports[`basic snapshot 1`] = `
     >
       Field(undefined)
     </div>
+    
   </div>
 </div>
 `;

--- a/package/src/components/AddressForm/v1/__snapshots__/AddressForm.test.js.snap
+++ b/package/src/components/AddressForm/v1/__snapshots__/AddressForm.test.js.snap
@@ -87,7 +87,6 @@ exports[`basic snapshot 1`] = `
     >
       Field(undefined)
     </div>
-    
   </div>
 </div>
 `;

--- a/package/src/tests/mockComponents.js
+++ b/package/src/tests/mockComponents.js
@@ -20,14 +20,15 @@ function stringifyJSONCircularSafe(obj) {
  */
 [
   "AddressForm",
-  "CheckoutAction",
-  "CheckoutActionComplete",
-  "CheckoutActionIncomplete",
   "Button",
   "CartItem",
   "CartItemDetail",
   "CartItems",
   "CartSummary",
+  "Checkbox",
+  "CheckoutAction",
+  "CheckoutActionComplete",
+  "CheckoutActionIncomplete",
   "ErrorsBlock",
   "Field",
   "MiniCartSummary",

--- a/styleguide/src/appComponents.js
+++ b/styleguide/src/appComponents.js
@@ -5,6 +5,7 @@ import CartItem from "../../package/src/components/CartItem/v1";
 import CartItemDetail from "../../package/src/components/CartItemDetail/v1";
 import CartItems from "../../package/src/components/CartItems/v1";
 import CartSummary from "../../package/src/components/CartSummary/v1";
+import Checkbox from "../../package/src/components/Checkbox/v1";
 import CheckoutAction from "../../package/src/components/CheckoutAction/v1";
 import CheckoutActionComplete from "../../package/src/components/CheckoutActionComplete/v1";
 import CheckoutActionIncomplete from "../../package/src/components/CheckoutActionIncomplete/v1";
@@ -80,6 +81,7 @@ export default {
   CartItemDetail,
   CartItems,
   CartSummary,
+  Checkbox,
   CheckoutAction,
   CheckoutActionComplete,
   CheckoutActionIncomplete,

--- a/styleguide/src/sections/InstallingandImporting.md
+++ b/styleguide/src/sections/InstallingandImporting.md
@@ -35,6 +35,7 @@ import CartItem from "@reactioncommerce/components/CartItem/v1";
 import CartItemDetail from "@reactioncommerce/components/CartItemDetail/v1";
 import CartItems from "@reactioncommerce/components/CartItems/v1";
 import CartSummary from "@reactioncommerce/components/CartSummary/v1";
+import Checkbox from "@reactioncommerce/components/Checkbox/v1";
 import CheckoutAction from "@reactioncommerce/components/CheckoutAction/v1";
 import CheckoutActionComplete from "@reactioncommerce/components/CheckoutActionComplete/v1";
 import CheckoutActionIncomplete from "@reactioncommerce/components/CheckoutActionIncomplete/v1";
@@ -110,6 +111,7 @@ export default {
   CartItemDetail,
   CartItems,
   CartSummary,
+  Checkbox,
   CheckoutAction,
   CheckoutActionComplete,
   CheckoutActionIncomplete,


### PR DESCRIPTION
Resolves #234 
Impact: **minor**  
Type: **feature**

## Component
Added a `Checkbox` field for `isCommercial` property.

## Breaking changes
N/A

## Testing
1. At the bottom of the `AddressForm` page add `shouldShowIsCommercialField` prop to the `AddressForm` inside the implementation example editor.
2. The "Is a commercial address" field should appear, select the checkbox and submit the form
3. In the browser console, you should see the address object from the form with an `isCommercial` property set to `true`.