### PR TITLE
fix: nnnnat 241 fixed font family on form/checkout action elements

### DIFF
--- a/package/src/components/Field/v1/__snapshots__/Field.test.js.snap
+++ b/package/src/components/Field/v1/__snapshots__/Field.test.js.snap
@@ -28,7 +28,7 @@ exports[`renders with help text 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -45,7 +45,7 @@ exports[`renders with help text 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }
@@ -139,7 +139,7 @@ exports[`renders with label 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -156,7 +156,7 @@ exports[`renders with label 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }
@@ -241,7 +241,7 @@ exports[`renders with no help text 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -258,7 +258,7 @@ exports[`renders with no help text 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }
@@ -337,7 +337,7 @@ exports[`renders with no label 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -354,7 +354,7 @@ exports[`renders with no label 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }

--- a/package/src/components/PhoneNumberInput/v1/__snapshots__/PhoneNumberInput.test.js.snap
+++ b/package/src/components/PhoneNumberInput/v1/__snapshots__/PhoneNumberInput.test.js.snap
@@ -15,7 +15,7 @@ exports[`basic snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -32,7 +32,7 @@ exports[`basic snapshot 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;

--- a/package/src/components/Select/v1/Select.js
+++ b/package/src/components/Select/v1/Select.js
@@ -83,6 +83,7 @@ const getSelectIndicatorColor = applyTheme("selectIndicatorColor");
 const getSelectMenuBorder = applyTheme("selectMenuBorder");
 const getSelectLetterSpacing = applyTheme("selectLetterSpacing");
 const getSelectTextColor = applyTheme("selectTextColor");
+const getInputFontFamily = applyTheme("inputFontFamily");
 
 function getCustomStyles(props) {
   const { maxWidth } = props;
@@ -93,6 +94,7 @@ function getCustomStyles(props) {
       return {
         ...base,
         maxWidth,
+        fontFamily: getInputFontFamily(),
         fontSize: getInputFontSize()
       };
     },

--- a/package/src/components/Select/v1/__snapshots__/Select.test.js.snap
+++ b/package/src/components/Select/v1/__snapshots__/Select.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`basic snapshot 1`] = `
 <div
-  className="css-wi1kty"
+  className="css-15mpz6f"
   id={undefined}
   onKeyDown={[Function]}
 >

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -5,6 +5,7 @@ import { withComponents } from "@reactioncommerce/components-context";
 import { applyTheme, CustomPropTypes } from "../../../utils";
 
 const Title = styled.h3`
+  font-family: ${applyTheme("font_family")};
   font-size: ${applyTheme("font_size_h3")};
   font-weight: ${applyTheme("font_weight_bold")};
   font-style: normal;
@@ -14,6 +15,7 @@ const Title = styled.h3`
 `;
 
 const Address = styled.address`
+  font-family: ${applyTheme("font_family")};
   font-style: normal;
 `;
 

--- a/package/src/components/ShippingAddressCheckoutAction/v1/__snapshots__/ShippingAddressCheckoutAction.test.js.snap
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/__snapshots__/ShippingAddressCheckoutAction.test.js.snap
@@ -3,6 +3,7 @@
 exports[`basic snapshot with address 1`] = `
 Array [
   .c0 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 18px;
   font-weight: 700;
   font-style: normal;
@@ -26,6 +27,7 @@ Array [
 exports[`basic snapshot with empty address 1`] = `
 Array [
   .c0 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 18px;
   font-weight: 700;
   font-style: normal;

--- a/package/src/components/TextInput/v1/__snapshots__/TextInput.test.js.snap
+++ b/package/src/components/TextInput/v1/__snapshots__/TextInput.test.js.snap
@@ -15,7 +15,7 @@ exports[`renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -32,7 +32,7 @@ exports[`renders 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }
@@ -97,7 +97,7 @@ exports[`renders textarea 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -114,7 +114,7 @@ exports[`renders textarea 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }
@@ -179,7 +179,7 @@ exports[`renders textarea with props 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -196,7 +196,7 @@ exports[`renders textarea with props 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }
@@ -261,7 +261,7 @@ exports[`renders with props 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   line-height: 1;
   outline: none;
@@ -278,7 +278,7 @@ exports[`renders with props 1`] = `
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
   flex-grow: 2;
-  font-family: inherit;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   outline: none;
 }

--- a/package/src/defaultComponentTheme.js
+++ b/package/src/defaultComponentTheme.js
@@ -309,7 +309,7 @@ const inputStyles = {
   rui_inputColor_focus: coolGrey500,
   rui_inputColor_success: black55,
   rui_inputPlaceholderColor: black20,
-  rui_inputFontFamily: "inherit",
+  rui_inputFontFamily: fontFamily,
   rui_inputFontSize: fontSize14,
   rui_inputLineHeight: flatLeading,
   rui_inputVerticalPadding: baseUnit(0.8),


### PR DESCRIPTION
Resolves #241 
Impact: **minor**  
Type: **bugfix**

## Component
The TextInput, Select and ShippingAddressCheckoutAction all had been inheriting their font-family from the `body`. This would cause a serif text to render when using these components in the storefront.

## Testing
1. Visit the TextInput, Select and ShippingAddressCheckoutAction, verify that "source sans" is being used by all text elements.