### PR TITLE
(feat): added addressName optional field to AddressForm

### DIFF
--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -27,6 +27,10 @@ const ColHalf = styled.div`
 class AddressForm extends Component {
   static propTypes = {
     /**
+     * Place holder for Address Name field.
+     */
+    addressNamePlaceholder: PropTypes.string,
+    /**
      * If you've set up a components context using @reactioncommerce/components-context
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
@@ -158,6 +162,7 @@ class AddressForm extends Component {
   };
 
   static defaultProps = {
+    addressNamePlaceholder: "Address Name",
     errors: [],
     isSaving: false,
     name: "address",
@@ -215,6 +220,7 @@ class AddressForm extends Component {
 
   render() {
     const {
+      addressNamePlaceholder,
       value,
       components: { Checkbox, ErrorsBlock, Field, TextInput, Select, PhoneNumberInput },
       countries,
@@ -256,7 +262,7 @@ class AddressForm extends Component {
         <Grid>
           {shouldShowAddressNameField && <ColFull>
             <Field name="addressName" label="Address Name" labelFor={addressNameInputId}>
-              <TextInput id={addressNameInputId} name="addressName" placeholder="Address Name" isReadOnly={isSaving} />
+                <TextInput id={addressNameInputId} name="addressName" placeholder={addressNamePlaceholder}isReadOnly={isSaving} />
             </Field>
           </ColFull>}
 

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -128,6 +128,10 @@ class AddressForm extends Component {
       value: PropTypes.string
     })),
     /**
+     * Should the AddressForm show the "Address Names" field.
+     */
+    shouldShowAddressNameField: PropTypes.bool,
+    /**
      * Should the AddressForm show the "Is Commercial Address" field.
      */
     shouldShowIsCommercialField: PropTypes.bool,
@@ -154,11 +158,14 @@ class AddressForm extends Component {
 
   static defaultProps = {
     errors: [],
+    isSaving: false,
     name: "address",
     onCancel() {},
     onChange() {},
     onCountryChange() {},
     onSubmit() {},
+    shouldShowAddressNameField: false,
+    shouldShowIsCommercialField: false,
     validator: getRequiredValidator(
       "country",
       "firstName",
@@ -215,9 +222,11 @@ class AddressForm extends Component {
       regions,
       validator,
       onChange,
+      shouldShowAddressNameField,
       shouldShowIsCommercialField
     } = this.props;
 
+    const addressNameInputId = `addressName_${this.uniqueInstanceIdentifier}`;
     const countryInputId = `country_${this.uniqueInstanceIdentifier}`;
     const firstNameInputId = `firstName_${this.uniqueInstanceIdentifier}`;
     const lastNameInputId = `lastName_${this.uniqueInstanceIdentifier}`;
@@ -243,6 +252,12 @@ class AddressForm extends Component {
         value={value}
       >
         <Grid>
+          {shouldShowAddressNameField && <ColFull>
+            <Field name="addressName" label="Address Name" labelFor={addressNameInputId}>
+              <TextInput id={addressNameInputId} name="addressName" placeholder="Address Name" isReadOnly={isSaving} />
+            </Field>
+          </ColFull>}
+
           <ColFull>
             <Field name="country" label="Country" labelFor={countryInputId} isRequired>
               <Select

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -143,6 +143,7 @@ class AddressForm extends Component {
      * Address object to be edited
      */
     value: PropTypes.shape({
+      addressName: PropTypes.string,
       address1: PropTypes.string,
       address2: PropTypes.string,
       country: PropTypes.string,
@@ -177,6 +178,7 @@ class AddressForm extends Component {
       "region"
     ),
     value: {
+      addressName: "",
       address1: "",
       address2: "",
       country: "",

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -95,10 +95,6 @@ class AddressForm extends Component {
       name: PropTypes.string.isRequired
     })),
     /**
-     * Is Address Name a required field.
-     */
-    isAddressNameRequired: PropTypes.bool,
-    /**
      * Is the shipping address being saved
      */
     isSaving: PropTypes.bool,
@@ -168,7 +164,6 @@ class AddressForm extends Component {
   static defaultProps = {
     addressNamePlaceholder: "Address Name",
     errors: [],
-    isAddressNameRequired: false,
     isSaving: false,
     name: "address",
     onCancel() {},
@@ -230,15 +225,14 @@ class AddressForm extends Component {
       components: { Checkbox, ErrorsBlock, Field, TextInput, Select, PhoneNumberInput },
       countries,
       errors,
-      isAddressNameRequired,
       isSaving,
       name,
       regions,
       onChange,
       shouldShowAddressNameField,
-      shouldShowIsCommercialField
+      shouldShowIsCommercialField,
+      validator
     } = this.props;
-    let { validator } = this.props;
 
     const addressNameInputId = `addressName_${this.uniqueInstanceIdentifier}`;
     const countryInputId = `country_${this.uniqueInstanceIdentifier}`;
@@ -251,20 +245,6 @@ class AddressForm extends Component {
     const postalInputId = `postal_${this.uniqueInstanceIdentifier}`;
     const phoneInputId = `phone_${this.uniqueInstanceIdentifier}`;
     const isCommercialInputId = `isCommercial_${this.uniqueInstanceIdentifier}`;
-
-    if (isAddressNameRequired) {
-      validator = getRequiredValidator(
-        "addressName",
-        "country",
-        "firstName",
-        "lastName",
-        "address1",
-        "city",
-        "phone",
-        "postal",
-        "region"
-      );
-    }
 
     return (
       <Form
@@ -286,8 +266,7 @@ class AddressForm extends Component {
                 name="addressName"
                 label="Address Name"
                 labelFor={addressNameInputId}
-                isOptional={!isAddressNameRequired}
-                isRequired={isAddressNameRequired}
+                isOptional
               >
                 <TextInput
                   id={addressNameInputId}
@@ -295,7 +274,6 @@ class AddressForm extends Component {
                   placeholder={addressNamePlaceholder}
                   isReadOnly={isSaving}
                 />
-                {isAddressNameRequired && <ErrorsBlock names={["addressName"]} />}
               </Field>
             </ColFull>
           )}

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -262,7 +262,7 @@ class AddressForm extends Component {
         <Grid>
           {shouldShowAddressNameField && <ColFull>
             <Field name="addressName" label="Address Name" labelFor={addressNameInputId}>
-                <TextInput id={addressNameInputId} name="addressName" placeholder={addressNamePlaceholder}isReadOnly={isSaving} />
+              <TextInput id={addressNameInputId} name="addressName" placeholder={addressNamePlaceholder}isReadOnly={isSaving} />
             </Field>
           </ColFull>}
 

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -95,6 +95,10 @@ class AddressForm extends Component {
       name: PropTypes.string.isRequired
     })),
     /**
+     * Is Address Name a required field.
+     */
+    isAddressNameRequired: PropTypes.bool,
+    /**
      * Is the shipping address being saved
      */
     isSaving: PropTypes.bool,
@@ -164,6 +168,7 @@ class AddressForm extends Component {
   static defaultProps = {
     addressNamePlaceholder: "Address Name",
     errors: [],
+    isAddressNameRequired: false,
     isSaving: false,
     name: "address",
     onCancel() {},
@@ -225,14 +230,15 @@ class AddressForm extends Component {
       components: { Checkbox, ErrorsBlock, Field, TextInput, Select, PhoneNumberInput },
       countries,
       errors,
+      isAddressNameRequired,
       isSaving,
       name,
       regions,
-      validator,
       onChange,
       shouldShowAddressNameField,
       shouldShowIsCommercialField
     } = this.props;
+    let { validator } = this.props;
 
     const addressNameInputId = `addressName_${this.uniqueInstanceIdentifier}`;
     const countryInputId = `country_${this.uniqueInstanceIdentifier}`;
@@ -245,6 +251,20 @@ class AddressForm extends Component {
     const postalInputId = `postal_${this.uniqueInstanceIdentifier}`;
     const phoneInputId = `phone_${this.uniqueInstanceIdentifier}`;
     const isCommercialInputId = `isCommercial_${this.uniqueInstanceIdentifier}`;
+
+    if (isAddressNameRequired) {
+      validator = getRequiredValidator(
+        "addressName",
+        "country",
+        "firstName",
+        "lastName",
+        "address1",
+        "city",
+        "phone",
+        "postal",
+        "region"
+      );
+    }
 
     return (
       <Form
@@ -260,11 +280,25 @@ class AddressForm extends Component {
         value={value}
       >
         <Grid>
-          {shouldShowAddressNameField && <ColFull>
-            <Field name="addressName" label="Address Name" labelFor={addressNameInputId}>
-              <TextInput id={addressNameInputId} name="addressName" placeholder={addressNamePlaceholder}isReadOnly={isSaving} />
-            </Field>
-          </ColFull>}
+          {shouldShowAddressNameField && (
+            <ColFull>
+              <Field
+                name="addressName"
+                label="Address Name"
+                labelFor={addressNameInputId}
+                isOptional={!isAddressNameRequired}
+                isRequired={isAddressNameRequired}
+              >
+                <TextInput
+                  id={addressNameInputId}
+                  name="addressName"
+                  placeholder={addressNamePlaceholder}
+                  isReadOnly={isSaving}
+                />
+                {isAddressNameRequired && <ErrorsBlock names={["addressName"]} />}
+              </Field>
+            </ColFull>
+          )}
 
           <ColFull>
             <Field name="country" label="Country" labelFor={countryInputId} isRequired>
@@ -350,7 +384,7 @@ class AddressForm extends Component {
             </Field>
           </ColFull>
 
-          {shouldShowIsCommercialField &&
+          {shouldShowIsCommercialField && (
             <ColFull>
               <Field name="isCommercial" labelFor={isCommercialInputId}>
                 <Checkbox
@@ -361,7 +395,7 @@ class AddressForm extends Component {
                 />
               </Field>
             </ColFull>
-          }
+          )}
         </Grid>
       </Form>
     );

--- a/package/src/components/AddressForm/v1/AddressForm.md
+++ b/package/src/components/AddressForm/v1/AddressForm.md
@@ -128,6 +128,7 @@ const regions = [
   countries={countries}
   regions={regions}
   onSubmit={(address) => console.log(address)}
+  addressNamePlaceholder="Headquarters"
   shouldShowAddressNameField
  />
 ```

--- a/package/src/components/AddressForm/v1/AddressForm.md
+++ b/package/src/components/AddressForm/v1/AddressForm.md
@@ -110,6 +110,28 @@ const errors = [{ message: "error message", name: "address1"}];
  />
 ```
 
+#### Address name field
+You may want to save mutiple addresses, `shouldShowAddressNameField` renders a field so the user can "name" each address they enter.
+```jsx
+const countries = [
+  { value: "US", label: "United States" },
+  { value: "DE", label: "Germany" },
+  { value: "NU", label: "Nigeria" }
+];
+
+const regions = [
+  { value: "LA", label: "Louisiana" },
+  { value: "CA", label: "California" }
+];
+
+<AddressForm
+  countries={countries}
+  regions={regions}
+  onSubmit={(address) => console.log(address)}
+  shouldShowAddressNameField
+ />
+```
+
 #### Is commercial address field
 Some `fulfillmentMethods` will charge a different shipping rate if shipping to a commercial address.
 ```jsx

--- a/package/src/components/AddressForm/v1/AddressForm.md
+++ b/package/src/components/AddressForm/v1/AddressForm.md
@@ -111,7 +111,7 @@ const errors = [{ message: "error message", name: "address1"}];
 ```
 
 #### Address name field
-You may want to save mutiple addresses, `shouldShowAddressNameField` renders a field so the user can "name" each address they enter.
+You may want to save mutiple addresses, `shouldShowAddressNameField` renders a field so the user can "name" each address they enter. You can require the Address Name field by adding the `isAddressNameRequired` prop.
 ```jsx
 const countries = [
   { value: "US", label: "United States" },

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -60,16 +60,20 @@ const isReady = (ready) => console.log("is action ready for save?", ready);
 #### Render Complete Method
 ```jsx
 const capturedData = {
-  shippingAddress: {
-    address1: "7742 Hwy 23",
-    address2: "",
-    country: "US",
-    city: "Belle Chasse",
-    firstName: "Salvos",
-    lastName: "Seafood",
-    postal: "70037",
-    region: "LA",
-    phone: "(504) 393-7303"
+  fulfillmentGroup: {
+    data: {
+     shippingAddress: {
+        address1: "7742 Hwy 23",
+        address2: "",
+        country: "US",
+        city: "Belle Chasse",
+        firstName: "Salvos",
+        lastName: "Seafood",
+        postal: "70037",
+        region: "LA",
+        phone: "(504) 393-7303"
+      }
+    }
   }
 };
 const action = ShippingAddressCheckoutAction;


### PR DESCRIPTION
Resolves #229 
Impact: **minor**  
Type: **feature**

## Component
Added an optional text field that can capture an "Address Name" to the `AddressForm`.

## Screenshots
![screen shot 2018-08-20 at 4 56 12 pm](https://user-images.githubusercontent.com/1135948/44368900-fd372000-a499-11e8-938b-8aa4dff635a5.png)

## Breaking changes
N/A

## Testing
1. On staging go to the bottom of the `AddressForm` docs and add `shouldShowAddressNameField` prop to the `<AddressForm />` in the example implementation editor.
2. Fill out the `AddressForm` with an "Address Name" and submit the form.
3. In the browser console, you should see the address object with the `addressName` property.

@aldeed  I tagged you as a reviewer just to verify my address property name "addressName" would be OK.
