### PR TITLE
feat: add item click handler prop to CatalogGrid

### DIFF
--- a/package/src/components/CatalogGrid/v1/CatalogGrid.js
+++ b/package/src/components/CatalogGrid/v1/CatalogGrid.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { ContainerQuery } from "react-container-query";
 import styled from "styled-components";
 import { withComponents } from "@reactioncommerce/components-context";
-import { getFromTheme, CustomPropTypes } from "../../../utils";
+import { getFromTheme, CustomPropTypes, preventAccidentalDoubleClick } from "../../../utils";
 
 const mdWidth = getFromTheme({}, "rui_md");
 const containerQueries = {
@@ -72,6 +72,10 @@ class CatalogGrid extends Component {
      */
     currencyCode: PropTypes.string,
     /**
+     * Item click handler
+     */
+    onItemClick: PropTypes.func,
+    /**
      * Image to display when product doesn't have a primary image
      */
     placeholderImageURL: PropTypes.string,
@@ -83,14 +87,20 @@ class CatalogGrid extends Component {
 
   static defaultProps = {
     currencyCode: "USD",
+    onItemClick() {},
     placeholderImageURL: "/resources/placeholder.gif",
     products: []
   };
+
+  handleOnClick = preventAccidentalDoubleClick((event) => {
+    this.props.onItemClick(event);
+  });
 
   render() {
     const {
       components: { CatalogGridItem },
       currencyCode,
+      onItemClick,
       placeholderImageURL,
       products
     } = this.props;
@@ -103,6 +113,7 @@ class CatalogGrid extends Component {
               <GridItem containerParams={params} key={`grid-item-${index}`} {...this.props}>
                 <CatalogGridItem
                   currencyCode={currencyCode}
+                  onClick={onItemClick}
                   placeholderImageURL={placeholderImageURL}
                   product={product}
                 />

--- a/package/src/components/CatalogGrid/v1/CatalogGrid.md
+++ b/package/src/components/CatalogGrid/v1/CatalogGrid.md
@@ -13,7 +13,7 @@ that products always render appropriately regardless of where the grid is render
 ```
 
 ```jsx
-  <CatalogGrid products={products} onClick={(event) => event.preventDefault()} />
+  <CatalogGrid products={products} onItemClick={(event) => event.preventDefault()} />
 ```
 
 ##### Fixed-width container, 1 product per row (325px width)

--- a/package/src/components/CatalogGrid/v1/CatalogGrid.md
+++ b/package/src/components/CatalogGrid/v1/CatalogGrid.md
@@ -13,7 +13,7 @@ that products always render appropriately regardless of where the grid is render
 ```
 
 ```jsx
-  <CatalogGrid products={products} />
+  <CatalogGrid products={products} onClick={(event) => event.preventDefault()} />
 ```
 
 ##### Fixed-width container, 1 product per row (325px width)

--- a/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
+++ b/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { withComponents } from "@reactioncommerce/components-context";
-import { applyTheme, CustomPropTypes } from "../../../utils";
+import { applyTheme, CustomPropTypes, preventAccidentalDoubleClick } from "../../../utils";
 import { priceByCurrencyCode } from "./utils";
 
 const ProductMediaWrapper = styled.div`
@@ -56,6 +56,10 @@ class CatalogGridItem extends Component {
      */
     currencyCode: PropTypes.string.isRequired,
     /**
+     * Item click handler
+     */
+    onClick: PropTypes.func,
+    /**
      * Image to display when product doesn't have a primary image
      */
     placeholderImageURL: PropTypes.string,
@@ -89,6 +93,7 @@ class CatalogGridItem extends Component {
   };
 
   static defaultProps = {
+    onClick() {},
     placeholderImageURL: ""
   };
 
@@ -113,7 +118,9 @@ class CatalogGridItem extends Component {
     return primaryImage;
   }
 
-  handleOnClick = () => {};
+  handleOnClick = preventAccidentalDoubleClick((event) => {
+    this.props.onClick(event);
+  });
 
   renderProductMedia() {
     const { components: { ProgressiveImage }, product: { description } } = this.props;


### PR DESCRIPTION
Resolves #247 
Impact: **minor**  
Type: **feature**

## Component
Added an `onItemClick` prop to CatalogGrid, `onClick` prop to CatalogItem, and passed that as the link's click handler. Result: When a user clicks on an item in the grid, `onItemClick` is fired.

## Screenshots
N/A (UI doesn't change)

## Breaking changes
None

## Testing
1. Click on items in the first example grid.
2. Confirm nothing happens (`event.preventDefault` is called in the example code).
3. Confirm other examples link to /product/SLUG (even though 404 in component lib)
