### PR TITLE
fix: pass product in CatalogGrid's onItemClick handler

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -79,6 +79,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "reacto-form": "^0.0.2",
+    "react-container-query": "^0.11.0",
     "react-stripe-elements": "^2.0.1",
     "styled-components": "^3.3.3"
   }

--- a/package/src/components/CatalogGrid/v1/CatalogGrid.js
+++ b/package/src/components/CatalogGrid/v1/CatalogGrid.js
@@ -92,8 +92,8 @@ class CatalogGrid extends Component {
     products: []
   };
 
-  handleOnClick = preventAccidentalDoubleClick((event) => {
-    this.props.onItemClick(event);
+  handleOnClick = preventAccidentalDoubleClick((event, product) => {
+    this.props.onItemClick(event, product);
   });
 
   render() {

--- a/package/src/components/CatalogGrid/v1/CatalogGrid.md
+++ b/package/src/components/CatalogGrid/v1/CatalogGrid.md
@@ -13,7 +13,10 @@ that products always render appropriately regardless of where the grid is render
 ```
 
 ```jsx
-  <CatalogGrid products={products} onItemClick={(event) => event.preventDefault()} />
+  <CatalogGrid products={products} onItemClick={(event, product) => {
+    event.preventDefault();
+    alert(product.title);
+  }} />
 ```
 
 ##### Fixed-width container, 1 product per row (325px width)

--- a/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
+++ b/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
@@ -119,7 +119,7 @@ class CatalogGridItem extends Component {
   }
 
   handleOnClick = preventAccidentalDoubleClick((event) => {
-    this.props.onClick(event);
+    this.props.onClick(event, this.props.product);
   });
 
   renderProductMedia() {


### PR DESCRIPTION
Resolves #251 
Impact: **minor**  
Type: **bugfix**

## Component
This PR simply passes `product` in `CatalogGrid`'s `onItemClick` handler. This will allow the tracking decorator in starterkit access to the product.

## Screenshots
N/A 

## Breaking changes
None

## Testing
1. Catalog Grid examples
2. Click first example
3. Confirm alert appears with product's title