### PR TITLE
(fix): nnnnat updated CheckoutEmailAddress styles

### DIFF
--- a/package/src/components/CheckoutEmailAddress/v1/CheckoutEmailAddress.js
+++ b/package/src/components/CheckoutEmailAddress/v1/CheckoutEmailAddress.js
@@ -4,9 +4,11 @@ import styled from "styled-components";
 import { applyTheme } from "../../../utils";
 
 const StyledDiv = styled.div`
+  border-bottom: solid 2px ${applyTheme("color_black10")};
   color: ${applyTheme("color_coolGrey500")};
   font-family: ${applyTheme("font_family")};
   font-size: ${applyTheme("font_size_small")};
+  padding: 1rem 0;
 `;
 
 const StyledSpan = styled.span`
@@ -27,7 +29,7 @@ class CheckoutEmailAddress extends Component {
     }
 
     return null;
-  }
+  };
 
   render() {
     const { emailAddress } = this.props;

--- a/package/src/components/CheckoutEmailAddress/v1/__snapshots__/CheckoutEmailAddress.test.js.snap
+++ b/package/src/components/CheckoutEmailAddress/v1/__snapshots__/CheckoutEmailAddress.test.js.snap
@@ -2,9 +2,11 @@
 
 exports[`render email address of a guest 1`] = `
 .c0 {
+  border-bottom: solid 2px #e6e6e6;
   color: #3c3c3c;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
+  padding: 1rem 0;
 }
 
 .c1 {
@@ -25,9 +27,11 @@ exports[`render email address of a guest 1`] = `
 
 exports[`render email address of a user with an account 1`] = `
 .c0 {
+  border-bottom: solid 2px #e6e6e6;
   color: #3c3c3c;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
+  padding: 1rem 0;
 }
 
 .c1 {


### PR DESCRIPTION
Resolves N/A
Impact: **minor**  
Type: **feature|bugfix**

## Component
Updated `CheckoutEmailAddress` CSS to encapsulate more styles into the component and not make the consuming app responsible for the padding and border.

## Screenshots
#### Current `CheckoutEmailAddress` in storefront
![screen shot 2018-08-24 at 4 07 58 pm](https://user-images.githubusercontent.com/1135948/44608022-f705b400-a7b7-11e8-960b-369e361e5231.png)

[design](https://zpl.io/2y7D0Nn)

## Breaking changes
N/A

## Testing
1. Make sure the CheckoutEmailAddress component looks like the design.
