### PR TITLE
Wireup StripeForm to collect billing address

### DIFF
--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -113,11 +113,11 @@ class CheckoutActionsExample extends React.Component {
   }
 
   setPaymentMethod(data) {
-    const { token: { card } } = data;
+    const { billingAddress, token: { card } } = data;
     const { checkout } = this.state;
     const payment = {
       data: {
-        billingAddress: null,
+        billingAddress,
         displayName: `${card.brand} ending in ${card.last4}`
       }
     }
@@ -127,7 +127,7 @@ class CheckoutActionsExample extends React.Component {
           this.setState(Object.assign(this.state, {
             checkout: {
               fulfillmentGroups: checkout.fulfillmentGroups,
-              payments: [ payment ]
+              payments: [payment] 
             }
           }));
           resolve(payment);

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -113,18 +113,15 @@ class StripePaymentCheckoutAction extends Component {
   _addressForm = null;
 
   submit = async () => {
-    // TODO: submit billing address form
-    // For now, only the stripe form will be submitted.
-    // this._addressForm.submit();
-    this.handleSubmit();
+    this._addressForm.submit();
   }
 
-  handleSubmit = async () => {
+  handleSubmit = async (value) => {
     const { onSubmit } = this.props;
     const { token } = await this._stripe.createToken();
 
     await onSubmit({
-      // billingAddress: value,
+      billingAddress: value,
       token
     });
   }
@@ -133,7 +130,6 @@ class StripePaymentCheckoutAction extends Component {
     const { onReadyForSaveChange } = this.props;
     const isFilled = Object.keys(values).every((key) => (key === "address2" ? true : values[key] !== null));
 
-    // Setting the "readyForSave" flag should take into account, both, the Stripe for and billing address form
     onReadyForSaveChange(isFilled);
   };
 
@@ -164,6 +160,8 @@ class StripePaymentCheckoutAction extends Component {
     const { components: { AddressForm } } = this.props;
     const { billingAddress } = this.state;
 
+    // Only render billing address when user chooses to use
+    // a different billing address
     if (billingAddress === "same_as_shipping") {
       return null;
     }


### PR DESCRIPTION
Impact: minor
Type: fix

## Summary
Wiresup the `StripeForm` component to collect billing address

## Testing
1. Run component library locally
2. Add a console.log(payment) here: https://github.com/reactioncommerce/reaction-component-library/compare/feat-willopez-wireup-billing-address-in-stripe-form?expand=1#diff-28d16de18ab7ee6a9975f2f042a7428cL124

3. In CheckoutActions complete step 1 and then 2, on the step 2 click on "Use different billing address" and fill out form.
4. Submit form
5. Verify the console log outputs the entered billing address


