### PR TITLE
fix: clone fulfillment options before sorting

### DIFF
--- a/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
+++ b/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
@@ -128,9 +128,13 @@ class FulfillmentOptionsCheckoutAction extends Component {
       return selectedFulfillmentOption.fulfillmentMethod._id;
     }
 
+    // Apollo Client returns immutable Objects, therefore it's necessary to
+    // clone the fulfillment options before sorting.
+    const clonedFulfillmentOptions = availableFulfillmentOptions.slice();
+
     // If a selection has not been made yet, default to cheapest
     if (availableFulfillmentOptions && availableFulfillmentOptions.length > 0) {
-      return availableFulfillmentOptions.sort((itemA, itemB) => itemA.price.amount - itemB.price.amount)[0].fulfillmentMethod._id;
+      return clonedFulfillmentOptions.sort((itemA, itemB) => itemA.price.amount - itemB.price.amount)[0].fulfillmentMethod._id;
     }
 
     return null;

--- a/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
+++ b/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
@@ -128,16 +128,15 @@ class FulfillmentOptionsCheckoutAction extends Component {
       return selectedFulfillmentOption.fulfillmentMethod._id;
     }
 
-    // Apollo Client returns immutable Objects, therefore it's necessary to
-    // clone the fulfillment options before sorting.
-    const clonedFulfillmentOptions = availableFulfillmentOptions.slice();
-
     // If a selection has not been made yet, default to cheapest
-    if (availableFulfillmentOptions && availableFulfillmentOptions.length > 0) {
-      return clonedFulfillmentOptions.sort((itemA, itemB) => itemA.price.amount - itemB.price.amount)[0].fulfillmentMethod._id;
-    }
+    const cheapestOption = availableFulfillmentOptions.reduce((cheapest, option) => {
+      if (!cheapest || option.price.amount < cheapest.price.amount) {
+        return option;
+      }
+      return cheapest;
+    }, null);
 
-    return null;
+    return cheapestOption.fulfillmentMethod._id;
   }
 
   render() {


### PR DESCRIPTION
Impact: minor
Type: bug

### Summary
It's necessary to clone fulfillment options before sorting, due to the fact the Apollo Client uses immutable Objects


## Testing
1. Verify that the most inexpensive shipping option is selected by default in `CheckoutActions`
