### PR TITLE
fix: removes the bottom border from the last CheckoutAction

### DIFF
--- a/package/src/components/CheckoutActions/v1/CheckoutActions.js
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.js
@@ -12,6 +12,9 @@ const Action = styled.div`
   &:first-of-type {
     border-top: solid 1px ${applyTheme("color_black10")};
   }
+  &:last-of-type {
+    border-bottom: none;
+  }
 `;
 
 const FormActions = styled.div`

--- a/package/src/components/CheckoutActions/v1/__snapshots__/CheckoutActions.test.js.snap
+++ b/package/src/components/CheckoutActions/v1/__snapshots__/CheckoutActions.test.js.snap
@@ -10,6 +10,10 @@ exports[`basic snapshot 1`] = `
   border-top: solid 1px #e6e6e6;
 }
 
+.c0:last-of-type {
+  border-bottom: none;
+}
+
 <div
   className="c0"
 >


### PR DESCRIPTION
Impact: minor
Type: fix

#### Summary 
Removes the bottom border for the last `CheckoutAction`, so that it matches designs.

Testing; 
Verify bottom border for last `CheckoutAction` is not rendered.