### PR TITLE
fix: remove insecure http protocol from placehold.it src

### DIFF
--- a/package/src/components/ShopLogo/v1/ShopLogo.md
+++ b/package/src/components/ShopLogo/v1/ShopLogo.md
@@ -6,7 +6,7 @@ Renders a shop's logo if a logo URL is provided, otherwise, it will render the s
 ##### Default
 
 ```jsx
-<ShopLogo shopLogoUrl="http://placehold.it/60" shopName="Reaction" />
+<ShopLogo shopLogoUrl="//placehold.it/60" shopName="Reaction" />
 ```
 
 ##### Without a logo

--- a/package/src/components/ShopLogo/v1/ShopLogo.test.js
+++ b/package/src/components/ShopLogo/v1/ShopLogo.test.js
@@ -4,7 +4,7 @@ import ShopLogo from "./ShopLogo";
 
 test("basic snapshot", () => {
   const component = renderer.create((
-    <ShopLogo shopLogoUrl="http://placehold.it/60" shopName="Reaction" />
+    <ShopLogo shopLogoUrl="//placehold.it/60" shopName="Reaction" />
   ));
 
   const tree = component.toJSON();

--- a/package/src/components/ShopLogo/v1/__snapshots__/ShopLogo.test.js.snap
+++ b/package/src/components/ShopLogo/v1/__snapshots__/ShopLogo.test.js.snap
@@ -12,7 +12,7 @@ exports[`basic snapshot 1`] = `
 >
   <img
     alt="Reaction"
-    src="http://placehold.it/60"
+    src="//placehold.it/60"
   />
 </div>
 `;


### PR DESCRIPTION
Resolves #278
Impact: **major**  
Type: **bugfix**

## Component
Updates `ShopLogo` markdown, tests, and snapshot to remove the `http` protocol from the source for the placehold.it image.
`http://placehold.it/60` => `//placehold.it/60` so that we're not loading an insecure resource.

## Testing
1. Visit the preview link for the `ShopLogo` component: https://deploy-preview-279--stoic-hodgkin-c0179e.netlify.com/#!/ShopLogo
2. Ensure that the image is being loaded over https and that there are no https warnings.
3. Ensure that the image is visible