### PR TITLE
fix: make stock warning props optional

### DIFF
--- a/package/src/components/StockWarning/v1/StockWarning.js
+++ b/package/src/components/StockWarning/v1/StockWarning.js
@@ -14,12 +14,12 @@ class StockWarning extends Component {
     /**
      * The product's current stock level
      */
-    inventoryQuantity: PropTypes.number.isRequired,
+    inventoryQuantity: PropTypes.number,
     /**
      * When true, indicates that a product's inventory level has reached
      * the low level threshold.
      */
-    isLowInventoryQuantity: PropTypes.bool.isRequired
+    isLowInventoryQuantity: PropTypes.bool
   };
 
   render() {


### PR DESCRIPTION
Impact: minor  
Type: fix

### Summary
Make `StockWaring` props optional as they are used in `CartItem` which is used in the grid and in the order confirmation page, the `OrderItem` does not have `inventoryQuantity` nor `isLowInventoryQuanity` fields, and therefore prop validation errors are thrown
