### PR TITLE
feat: added initailSize prop for SSR

### DIFF
--- a/package/src/components/CatalogGrid/v1/CatalogGrid.js
+++ b/package/src/components/CatalogGrid/v1/CatalogGrid.js
@@ -82,6 +82,13 @@ class CatalogGrid extends Component {
      */
     currencyCode: PropTypes.string,
     /**
+     * The inital size the grid should render at. Use to set grid width during SSR.
+     */
+    initialSize: PropTypes.shape({
+      height: PropTypes.number,
+      width: PropTypes.number
+    }),
+    /**
      * Item click handler
      */
     onItemClick: PropTypes.func,
@@ -98,6 +105,9 @@ class CatalogGrid extends Component {
   static defaultProps = {
     badgeLabels: null,
     currencyCode: "USD",
+    initialSize: {
+      width: 325
+    },
     onItemClick() {},
     placeholderImageURL: "/resources/placeholder.gif",
     products: []
@@ -112,6 +122,7 @@ class CatalogGrid extends Component {
       badgeLabels,
       components: { CatalogGridItem },
       currencyCode,
+      initialSize,
       onItemClick,
       placeholderImageURL,
       products
@@ -128,7 +139,7 @@ class CatalogGrid extends Component {
     }
 
     return (
-      <ContainerQuery query={containerQueries}>
+      <ContainerQuery query={containerQueries} initialSize={initialSize}>
         {(params) => (
           <GridContainer>
             {products.map((product, index) => (


### PR DESCRIPTION
Resolves #282 
Impact: **minor**  
Type: **feature**

## Component
Add `initialSize` prop to `CatalogGrid` to be passed down to the [container-query](https://github.com/d6u/react-container-query) component.

## Breaking changes
N/A

## Testing
1. Spin up Styleguide and navigate to the [CatalogGrid](https://stoic-hodgkin-c0179e.netlify.com/#!/CatalogGrid) page
3. Using React Devtools inspect the ContainerQuery component and verify the `initailSize` prop is set to `{ width: 325 }`
