### PR TITLE
fix: 283 nnnnat viewerinfo

### DIFF
--- a/package/src/components/ViewerInfo/v1/ViewerInfo.js
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.js
@@ -3,31 +3,30 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { applyTheme } from "../../../utils";
 
-const Container = styled.div`
+const ViewerInfoContainer = styled.div`
   position: relative;
   display: flex;
 `;
 
-const Circle = styled.div`
+const ViewerInitialsCircle = styled.div`
   background: ${applyTheme("color_teal")};
-  width: 30px;
-  height: 30px;
   border-radius: 50%;
-  display: inline-block;
+  height: ${applyTheme("viewerInfo_initials_size")};
+  text-align: center;
+  width: ${applyTheme("viewerInfo_initials_size")};
 `;
 
-const ViewerInitials = styled.div`
+const ViewerInitialsText = styled.div`
   font-family: ${applyTheme("font_family")};
   font-weight: ${applyTheme("font_weight_normal")};
   font-size: ${applyTheme("font_size_small")};
   color: ${applyTheme("color_white")};
-  position: absolute;
-  top: 6px;
-  left: 9px;
-  z-index: 10;
+  line-height: 1;
+  position: relative;
+  top: calc(${applyTheme("viewerInfo_initials_size")} / 4);
 `;
 
-const FirstName = styled.span`
+const ViewerFirstNameText = styled.span`
   font-family: ${applyTheme("font_family")};
   font-size: ${applyTheme("font_size_small")};
   color: ${applyTheme("color_coolGrey500")};
@@ -44,6 +43,14 @@ const FirstName = styled.span`
 class ViewerInfo extends Component {
   static propTypes = {
     /**
+     * Enable this prop when you only want to display the initials/avatar on all screens
+     */
+    compact: PropTypes.bool,
+    /**
+     * Enable this prop when you want to display the initials and first name on all screens
+     */
+    full: PropTypes.bool,
+    /**
      * An object containing basic user information.
      */
     viewer: PropTypes.shape({
@@ -53,19 +60,35 @@ class ViewerInfo extends Component {
   };
 
   static defaultProps = {
-    viewer: {}
+    compact: false,
+    full: false,
+    viewer: {
+      firstName: "He-Who-Must-Not-Be-Named"
+    }
   };
 
-  render() {
+  /**
+   *
+   * @name viewerInitials
+   * @summary Build the initials string from the `viewer` first and last name
+   * @return {String} the viewers initials. (Patricia Smith => PS, Olamide => O)
+   */
+  get viewerInitials() {
     const { viewer: { firstName, lastName } } = this.props;
-    const initials = firstName && lastName ? `${firstName.charAt()}${lastName.charAt()}` : "";
+    const lastInitial = (lastName && lastName.charAt()) || "";
+    return `${firstName.charAt()}${lastInitial}`;
+  }
+
+  render() {
+    const { viewer: { firstName } } = this.props;
 
     return (
-      <Container>
-        <Circle />
-        <ViewerInitials>{initials}</ViewerInitials>
-        <FirstName>{firstName && firstName}</FirstName>
-      </Container>
+      <ViewerInfoContainer>
+        <ViewerInitialsCircle>
+          <ViewerInitialsText>{this.viewerInitials}</ViewerInitialsText>
+        </ViewerInitialsCircle>
+        <ViewerFirstNameText>{firstName && firstName}</ViewerFirstNameText>
+      </ViewerInfoContainer>
     );
   }
 }

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.js
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.js
@@ -44,19 +44,22 @@ class ViewerInfo extends Component {
     viewer: PropTypes.shape({
       firstName: PropTypes.string,
       lastName: PropTypes.string
-    }).isRequired
+    })
+  };
+
+  static defaultProps = {
+    viewer: {}
   };
 
   render() {
     const { viewer: { firstName, lastName } } = this.props;
+    const initials = firstName && lastName ? `${firstName.charAt()}${lastName.charAt()}` : "";
 
     return (
       <Container>
         <Circle />
-        <ViewerInitials>
-          {`${firstName.charAt()}${lastName.charAt()}`}
-        </ViewerInitials>
-        <FirstName>{firstName}</FirstName>
+        <ViewerInitials>{initials}</ViewerInitials>
+        <FirstName>{firstName && firstName}</FirstName>
       </Container>
     );
   }

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.js
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.js
@@ -30,13 +30,18 @@ const ViewerFirstNameText = styled.span`
   font-family: ${applyTheme("font_family")};
   font-size: ${applyTheme("font_size_small")};
   color: ${applyTheme("color_coolGrey500")};
-  display: none;
+  display: ${({ compact, full }) => {
+    if (full) {
+      return compact ? "none" : "inline";
+    }
+    return "none";
+  }};
   align-self: center;
   margin-left: 0.5rem;
   letter-spacing: 0.2px;
 
-  @media (min-width: 768px) {
-    display: inline;
+  @media (${applyTheme("bp_md")}) {
+    display: ${({ compact }) => (compact ? "none" : "inline")};
   }
 `;
 
@@ -80,14 +85,16 @@ class ViewerInfo extends Component {
   }
 
   render() {
-    const { viewer: { firstName } } = this.props;
+    const { compact, full, viewer: { firstName } } = this.props;
 
     return (
       <ViewerInfoContainer>
         <ViewerInitialsCircle>
           <ViewerInitialsText>{this.viewerInitials}</ViewerInitialsText>
         </ViewerInitialsCircle>
-        <ViewerFirstNameText>{firstName && firstName}</ViewerFirstNameText>
+        <ViewerFirstNameText compact={compact} full={full}>
+          {firstName && firstName}
+        </ViewerFirstNameText>
       </ViewerInfoContainer>
     );
   }

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.js
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.js
@@ -31,9 +31,14 @@ const FirstName = styled.span`
   font-family: ${applyTheme("font_family")};
   font-size: ${applyTheme("font_size_small")};
   color: ${applyTheme("color_coolGrey500")};
+  display: none;
   align-self: center;
   margin-left: 0.5rem;
   letter-spacing: 0.2px;
+
+  @media (min-width: 768px) {
+    display: inline;
+  }
 `;
 
 class ViewerInfo extends Component {

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.md
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.md
@@ -2,7 +2,11 @@
 Renders a user's first name next to their initials.
 
 #### Usage
+```jsx
+<ViewerInfo />
+```
 
+#### With Viewer
 ```jsx
 const viewer = {
   firstName: "Issac",
@@ -10,4 +14,53 @@ const viewer = {
 };
 
 <ViewerInfo viewer={viewer} />
+```
+
+**Long Name**
+```jsx
+const viewer = {
+  firstName: "Madhavaditya",
+  lastName: "Balakrishnan"
+};
+
+<ViewerInfo viewer={viewer} />
+```
+
+**Hypenated Name**
+```jsx
+const viewer = {
+  firstName: "Keeanga-Yamahtta",
+  lastName: "Taylor"
+};
+
+<ViewerInfo viewer={viewer} />
+```
+
+**Incomplete Name**
+```jsx
+const viewer = {
+  firstName: "Olamide"
+};
+
+<ViewerInfo viewer={viewer} />
+```
+
+#### Full
+```jsx
+const viewer = {
+  firstName: "Ligaya",
+  lastName: "Ocampo"
+};
+
+<ViewerInfo viewer={viewer} full />
+```
+
+#### Compact
+```jsx
+const viewer = {
+  firstName: "Patricia",
+  lastName: "Smith"
+};
+
+<ViewerInfo viewer={viewer} compact />
 ```

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.md
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.md
@@ -6,7 +6,7 @@ Renders a user's first name next to their initials.
 <ViewerInfo />
 ```
 
-#### With Viewer
+#### With Viewer Data
 ```jsx
 const viewer = {
   firstName: "Issac",
@@ -45,17 +45,10 @@ const viewer = {
 <ViewerInfo viewer={viewer} />
 ```
 
-#### Full
-```jsx
-const viewer = {
-  firstName: "Ligaya",
-  lastName: "Ocampo"
-};
+#### Display Style
+The `ViewerInfo` component's default style is to show only the viewers initials on small screen and show both the initials and first name on larger screens. You may however run into situations where you want the initials and first name or only initials to display on all screen sizes. `ViewerInfo` has a `compact` and a `full` prop to achieve either display style, keep in mind that `compact` will override `full` so they can't be used together.
 
-<ViewerInfo viewer={viewer} full />
-```
-
-#### Compact
+**Compact**
 ```jsx
 const viewer = {
   firstName: "Patricia",
@@ -63,4 +56,14 @@ const viewer = {
 };
 
 <ViewerInfo viewer={viewer} compact />
+```
+
+**Full**
+```jsx
+const viewer = {
+  firstName: "Ligaya",
+  lastName: "Ocampo"
+};
+
+<ViewerInfo viewer={viewer} full />
 ```

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.test.js
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.test.js
@@ -2,6 +2,13 @@ import React from "react";
 import renderer from "react-test-renderer";
 import ViewerInfo from "./ViewerInfo";
 
+test("Render a viewerinfo without any props", () => {
+  const component = renderer.create(<ViewerInfo />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test("Render a viewer's initials and first name", () => {
   const viewer = {
     firstName: "Issac",

--- a/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
+++ b/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
@@ -60,3 +60,62 @@ exports[`Render a viewer's initials and first name 1`] = `
   </span>
 </div>
 `;
+
+exports[`Render a viewerinfo without any props 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  background: #8ce0c9;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.c2 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  color: #ffffff;
+  position: absolute;
+  top: 6px;
+  left: 9px;
+  z-index: 10;
+}
+
+.c3 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #3c3c3c;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: 0.5rem;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  />
+  <div
+    className="c2"
+  >
+    
+  </div>
+  <span
+    className="c3"
+  />
+</div>
+`;

--- a/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
+++ b/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
@@ -11,10 +11,10 @@ exports[`Render a viewer's initials and first name 1`] = `
 
 .c1 {
   background: #8ce0c9;
-  width: 30px;
-  height: 30px;
   border-radius: 50%;
-  display: inline-block;
+  height: 30px;
+  text-align: center;
+  width: 30px;
 }
 
 .c2 {
@@ -22,10 +22,9 @@ exports[`Render a viewer's initials and first name 1`] = `
   font-weight: 400;
   font-size: 14px;
   color: #ffffff;
-  position: absolute;
-  top: 6px;
-  left: 9px;
-  z-index: 10;
+  line-height: 1;
+  position: relative;
+  top: calc(30px / 4);
 }
 
 .c3 {
@@ -43,7 +42,7 @@ exports[`Render a viewer's initials and first name 1`] = `
   letter-spacing: 0.2px;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .c3 {
     display: inline;
   }
@@ -54,11 +53,12 @@ exports[`Render a viewer's initials and first name 1`] = `
 >
   <div
     className="c1"
-  />
-  <div
-    className="c2"
   >
-    IN
+    <div
+      className="c2"
+    >
+      IN
+    </div>
   </div>
   <span
     className="c3"
@@ -79,10 +79,10 @@ exports[`Render a viewerinfo without any props 1`] = `
 
 .c1 {
   background: #8ce0c9;
-  width: 30px;
-  height: 30px;
   border-radius: 50%;
-  display: inline-block;
+  height: 30px;
+  text-align: center;
+  width: 30px;
 }
 
 .c2 {
@@ -90,10 +90,9 @@ exports[`Render a viewerinfo without any props 1`] = `
   font-weight: 400;
   font-size: 14px;
   color: #ffffff;
-  position: absolute;
-  top: 6px;
-  left: 9px;
-  z-index: 10;
+  line-height: 1;
+  position: relative;
+  top: calc(30px / 4);
 }
 
 .c3 {
@@ -111,7 +110,7 @@ exports[`Render a viewerinfo without any props 1`] = `
   letter-spacing: 0.2px;
 }
 
-@media (min-width:768px) {
+@media (min-width:960px) {
   .c3 {
     display: inline;
   }
@@ -122,14 +121,17 @@ exports[`Render a viewerinfo without any props 1`] = `
 >
   <div
     className="c1"
-  />
-  <div
-    className="c2"
   >
-    
+    <div
+      className="c2"
+    >
+      H
+    </div>
   </div>
   <span
     className="c3"
-  />
+  >
+    He-Who-Must-Not-Be-Named
+  </span>
 </div>
 `;

--- a/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
+++ b/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
@@ -32,6 +32,7 @@ exports[`Render a viewer's initials and first name 1`] = `
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   color: #3c3c3c;
+  display: none;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -40,6 +41,12 @@ exports[`Render a viewer's initials and first name 1`] = `
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
   letter-spacing: 0.2px;
+}
+
+@media (min-width:768px) {
+  .c3 {
+    display: inline;
+  }
 }
 
 <div
@@ -93,6 +100,7 @@ exports[`Render a viewerinfo without any props 1`] = `
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   color: #3c3c3c;
+  display: none;
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -101,6 +109,12 @@ exports[`Render a viewerinfo without any props 1`] = `
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
   letter-spacing: 0.2px;
+}
+
+@media (min-width:768px) {
+  .c3 {
+    display: inline;
+  }
 }
 
 <div

--- a/package/src/defaultComponentTheme.js
+++ b/package/src/defaultComponentTheme.js
@@ -457,6 +457,11 @@ const selectableList = {
   rui_selectableListIconHeight: "24px"
 };
 
+// viewerinfo
+const viewerInfo = {
+  rui_viewerInfo_initials_size: "30px"
+};
+
 export default {
   ...defaultStyles,
   ...buttonStyles,
@@ -471,5 +476,6 @@ export default {
   ...checkoutActions,
   ...checkbox,
   ...selectableItem,
-  ...selectableList
+  ...selectableList,
+  ...viewerInfo
 };


### PR DESCRIPTION
Resolves #283 
Impact: **minor**  
Type: **bugfix|refactor**

## Component
* Guard against null/undef `viewer` props.
* Updated to only show the initial on mobile devices.
* Updated test

## Screenshots
![screen shot 2018-09-19 at 10 05 23 am](https://user-images.githubusercontent.com/1135948/45762249-94a3a600-bbf3-11e8-89fa-3bd5b009c508.png)

## Breaking changes
N/A

## Testing
1. Load the compo-lib and navigate to the ViewerInfo page.
2. size the browser down or use responsive design view to see the component render only the initial for the small screen size.
3. Remove the `viewer` prop from the component example and see the page no-longer throws an error.
