### PR TITLE
fix(287): update font color in cart summary, minicart summary

### DIFF
--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -25,7 +25,7 @@ const Thr = styled.th`
 const Td = styled.td`
   font-family: ${applyTheme("font_family")};
   padding: ${(props) => (props.isDense ? "0.5rem 0" : "1rem 0")};
-  color: ${applyTheme("color_coolGrey400")};
+  color: ${applyTheme("color_coolGrey500")};
   border-top: ${(props) => (props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial")};
   border-bottom: ${(props) => (props.isBordered ? `1px solid ${applyTheme("color_black10")(props)}` : "initial")};
 `;

--- a/package/src/components/CartSummary/v1/__snapshots__/CartSummary.test.js.snap
+++ b/package/src/components/CartSummary/v1/__snapshots__/CartSummary.test.js.snap
@@ -23,7 +23,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
 }
@@ -31,7 +31,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
 .c6 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
 }
@@ -39,7 +39,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
 .c5 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -50,7 +50,7 @@ exports[`Displays a summary of the current items in the cart 1`] = `
 .c7 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -171,7 +171,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
 }
@@ -179,7 +179,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
 .c6 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
 }
@@ -187,7 +187,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
 .c5 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -198,7 +198,7 @@ exports[`Displays a summary with FREE shipping 1`] = `
 .c7 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -319,7 +319,7 @@ exports[`Displays a summary with applied discount 1`] = `
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
 }
@@ -327,7 +327,7 @@ exports[`Displays a summary with applied discount 1`] = `
 .c7 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
 }
@@ -335,7 +335,7 @@ exports[`Displays a summary with applied discount 1`] = `
 .c5 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -346,7 +346,7 @@ exports[`Displays a summary with applied discount 1`] = `
 .c8 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -489,7 +489,7 @@ exports[`Displays a summary with calculated taxes 1`] = `
 .c4 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
 }
@@ -497,7 +497,7 @@ exports[`Displays a summary with calculated taxes 1`] = `
 .c6 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
 }
@@ -505,7 +505,7 @@ exports[`Displays a summary with calculated taxes 1`] = `
 .c5 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: initial;
   border-bottom: initial;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -516,7 +516,7 @@ exports[`Displays a summary with calculated taxes 1`] = `
 .c7 {
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   padding: 1rem 0;
-  color: #3c5d6f;
+  color: #3c3c3c;
   border-top: 1px solid #e6e6e6;
   border-bottom: 1px solid #e6e6e6;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;

--- a/package/src/components/MiniCartSummary/v1/MiniCartSummary.js
+++ b/package/src/components/MiniCartSummary/v1/MiniCartSummary.js
@@ -11,7 +11,7 @@ const Table = styled.table`
 
 const Td = styled.td`
   padding: 0.5rem 0.3rem 0.5rem 0.5rem;
-  color: ${applyTheme("color_coolGrey400")};
+  color: ${applyTheme("color_coolGrey500")};
   text-align: right;
 `;
 

--- a/package/src/components/MiniCartSummary/v1/__snapshots__/MiniCartSummary.test.js.snap
+++ b/package/src/components/MiniCartSummary/v1/__snapshots__/MiniCartSummary.test.js.snap
@@ -9,7 +9,7 @@ exports[`Renders only subtotal + computed taxes 1`] = `
 
 .c1 {
   padding: 0.5rem 0.3rem 0.5rem 0.5rem;
-  color: #3c5d6f;
+  color: #3c3c3c;
   text-align: right;
 }
 
@@ -61,7 +61,7 @@ exports[`Renders only subtotal 1`] = `
 
 .c1 {
   padding: 0.5rem 0.3rem 0.5rem 0.5rem;
-  color: #3c5d6f;
+  color: #3c3c3c;
   text-align: right;
 }
 


### PR DESCRIPTION
Resolves #287 
Impact: **minor**  
Type: **bugfix|style**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Components (2)
- MiniCartSummary: Update font color of left-hand side labels
- CartSummary: Update font color of left-hand side labels

## Testing
1. https://deploy-preview-290--stoic-hodgkin-c0179e.netlify.com/#!/MiniCartSummary
2. https://deploy-preview-290--stoic-hodgkin-c0179e.netlify.com/#!/CartSummary
