### PR TITLE
refactor: nnnnat viewerinfo

### DIFF
--- a/package/src/components/ViewerInfo/v1/ViewerInfo.js
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.js
@@ -60,40 +60,51 @@ class ViewerInfo extends Component {
      */
     viewer: PropTypes.shape({
       firstName: PropTypes.string,
-      lastName: PropTypes.string
-    })
+      lastName: PropTypes.string,
+      primaryEmailAddress: PropTypes.string.isRequired
+    }).isRequired
   };
 
   static defaultProps = {
     compact: false,
-    full: false,
-    viewer: {
-      firstName: "He-Who-Must-Not-Be-Named"
-    }
+    full: false
   };
 
   /**
    *
    * @name viewerInitials
    * @summary Build the initials string from the `viewer` first and last name
-   * @return {String} the viewers initials. (Patricia Smith => PS, Olamide => O)
+   * If those props are not availible use the first letter of the primary email address.
+   * @return {String} the viewers initials. (Patricia Smith => PS, Olamide => O, james.booker@ponderosafarms.com => J)
    */
   get viewerInitials() {
-    const { viewer: { firstName, lastName } } = this.props;
+    const { viewer: { firstName, lastName, primaryEmailAddress } } = this.props;
+    const firstInitial = (firstName && firstName.charAt()) || primaryEmailAddress.charAt().toUpperCase();
     const lastInitial = (lastName && lastName.charAt()) || "";
-    return `${firstName.charAt()}${lastInitial}`;
+    return `${firstInitial}${lastInitial}`;
+  }
+
+  /**
+   *
+   * @name viewerName
+   * @summary If `firstName` is availible on the `viewer` object
+   * return that else return the email address
+   * @return {String} the viewers name.
+   */
+  get viewerName() {
+    const { viewer: { firstName, primaryEmailAddress } } = this.props;
+    return (firstName && firstName) || primaryEmailAddress;
   }
 
   render() {
-    const { compact, full, viewer: { firstName } } = this.props;
-
+    const { compact, full } = this.props;
     return (
       <ViewerInfoContainer>
         <ViewerInitialsCircle>
           <ViewerInitialsText>{this.viewerInitials}</ViewerInitialsText>
         </ViewerInitialsCircle>
         <ViewerFirstNameText compact={compact} full={full}>
-          {firstName && firstName}
+          {this.viewerName}
         </ViewerFirstNameText>
       </ViewerInfoContainer>
     );

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.md
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.md
@@ -3,14 +3,19 @@ Renders a user's first name next to their initials.
 
 #### Usage
 ```jsx
-<ViewerInfo />
-```
-
-#### With Viewer Data
-```jsx
 const viewer = {
+  primaryEmailAddress: "issac99@gravity.com",
   firstName: "Issac",
   lastName: "Newton"
+};
+
+<ViewerInfo viewer={viewer} />
+```
+
+**Email Address Only**
+```jsx
+const viewer = {
+  primaryEmailAddress: "james.booker@ponderosafarms.com"
 };
 
 <ViewerInfo viewer={viewer} />
@@ -19,6 +24,7 @@ const viewer = {
 **Long Name**
 ```jsx
 const viewer = {
+  primaryEmailAddress: "email@domain.in",
   firstName: "Madhavaditya",
   lastName: "Balakrishnan"
 };
@@ -29,6 +35,7 @@ const viewer = {
 **Hypenated Name**
 ```jsx
 const viewer = {
+  primaryEmailAddress: "aas21@princeton.edu",
   firstName: "Keeanga-Yamahtta",
   lastName: "Taylor"
 };
@@ -39,6 +46,7 @@ const viewer = {
 **Incomplete Name**
 ```jsx
 const viewer = {
+  primaryEmailAddress: "baddosneh@ybnl-nation.com",
   firstName: "Olamide"
 };
 

--- a/package/src/components/ViewerInfo/v1/ViewerInfo.test.js
+++ b/package/src/components/ViewerInfo/v1/ViewerInfo.test.js
@@ -2,21 +2,50 @@ import React from "react";
 import renderer from "react-test-renderer";
 import ViewerInfo from "./ViewerInfo";
 
-test("Render a viewerinfo without any props", () => {
-  const component = renderer.create(<ViewerInfo />);
-
+test("Render with only required props", () => {
+  const mockViewer = {
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-test("Render a viewer's initials and first name", () => {
-  const viewer = {
+test("Render with only email & first name props", () => {
+  const mockViewer = {
     firstName: "Issac",
-    lastName: "Newton"
+    primaryEmailAddress: "email@domain.com"
   };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
 
-  const component = renderer.create(<ViewerInfo viewer={viewer} />);
+test("Render with full name and email props", () => {
+  const mockViewer = {
+    firstName: "Issac",
+    lastName: "Newton",
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
 
+test("Render with full prop", () => {
+  const mockViewer = {
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} full />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Render with compact prop", () => {
+  const mockViewer = {
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} compact />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
+++ b/package/src/components/ViewerInfo/v1/__snapshots__/ViewerInfo.test.js.snap
@@ -1,6 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render a viewer's initials and first name 1`] = `
+exports[`Render with compact prop 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  background: #8ce0c9;
+  border-radius: 50%;
+  height: 30px;
+  text-align: center;
+  width: 30px;
+}
+
+.c2 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  color: #ffffff;
+  line-height: 1;
+  position: relative;
+  top: calc(30px / 4);
+}
+
+.c3 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #3c3c3c;
+  display: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: 0.5rem;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+}
+
+@media (min-width:960px) {
+  .c3 {
+    display: none;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      E
+    </div>
+  </div>
+  <span
+    className="c3"
+  >
+    email@domain.com
+  </span>
+</div>
+`;
+
+exports[`Render with full name and email props 1`] = `
 .c0 {
   position: relative;
   display: -webkit-box;
@@ -68,7 +136,75 @@ exports[`Render a viewer's initials and first name 1`] = `
 </div>
 `;
 
-exports[`Render a viewerinfo without any props 1`] = `
+exports[`Render with full prop 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  background: #8ce0c9;
+  border-radius: 50%;
+  height: 30px;
+  text-align: center;
+  width: 30px;
+}
+
+.c2 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  color: #ffffff;
+  line-height: 1;
+  position: relative;
+  top: calc(30px / 4);
+}
+
+.c3 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #3c3c3c;
+  display: inline;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: 0.5rem;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+}
+
+@media (min-width:960px) {
+  .c3 {
+    display: inline;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      E
+    </div>
+  </div>
+  <span
+    className="c3"
+  >
+    email@domain.com
+  </span>
+</div>
+`;
+
+exports[`Render with only email & first name props 1`] = `
 .c0 {
   position: relative;
   display: -webkit-box;
@@ -125,13 +261,81 @@ exports[`Render a viewerinfo without any props 1`] = `
     <div
       className="c2"
     >
-      H
+      I
     </div>
   </div>
   <span
     className="c3"
   >
-    He-Who-Must-Not-Be-Named
+    Issac
+  </span>
+</div>
+`;
+
+exports[`Render with only required props 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  background: #8ce0c9;
+  border-radius: 50%;
+  height: 30px;
+  text-align: center;
+  width: 30px;
+}
+
+.c2 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  color: #ffffff;
+  line-height: 1;
+  position: relative;
+  top: calc(30px / 4);
+}
+
+.c3 {
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  color: #3c3c3c;
+  display: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-left: 0.5rem;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+}
+
+@media (min-width:960px) {
+  .c3 {
+    display: inline;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      E
+    </div>
+  </div>
+  <span
+    className="c3"
+  >
+    email@domain.com
   </span>
 </div>
 `;


### PR DESCRIPTION
Resolves #291
Impact: **minor**  
Type: **refactor**

## Component
`ViewerInfo` component would throw an error if it received a `viewer` object that was missing a `firstName` prop. 

`ViewerInfo` now expects `primaryEmailAddress` to always be available on the `viewer` object and will use the viewer's email address in place of `firstName`.

## Screenshots
![screen shot 2018-09-20 at 1 24 51 pm](https://user-images.githubusercontent.com/1135948/45838959-9abf8280-bcd8-11e8-842e-96e845dbd9fc.png)

## Breaking changes
N/A

## Testing
1. Verify `ViewerInfo` will not throw an error if missing the `firstName` prop.
