### PR TITLE
fix: update catalog item's image fit on component update

### DIFF
--- a/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
+++ b/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
@@ -141,6 +141,9 @@ class CatalogGridItem extends Component {
         if (height > width) {
           // Image is portrait
           this.setState({ fit: "contain" });
+        } else {
+          // Image is landscape
+          this.setState({ fit: "cover" });
         }
       };
     }

--- a/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
+++ b/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
@@ -113,12 +113,30 @@ class CatalogGridItem extends Component {
   };
 
   componentDidMount() {
+    this._mounted = true;
+
+    this.setImageFit();
+  }
+
+  componentDidUpdate() {
+    this.setImageFit();
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
+  }
+
+  setImageFit = () => {
     // Use cover fit if image is landcape, contain if portrait
     if (typeof Image !== "undefined") {
       const { large } = this.primaryImage.URLs;
       const largeImage = new Image();
       largeImage.src = large;
       largeImage.onload = () => {
+        if (this._mounted === false) {
+          return;
+        }
+
         const { width, height } = largeImage;
         if (height > width) {
           // Image is portrait
@@ -126,7 +144,7 @@ class CatalogGridItem extends Component {
         }
       };
     }
-  }
+  };
 
   get productDetailHref() {
     const { product: { slug } } = this.props;


### PR DESCRIPTION
Resolves #324 from Starterkit: https://github.com/reactioncommerce/reaction-next-starterkit/issues/324
Impact: **minor**  
Type: **bugfix**

## Component
When a `CatalogGridItem` is updated with a new product, if the previous product's images were landscape, and the new images were portrait (or vice-versa), the `fit` prop on `ProgressiveImage` wasn't being updated. This caused portrait images to have the original bug where white bars appeared to the left & right of the image.

This PR fixes that by updating the image fit via `componentDidUpdate`. I was only able to confirm it in the component lib markdown example by temporarily moving `this.props.product` to `this.state.product` and using a `setTimeout` to change the product after 10s. Unfortunately the only way to fully confirm the fix is to merge this PR and update starterkit's component lib version.