### PR TITLE
fix(select): add background color for Selected and Focused options

### DIFF
--- a/package/src/components/Select/v1/Select.js
+++ b/package/src/components/Select/v1/Select.js
@@ -78,7 +78,8 @@ const getSelectMenuBorderRadius = applyTheme("selectMenuBorderRadius");
 const getSelectBorderColor = applyTheme("selectBorderColor");
 const getInputFontSize = applyTheme("inputFontSize");
 const getSelectHoverColor = applyTheme("selectHoverColor");
-const getSelecFocusBorderColor = applyTheme("selectFocusBorderColor");
+const getSelectedBackgroundColor = applyTheme("selectedBackgroundColor");
+const getSelectFocusBorderColor = applyTheme("selectFocusBorderColor");
 const getSelectIndicatorColor = applyTheme("selectIndicatorColor");
 const getSelectMenuBorder = applyTheme("selectMenuBorder");
 const getSelectLetterSpacing = applyTheme("selectLetterSpacing");
@@ -106,7 +107,7 @@ function getCustomStyles(props) {
         "boxShadow": "none",
         "cursor": "pointer",
         "&:hover": {
-          borderColor: state.isFocused ? getSelecFocusBorderColor() : getSelectBorderColor()
+          borderColor: state.isFocused ? getSelectFocusBorderColor() : getSelectBorderColor()
         }
       };
     },
@@ -131,7 +132,7 @@ function getCustomStyles(props) {
         ":hover": {
           backgroundColor: getSelectHoverColor()
         },
-        "backgroundColor": (state.isSelected ? getSelectHoverColor() : "#FFFFFF")
+        "backgroundColor": (state.isSelected ? getSelectedBackgroundColor() : state.isFocused ? getSelectHoverColor() : "#FFFFFF") // eslint-disable-line no-nested-ternary
       };
     },
     dropdownIndicator(base, state) {

--- a/package/src/components/Select/v1/Select.md
+++ b/package/src/components/Select/v1/Select.md
@@ -13,8 +13,10 @@ The simple select can be used in cases where there are fewer than 10 options.
 ```jsx
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
+  { value: 'darkchocolate', label: 'Dark Chocolate' },
+  { value: 'mintchip', label: 'Mint Chip' },
   { value: 'strawberry', label: 'Strawberry' },
-  { value: 'vanilla', label: 'Vanilla' }
+  { value: 'vanilla', label: 'Vanilla' },
 ];
 
 <Select options={options} />

--- a/package/src/defaultComponentTheme.js
+++ b/package/src/defaultComponentTheme.js
@@ -352,6 +352,7 @@ const textareaStyles = {
 
 const selectStyles = {
   rui_selectHoverColor: reactionBlue100,
+  rui_selectedBackgroundColor: reactionBlue200,
   rui_selectFocusBorderColor: teal,
   rui_selectBorderRadius: baseUnit(0.2),
   rui_selectMenuBorderRadius: `0 ${baseUnit(0.2)}`,


### PR DESCRIPTION
Resolves #286 
Impact: **minor**  
Type: **bugfix|style**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component: Select

The issue & solution -- It appeared as though when using <kbd>^</kbd> or <kbd>V</kbd> to navigate through Select options, nothing was happening. But actually, the option was being selected/focused, but the user couldn't tell because the option wasn't changing colors. The solution is to add a background color to the option that changes by the option's state: selected or hovered/focused.

- Fix: Adds `getSelectedBackgroundColor()` of `#d6e5ed` - Once a user selects an option, and then opens the Select again, the selected option will have a darker background color.
- Fix: Adds `getSelectHoverColor()` of `#ecf8fe` to any option that is focused with the keyboard <kbd>^</kbd> or <kbd>V</kbd>, in addition to options that are hovered with the mouse.

- Fix: Fixes spelling of `getSelecFocusBorderColor` to `getSelectFocusBorderColor`
- Docs: Adds some more dropdown option examples to the list

## Screenshots

- When a user has previously selected `Vanilla` and is hovering or up/down keying over `Strawberry`

<img width="670" alt="screen shot 2018-09-21 at 10 56 58 am" src="https://user-images.githubusercontent.com/3673236/45898473-ea608580-bd8e-11e8-9ada-99083e42ea8d.png">

- When a user has previously selected `Strawberry`, and is hovering or up/down keying over `Dark Chocolate`

<img width="690" alt="screen shot 2018-09-21 at 10 59 02 am" src="https://user-images.githubusercontent.com/3673236/45898474-ea608580-bd8e-11e8-8973-bc5328fe65e9.png">

## Breaking changes
None

## Testing
1. Test the select with keyboard https://deploy-preview-301--stoic-hodgkin-c0179e.netlify.com/#!/Select
2. Test the select with mouse https://deploy-preview-301--stoic-hodgkin-c0179e.netlify.com/#!/Select
