### PR TITLE
fix: prevent infinite loop when setting image size in CatalogGridItem

### DIFF
--- a/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
+++ b/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
@@ -137,13 +137,18 @@ class CatalogGridItem extends Component {
           return;
         }
 
+        let fit = "";
         const { width, height } = largeImage;
         if (height > width) {
           // Image is portrait
-          this.setState({ fit: "contain" });
+          fit = "contain";
         } else {
           // Image is landscape
-          this.setState({ fit: "cover" });
+          fit = "cover";
+        }
+
+        if (fit !== this.state.fit) {
+          this.setState({ fit });
         }
       };
     }


### PR DESCRIPTION
Resolves #302 
Impact: **major**  
Type: **bugfix**

## Bug
I introduced an infinite loop into `CatalogGridItem`. When the component is updated with a new product, the goal was to have the image `fit` prop for the child `ProgressiveImage` component to be determined automatically, based on whether the image is landscape or portrait. By not checking whether the new calculated fit differed from the previous, `this.setState` and thus `componentDidUpdate` were being called infinitely.

## Solution
The solution was to check whether the new calculated fit differed from the previous.

## Testing
1. Add a `console.log` to `componentDidUpdate` inside CatalogGridItem.js
2. Visit the Catalog Grid page in the component lib docs
3. Confirm `console.log` only prints once per product on the screen.
