### PR TITLE
fix: 322 nnnnat abc select

### DIFF
--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -313,6 +313,7 @@ class AddressForm extends Component {
               {this.countryOptions && this.countryOptions.length > 1 ? (
                 <Select
                   id={countryInputId}
+                  alphabetize
                   isSearchable
                   name="country"
                   onChange={this.handleCountryChange}
@@ -370,6 +371,7 @@ class AddressForm extends Component {
               {this.regionOptions && this.regionOptions.length > 1 ? (
                 <Select
                   id={regionInputId}
+                  alphabetize
                   isSearchable
                   name="region"
                   options={this.regionOptions}

--- a/package/src/components/Select/v1/Select.js
+++ b/package/src/components/Select/v1/Select.js
@@ -39,7 +39,6 @@ const supportedPassthroughProps = [
   "maxValueHeight",
   "menuIsOpen",
   "menuPlacement",
-  "name",
   "noOptionsMessage",
   "onBlur",
   "onFocus",
@@ -558,7 +557,6 @@ class Select extends Component {
     return (
       <ReactSelect
         {...passthroughProps}
-        autoCompplete="on"
         isDisabled={isReadOnly}
         value={optionValue}
         components={{ IndicatorSeparator: null }}

--- a/package/src/components/Select/v1/Select.js
+++ b/package/src/components/Select/v1/Select.js
@@ -39,6 +39,7 @@ const supportedPassthroughProps = [
   "maxValueHeight",
   "menuIsOpen",
   "menuPlacement",
+  "name",
   "noOptionsMessage",
   "onBlur",
   "onFocus",
@@ -132,14 +133,14 @@ function getCustomStyles(props) {
         ":hover": {
           backgroundColor: getSelectHoverColor()
         },
-        "backgroundColor": (state.isSelected ? getSelectedBackgroundColor() : state.isFocused ? getSelectHoverColor() : "#FFFFFF") // eslint-disable-line no-nested-ternary
+        "backgroundColor": state.isSelected ? getSelectedBackgroundColor() : state.isFocused ? getSelectHoverColor() : "#FFFFFF" // eslint-disable-line no-nested-ternary
       };
     },
     dropdownIndicator(base, state) {
       return {
         ...base,
         color: getSelectIndicatorColor(),
-        transform: (state.selectProps.menuIsOpen ? "rotateX(-180deg)" : "")
+        transform: state.selectProps.menuIsOpen ? "rotateX(-180deg)" : ""
       };
     },
     menuList(base) {
@@ -166,6 +167,10 @@ function getCustomStyles(props) {
 
 class Select extends Component {
   static propTypes = {
+    /**
+     * Alphabetize by option label
+     */
+    alphabetize: PropTypes.bool,
     /**
      * Passed through to react-select package. Focus the control when it is mounted
      */
@@ -402,10 +407,11 @@ class Select extends Component {
   };
 
   static defaultProps = {
+    alphabetize: false,
     isReadOnly: false,
     isSearchable: false,
-    onChange() { },
-    onChanging() { },
+    onChange() {},
+    onChanging() {},
     options: []
   };
 
@@ -500,14 +506,17 @@ class Select extends Component {
           this.dataType = checkDataType;
         } else if (checkDataType !== this.dataType) {
           // eslint-disable-next-line
-          throw new Error(`All option values must have the same data type. The data type of the first option is "${this.dataType}" while the data type of the ${option.label} option is "${checkDataType}"`);
+          throw new Error(
+            `All option values must have the same data type. The data type of the first option is "${
+              this.dataType
+            }" while the data type of the ${option.label} option is "${checkDataType}"`);
         }
       }
     });
   }
 
   render() {
-    const { isReadOnly, options } = this.props;
+    const { alphabetize, isReadOnly, options } = this.props;
     const { value } = this.state;
 
     // Unfortunately right now, react-select optgroup support is just a tad different from the
@@ -521,6 +530,17 @@ class Select extends Component {
       }
       return opt;
     });
+
+    if (alphabetize) {
+      reactSelectOptions.sort((thisOpt, nextOpt) => {
+        if (thisOpt.label > nextOpt.label) {
+          return 1;
+        } else if (nextOpt.label > thisOpt.label) {
+          return -1;
+        }
+        return 0;
+      });
+    }
 
     const passthroughProps = {};
     supportedPassthroughProps.forEach((prop) => {
@@ -538,6 +558,7 @@ class Select extends Component {
     return (
       <ReactSelect
         {...passthroughProps}
+        autoCompplete="on"
         isDisabled={isReadOnly}
         value={optionValue}
         components={{ IndicatorSeparator: null }}

--- a/package/src/components/Select/v1/Select.js
+++ b/package/src/components/Select/v1/Select.js
@@ -132,7 +132,10 @@ function getCustomStyles(props) {
         ":hover": {
           backgroundColor: getSelectHoverColor()
         },
-        "backgroundColor": state.isSelected ? getSelectedBackgroundColor() : state.isFocused ? getSelectHoverColor() : "#FFFFFF" // eslint-disable-line no-nested-ternary
+        // eslint-disable-next-line no-nested-ternary
+        "backgroundColor": state.isSelected
+          ? getSelectedBackgroundColor()
+          : state.isFocused ? getSelectHoverColor() : "#FFFFFF"
       };
     },
     dropdownIndicator(base, state) {
@@ -514,6 +517,17 @@ class Select extends Component {
     });
   }
 
+  sortOptions = (thisOpt, nextOpt) => {
+    if (thisOpt.options) thisOpt.options.sort(this.sortOptions);
+    if (nextOpt.options) nextOpt.options.sort(this.sortOptions);
+    if (thisOpt.label > nextOpt.label) {
+      return 1;
+    } else if (nextOpt.label > thisOpt.label) {
+      return -1;
+    }
+    return 0;
+  };
+
   render() {
     const { alphabetize, isReadOnly, options } = this.props;
     const { value } = this.state;
@@ -531,14 +545,7 @@ class Select extends Component {
     });
 
     if (alphabetize) {
-      reactSelectOptions.sort((thisOpt, nextOpt) => {
-        if (thisOpt.label > nextOpt.label) {
-          return 1;
-        } else if (nextOpt.label > thisOpt.label) {
-          return -1;
-        }
-        return 0;
-      });
+      reactSelectOptions.sort(this.sortOptions);
     }
 
     const passthroughProps = {};

--- a/package/src/components/Select/v1/Select.md
+++ b/package/src/components/Select/v1/Select.md
@@ -65,6 +65,62 @@ const options = [
 <Select options={options} alphabetize />
 ```
 
+##### Nested select optioins
+
+```jsx
+const options = [{
+    optgroup: 'Transportation',
+    options: [{
+        value: "car",
+        label: 'Car'
+      },
+      {
+        value: "bike",
+        label: "Bike"
+      },
+      {
+        value: "jetpack",
+        label: "Jetpack"
+      }
+    ]
+  },
+  {
+    optgroup: 'Plants',
+    options: [{
+        value: 'tree',
+        label: "Tree"
+      },
+      {
+        value: "cactus",
+        label: "Cactus"
+      },
+      {
+        value: "lily",
+        label: "Lily"
+      }
+    ]
+  },
+  {
+    optgroup: 'Athletes',
+    options: [{
+        value: 'lebron',
+        label: 'Lebron James'
+      },
+      {
+        value: "embiid",
+        label: "Joel Embiid"
+      },
+      {
+        value: "antetokounmpo",
+        label: "Giannis Antetokounmpo"
+      }
+    ]
+  }
+];
+
+<Select options={options} alphabetize />
+```
+
 #### States
 
 A select can be in one of three states: normal, invalid, or valid. Normal state is as shown previously

--- a/package/src/components/Select/v1/Select.md
+++ b/package/src/components/Select/v1/Select.md
@@ -48,6 +48,23 @@ const options = [
 <Select options={options} maxWidth={150} />
 ```
 
+##### Alphabetizing select options
+
+By default the `Select` will inherit the order of provided options. 
+To alphabetize by option label apply the `alphabetize` prop.
+
+```jsx
+const options = [
+  { value: 'mintchip', label: 'Mint Chip' },
+  { value: 'chocolate', label: 'Chocolate' },
+  { value: 'strawberry', label: 'Strawberry' },
+  { value: 'vanilla', label: 'Vanilla' },
+  { value: 'darkchocolate', label: 'Dark Chocolate' }
+];
+
+<Select options={options} alphabetize />
+```
+
 #### States
 
 A select can be in one of three states: normal, invalid, or valid. Normal state is as shown previously

--- a/package/src/components/Select/v1/Select.test.js
+++ b/package/src/components/Select/v1/Select.test.js
@@ -40,7 +40,19 @@ testInput({
 
 test("basic snapshot", () => {
   const component = renderer.create(<Select {...PROPS} options={OPTIONS} />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
 
+test("alphabetize option snapshot", () => {
+  const UNORDERED_OPTIONS = [
+    { label: "C", value: "c" },
+    { label: "A", value: "a" },
+    { label: "Z", value: "z" },
+    { label: "E", value: "e" }
+  ];
+
+  const component = renderer.create(<Select {...PROPS} alphabetize options={UNORDERED_OPTIONS} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/package/src/components/Select/v1/Select.test.js
+++ b/package/src/components/Select/v1/Select.test.js
@@ -51,7 +51,6 @@ test("alphabetize option snapshot", () => {
     { label: "Z", value: "z" },
     { label: "E", value: "e" }
   ];
-
   const component = renderer.create(<Select {...PROPS} alphabetize options={UNORDERED_OPTIONS} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/Select/v1/__snapshots__/Select.test.js.snap
+++ b/package/src/components/Select/v1/__snapshots__/Select.test.js.snap
@@ -1,5 +1,118 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`alphabetize option snapshot 1`] = `
+<div
+  className="css-15mpz6f"
+  id={undefined}
+  onKeyDown={[Function]}
+>
+  <div
+    className="css-168y8dr"
+    onMouseDown={[Function]}
+    onTouchEnd={[Function]}
+  >
+    <div
+      className="css-1rtrksz"
+    >
+      <div
+        className="css-tg64lk"
+      >
+        Select...
+      </div>
+      <input
+        className="css-14uuagi"
+        id="react-select-10-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={true}
+        tabIndex="0"
+        value=""
+      />
+    </div>
+    <div
+      className="css-1wy0on6"
+    >
+      <div
+        aria-hidden="true"
+        className="css-1lm7jx8"
+        onMouseDown={[Function]}
+        onTouchEnd={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="css-19bqh2r"
+          focusable="false"
+          height={20}
+          viewBox="0 0 20 20"
+          width={20}
+        >
+          <path
+            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      className="css-5ks0v5"
+      onMouseDown={[Function]}
+      onMouseMove={[Function]}
+    >
+      <div
+        className="css-1x0y3y4"
+      >
+        <div
+          className="css-1baujv3"
+          id="react-select-10-option-0"
+          onClick={[Function]}
+          onMouseMove={[Function]}
+          onMouseOver={[Function]}
+          role="option"
+          tabIndex={-1}
+        >
+          A
+        </div>
+        <div
+          className="css-1baujv3"
+          id="react-select-10-option-1"
+          onClick={[Function]}
+          onMouseMove={[Function]}
+          onMouseOver={[Function]}
+          role="option"
+          tabIndex={-1}
+        >
+          C
+        </div>
+        <div
+          className="css-1baujv3"
+          id="react-select-10-option-2"
+          onClick={[Function]}
+          onMouseMove={[Function]}
+          onMouseOver={[Function]}
+          role="option"
+          tabIndex={-1}
+        >
+          E
+        </div>
+        <div
+          className="css-1baujv3"
+          id="react-select-10-option-3"
+          onClick={[Function]}
+          onMouseMove={[Function]}
+          onMouseOver={[Function]}
+          role="option"
+          tabIndex={-1}
+        >
+          Z
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`basic snapshot 1`] = `
 <div
   className="css-15mpz6f"


### PR DESCRIPTION
Resolves [#322](https://github.com/reactioncommerce/reaction-next-starterkit/issues/322)
Impact: **minor**  
Type: **feature|bugfix**

## Component
The`AddressForm` component is using a locales dataset that is ordered by the country code, this causes the option's labels to not be alphabetized in the `Select`. 

## Solution
* Add `alphabetize` prop to the `Select` component that will sort the provided options by the label.
* Added the `alphabetize` prop to all `Select` components in `AddressForm`

## Breaking changes
N/A

## Testing
1. Visit the `Select` [page's](https://deploy-preview-305--stoic-hodgkin-c0179e.netlify.com/#!/Select) new "Alphabetizing select options` section and verify it's sorting the options correctly.
2. Visit the `AddressForm` [page](https://deploy-preview-305--stoic-hodgkin-c0179e.netlify.com/#!/AddressForm) and verify all `Select` components options are alphabetized correctly.
