### PR TITLE
fix: do not focus input after user clicks the clear button

### DIFF
--- a/package/src/components/TextInput/v1/TextInput.js
+++ b/package/src/components/TextInput/v1/TextInput.js
@@ -388,6 +388,7 @@ class TextInput extends Component {
 
   onClearValue = () => {
     this.setValue();
+    this.onButtonBlur();
   };
 
   getValue() {


### PR DESCRIPTION
Resolves #270 
Impact: minor
Type: bugfix

###
Remove input focus after user clicks on clear button, and when the user clicks away from the input.


## Testing
1. Enter text into TextInput component
2. Click away from component
3. Verify green focus ring is not present.
4. Click on the input
5. Click on the clear button
6. Verify green input ring is not present and that text was cleared.

