### PR TITLE
fix: ignore README.md file in /styleguide/src/components

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "fs-extra": "^5.0.0",
     "html-webpack-plugin": "2.29.0",
     "husky": "1.0.0-rc.9",
+    "ignore-loader": "^0.1.2",
     "jest": "^22.4.3",
     "jest-junit": "^3.6.0",
     "jest-styled-components": "^5.0.0",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -500,6 +500,10 @@ module.exports = {
         {
           test: /\.css$/,
           loader: "style-loader!css-loader"
+        },
+        {
+          test: /README\.md$/,
+          loader: "ignore-loader"
         }
       ]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5070,6 +5070,10 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
+ignore-loader@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
+
 ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Problem
When going to the style guide URL and looking in browser or server console, you would see this warning:

```
webpackHotDevClient.js:138 ./styleguide/src/components/README.md
Module parse failed: Unexpected token (1:4)
You may need an appropriate loader to handle this file type.
| Put components in this folder if they're used only by the style guide itself or required by code examples in Component.md files, but not part of the published component library.
```

## Solution
After adding the `ignore-loader` package as a dev dependency and configuring `README.md` files to use that loader, the warning no longer appears.

## Testing
Run the style guide locally and verify that the "Module parse failed" error does not appear in the browser console.