### PR TITLE
chore: updates to addcomponent script

### DIFF
--- a/.reaction/scripts/addcomponent.js
+++ b/.reaction/scripts/addcomponent.js
@@ -43,6 +43,7 @@ function createComponentFile(name) {
   const filePath = path.join(componentDirectory, "v1", `${name}.js`);
   let template = fs.readFileSync(".reaction/scripts/templates/Component.js.template", { encoding: "utf8" });
   template = template.replace(/COMPONENT/g, name);
+  template = template.replace(/cOMPONENT/g, name.charAt(0).toLowerCase() + name.slice(1));
   fs.ensureFileSync(filePath);
   fs.writeFileSync(filePath, template);
 }

--- a/.reaction/scripts/templates/Component.js.template
+++ b/.reaction/scripts/templates/Component.js.template
@@ -16,7 +16,8 @@ class COMPONENT extends Component {
      */
     className: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/.reaction/scripts/templates/Component.js.template
+++ b/.reaction/scripts/templates/Component.js.template
@@ -4,12 +4,25 @@ import styled from "styled-components";
 import { applyTheme } from "../../../utils";
 
 const StyledDiv = styled.div`
-  color: #333333;
+  color: ${applyTheme("cOMPONENTColor")};
 `;
 
 class COMPONENT extends Component {
   static propTypes = {
-
+    /**
+     * You can provide a `className` prop that will be applied to the outermost DOM element
+     * rendered by this component. We do not recommend using this for styling purposes, but
+     * it can be useful as a selector in some situations.
+     */
+    className: PropTypes.string,
+    /**
+     * If you've set up a components context using @reactioncommerce/components-context
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
+    components: PropTypes.shape({
+    }).isRequired
   };
 
   static defaultProps = {
@@ -17,8 +30,10 @@ class COMPONENT extends Component {
   };
 
   render() {
+    const { className } = this.props;
+
     return (
-      <StyledDiv>TEST</StyledDiv>
+      <StyledDiv className={className}>TEST</StyledDiv>
     );
   }
 }

--- a/docs/component-development-guidelines.md
+++ b/docs/component-development-guidelines.md
@@ -28,7 +28,8 @@ In general:
 
 ```js
 /**
- * If you've set up a components context using @reactioncommerce/components-context
+ * If you've set up a components context using
+ * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
  * (recommended), then this prop will come from there automatically. If you have not
  * set up a components context or you want to override one of the components in a
  * single spot, you can pass in the components prop directly.

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -32,7 +32,8 @@ class AddressForm extends Component {
      */
     addressNamePlaceholder: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/Button/v1/Button.js
+++ b/package/src/components/Button/v1/Button.js
@@ -90,7 +90,8 @@ class Button extends Component {
      */
     className: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
+++ b/package/src/components/CartEmptyMessage/v1/CartEmptyMessage.js
@@ -26,7 +26,8 @@ class CartEmptyMessage extends Component {
      */
     buttonText: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -94,7 +94,8 @@ const ItemRemoveButton = styled.button`
 class CartItem extends Component {
   static propTypes = {
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/CartItems/v1/CartItems.js
+++ b/package/src/components/CartItems/v1/CartItems.js
@@ -9,7 +9,8 @@ const Items = styled.div``;
 class CartItems extends Component {
   static propTypes = {
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/CatalogGrid/v1/CatalogGrid.js
+++ b/package/src/components/CatalogGrid/v1/CatalogGrid.js
@@ -69,7 +69,8 @@ class CatalogGrid extends Component {
       SALE: PropTypes.string
     }),
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
+++ b/package/src/components/CatalogGridItem/v1/CatalogGridItem.js
@@ -50,7 +50,8 @@ class CatalogGridItem extends Component {
       SALE: PropTypes.string
     }),
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/CheckoutActionComplete/v1/CheckoutActionComplete.js
+++ b/package/src/components/CheckoutActionComplete/v1/CheckoutActionComplete.js
@@ -62,7 +62,8 @@ const ActionButton = styled.div`
 class CheckoutActionComplete extends Component {
   static propTypes = {
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.js
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.js
@@ -58,7 +58,8 @@ class CheckoutActions extends Component {
       props: PropTypes.object
     })),
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/ErrorsBlock/v1/ErrorsBlock.js
+++ b/package/src/components/ErrorsBlock/v1/ErrorsBlock.js
@@ -35,7 +35,8 @@ class ErrorsBlock extends Component {
   static propTypes = {
     className: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.js
+++ b/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.js
@@ -65,7 +65,8 @@ class FinalReviewCheckoutAction extends Component {
       items: PropTypes.arrayOf(PropTypes.object).isRequired
     }),
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
+++ b/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
@@ -40,7 +40,8 @@ const FulfillmentOptionShape = PropTypes.shape({
 class FulfillmentOptionsCheckoutAction extends Component {
   static propTypes = {
     /**
-     * If you've set up a components context using [`@reactioncommerce/components-context`](https://github.com/reactioncommerce/components-context)
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/GuestForm/v1/GuestForm.js
+++ b/package/src/components/GuestForm/v1/GuestForm.js
@@ -27,7 +27,8 @@ class GuestForm extends Component {
      */
     buttonText: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/MiniCart/v1/MiniCart.js
+++ b/package/src/components/MiniCart/v1/MiniCart.js
@@ -79,7 +79,8 @@ class MiniCart extends Component {
       items: PropTypes.arrayOf(PropTypes.object).isRequired
     }),
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
+++ b/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
@@ -130,7 +130,8 @@ class PhoneNumberInput extends Component {
      */
     className: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/SelectableList/v1/SelectableList.js
+++ b/package/src/components/SelectableList/v1/SelectableList.js
@@ -69,7 +69,8 @@ class SelectableList extends Component {
 
   static propTypes = {
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -22,7 +22,8 @@ const Address = styled.address`
 class ShippingAddressCheckoutAction extends Component {
   static propTypes = {
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/StripeForm/v1/StripeForm.js
+++ b/package/src/components/StripeForm/v1/StripeForm.js
@@ -79,11 +79,12 @@ class StripeForm extends Component {
      */
     cardNumberPlaceholder: PropTypes.string,
     /**
-    * If you've set up a components context using @reactioncommerce/components-context
-    * (recommended), then this prop will come from there automatically. If you have not
-    * set up a components context or you want to override one of the components in a
-    * single spot, you can pass in the components prop directly.
-    */
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
     components: PropTypes.shape({
       /**
        * Visa icon as SVG

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -40,7 +40,8 @@ const billingAddressOptions = [{
 class StripePaymentCheckoutAction extends Component {
   static propTypes = {
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.

--- a/package/src/components/TextInput/v1/TextInput.js
+++ b/package/src/components/TextInput/v1/TextInput.js
@@ -176,7 +176,8 @@ class TextInput extends Component {
      */
     className: PropTypes.string,
     /**
-     * If you've set up a components context using @reactioncommerce/components-context
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
      * set up a components context or you want to override one of the components in a
      * single spot, you can pass in the components prop directly.


### PR DESCRIPTION
Resolves #245
Impact: **minor**  
Type: **chore**

## Changes
Updates the `addcomponent` script's component template.
- Includes `className` prop type and passes it along to the outermost DOM element. (#245)
- Includes `components` prop because it's a common requirement
- Uses `applyTheme` rather than a hard-coded color value to encourage proper theme-ability of components.

## Testing
1. Run `docker-compose run --rm web node .reaction/scripts/addcomponent SomeNewComponent`
2. Verify that the component files generated look good and have all of the mentioned changes.