### PR TITLE
feat: 265 nnnnat checkout action status labels

### DIFF
--- a/package/src/components/CheckoutAction/v1/CheckoutAction.js
+++ b/package/src/components/CheckoutAction/v1/CheckoutAction.js
@@ -40,7 +40,7 @@ class CheckoutAction extends Component {
   static defaultProps = {
     activeLabel: "Active Step",
     completeLabel: "Completed Step",
-    incompleteLabel: "Incompleted Step"
+    incompleteLabel: "Incomplete Step"
   };
 
   renderActiveAction = () => {

--- a/package/src/components/CheckoutAction/v1/CheckoutAction.js
+++ b/package/src/components/CheckoutAction/v1/CheckoutAction.js
@@ -4,21 +4,29 @@ import PropTypes from "prop-types";
 class CheckoutAction extends Component {
   static propTypes = {
     /**
+     * Action label when active
+     */
+    activeLabel: PropTypes.string,
+    /**
      * The component to display if workflow status is `active`
      */
     activeStepElement: PropTypes.node.isRequired,
+    /**
+     * Action label when completed
+     */
+    completeLabel: PropTypes.string,
     /**
      * The component to display if workflow status is `complete`
      */
     completeStepElement: PropTypes.node.isRequired,
     /**
+     * Action label when incomplete
+     */
+    incompleteLabel: PropTypes.string,
+    /**
      * The component to display if workflow status is `incomplete`
      */
     incompleteStepElement: PropTypes.node.isRequired,
-    /**
-     * Label of workflow step
-     */
-    label: PropTypes.string.isRequired,
     /**
      * Status of current checkout step
      */
@@ -29,11 +37,17 @@ class CheckoutAction extends Component {
     stepNumber: PropTypes.number.isRequired
   };
 
+  static defaultProps = {
+    activeLabel: "Active Step",
+    completeLabel: "Completed Step",
+    incompleteLabel: "Incompleted Step"
+  };
+
   renderActiveAction = () => {
-    const { activeStepElement, label, status, stepNumber } = this.props;
+    const { activeStepElement, activeLabel, status, stepNumber } = this.props;
 
     const component = React.cloneElement(activeStepElement, {
-      label: (activeStepElement.props && activeStepElement.props.label) || label,
+      label: (activeStepElement.props && activeStepElement.props.label) || activeLabel,
       stepNumber: (activeStepElement.props && activeStepElement.props.stepNumber) || stepNumber
     });
 
@@ -45,10 +59,10 @@ class CheckoutAction extends Component {
   };
 
   renderCompleteAction = () => {
-    const { completeStepElement, label, status, stepNumber } = this.props;
+    const { completeStepElement, completeLabel, status, stepNumber } = this.props;
 
     const component = React.cloneElement(completeStepElement, {
-      label: (completeStepElement.props && completeStepElement.props.label) || label,
+      label: (completeStepElement.props && completeStepElement.props.label) || completeLabel,
       stepNumber: (completeStepElement.props && completeStepElement.props.stepNumber) || stepNumber
     });
 
@@ -60,10 +74,10 @@ class CheckoutAction extends Component {
   };
 
   renderIncompleteAction = () => {
-    const { incompleteStepElement, label, status, stepNumber } = this.props;
+    const { incompleteStepElement, incompleteLabel, status, stepNumber } = this.props;
 
     const component = React.cloneElement(incompleteStepElement, {
-      label: (incompleteStepElement.props && incompleteStepElement.props.label) || label,
+      label: (incompleteStepElement.props && incompleteStepElement.props.label) || incompleteLabel,
       stepNumber: (incompleteStepElement.props && incompleteStepElement.props.stepNumber) || stepNumber
     });
 

--- a/package/src/components/CheckoutAction/v1/CheckoutAction.md
+++ b/package/src/components/CheckoutAction/v1/CheckoutAction.md
@@ -99,7 +99,7 @@ const Address = (
 ```
 
 #### Action status labels
-Each status can have it's own label by using the `activeLabel, completeLabel, incompleteLabel` props.
+Each status can have its own label by using the `activeLabel, completeLabel, incompleteLabel` props.
 
 ```jsx
 const ActiveStepComp = ({label, stepNumber}) => <span>{stepNumber}{label}: Active Component</span>;

--- a/package/src/components/CheckoutAction/v1/CheckoutAction.md
+++ b/package/src/components/CheckoutAction/v1/CheckoutAction.md
@@ -30,7 +30,6 @@ const Address = (
     }
     cart={{}}
     isLoading={false}
-    label="Shipping address"
     status="active"
     stepNumber={2}
   />
@@ -62,7 +61,6 @@ const Address = (
     }
     cart={{}}
     isLoading={false}
-    label="Shipping address"
     status="complete"
     stepNumber={2}
   />
@@ -94,15 +92,51 @@ const Address = (
     }
     cart={{}}
     isLoading={false}
-    label="Shipping address"
     status="incomplete"
     stepNumber={2}
   />
 </div>
 ```
 
-#### Override default `label` or `stepNumber`
+#### Action status labels
+Each status can have it's own label by using the `activeLabel, completeLabel, incompleteLabel` props.
 
+```jsx
+const ActiveStepComp = ({label, stepNumber}) => <span>{stepNumber}{label}: Active Component</span>;
+const onClick = () => {};
+const Address = (
+  <div>
+    Ms. Jane Doe<br />
+    123 Main Street<br />
+    Anytown, USA 01776
+  </div>
+);
+
+<div>
+  <CheckoutAction
+    activeStepElement={<ActiveStepComp />}
+    completeStepElement={
+      <CheckoutActionComplete
+        content={Address}
+        onClickChangeButton={onClick}
+      />
+    }
+    incompleteStepElement={
+      <CheckoutActionIncomplete />
+    }
+    cart={{}}
+    activeLabel="Active Label"
+    completeLabel="Complete Label"
+    incompleteLabel="Incomplete Label"
+    isLoading={false}
+    status="complete"
+    stepNumber={2}
+  />
+</div>
+```
+
+#### Override default `label` or `stepNumber`
+Passing `label` and `stepNumber` directly to each "status" component.
 ```jsx
 const ActiveStepComp = () => <span>Active Component</span>;
 const onClick = () => {};
@@ -130,7 +164,6 @@ const Address = (
     }
     cart={{}}
     isLoading={false}
-    label="Shipping address"
     status="complete"
     stepNumber={2}
   />

--- a/package/src/components/CheckoutAction/v1/CheckoutAction.test.js
+++ b/package/src/components/CheckoutAction/v1/CheckoutAction.test.js
@@ -5,9 +5,9 @@ import CheckoutActionComplete from "../../CheckoutActionComplete/v1";
 import CheckoutActionIncomplete from "../../CheckoutActionIncomplete/v1";
 import CheckoutAction from "./CheckoutAction";
 
-const MockActiveCheckoutAciton = () => (<span />);
+const MockActiveCheckoutAciton = ({ activeLabel }) => (<span>{activeLabel}</span>);
 
-test("CheckoutAction with `active` status", () => {
+test("CheckoutAction with `active` status & label", () => {
   const cart = {};
   const isLoading = false;
   const onClick = () => {};
@@ -21,6 +21,7 @@ test("CheckoutAction with `active` status", () => {
 
   const component = renderer.create((
     <CheckoutAction
+      activeLabel="Mock active label"
       activeStepElement={<MockActiveCheckoutAciton />}
       completeStepElement={
         <CheckoutActionComplete
@@ -34,7 +35,6 @@ test("CheckoutAction with `active` status", () => {
       }
       cart={cart}
       isLoading={isLoading}
-      label="Shipping address"
       status="active"
       stepNumber={2}
     />
@@ -44,7 +44,7 @@ test("CheckoutAction with `active` status", () => {
   expect(tree).toMatchSnapshot();
 });
 
-test("CheckoutAction with `complete` status", () => {
+test("CheckoutAction with `complete` status & label", () => {
   const cart = {};
   const isLoading = false;
   const onClick = () => {};
@@ -70,8 +70,8 @@ test("CheckoutAction with `complete` status", () => {
         <CheckoutActionIncomplete />
       }
       cart={cart}
+      completeLabel="Mock complete label"
       isLoading={isLoading}
-      label="Shipping address"
       status="complete"
       stepNumber={2}
     />
@@ -81,7 +81,7 @@ test("CheckoutAction with `complete` status", () => {
   expect(tree).toMatchSnapshot();
 });
 
-test("CheckoutAction with `incomplete` status", () => {
+test("CheckoutAction with `incomplete` status & label", () => {
   const cart = {};
   const isLoading = false;
   const onClick = () => {};
@@ -103,12 +103,12 @@ test("CheckoutAction with `incomplete` status", () => {
           onClickChangeButton={onClick}
         />
       }
+      incompleteLabel="Mock incomplete label"
       incompleteStepElement={
         <CheckoutActionIncomplete />
       }
       cart={cart}
       isLoading={isLoading}
-      label="Shipping address"
       status="incomplete"
       stepNumber={2}
     />
@@ -146,7 +146,6 @@ test("CheckoutAction with `complete` status and label override via props", () =>
       }
       cart={cart}
       isLoading={isLoading}
-      label="Shipping address"
       status="complete"
       stepNumber={2}
     />
@@ -184,7 +183,6 @@ test("CheckoutAction with `complete` status and stepNumber override via props", 
       }
       cart={cart}
       isLoading={isLoading}
-      label="Shipping address"
       status="complete"
       stepNumber={2}
     />

--- a/package/src/components/CheckoutAction/v1/__snapshots__/CheckoutAction.test.js.snap
+++ b/package/src/components/CheckoutAction/v1/__snapshots__/CheckoutAction.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CheckoutAction with \`active\` status 1`] = `
+exports[`CheckoutAction with \`active\` status & label 1`] = `
 <div>
   <span />
 </div>
 `;
 
-exports[`CheckoutAction with \`complete\` status 1`] = `
+exports[`CheckoutAction with \`complete\` status & label 1`] = `
 .c0 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -128,7 +128,7 @@ exports[`CheckoutAction with \`complete\` status 1`] = `
     >
       2
       . 
-      Shipping address
+      Mock complete label
     </div>
     <div
       className="c2"
@@ -416,7 +416,7 @@ exports[`CheckoutAction with \`complete\` status and stepNumber override via pro
     >
       500
       . 
-      Shipping address
+      Completed Step
     </div>
     <div
       className="c2"
@@ -438,7 +438,7 @@ exports[`CheckoutAction with \`complete\` status and stepNumber override via pro
 </div>
 `;
 
-exports[`CheckoutAction with \`incomplete\` status 1`] = `
+exports[`CheckoutAction with \`incomplete\` status & label 1`] = `
 .c0 {
   color: #a6a6a6;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -449,7 +449,7 @@ exports[`CheckoutAction with \`incomplete\` status 1`] = `
   <div
     className="c0"
   >
-    2. Shipping address
+    2. Mock incomplete label
   </div>
 </div>
 `;

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.js
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.js
@@ -41,9 +41,9 @@ class CheckoutActions extends Component {
      */
     actions: PropTypes.arrayOf(PropTypes.shape({
       /**
-         * Action _id
+         * Action id
          */
-      _id: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
       /**
          * Action label when active
          */
@@ -104,11 +104,11 @@ class CheckoutActions extends Component {
   static getDerivedStateFromProps(props, state) {
     if (!isEqual(props.actions, state.previousActionsProp)) {
       const { currentActions = [] } = state;
-      const actions = props.actions.map(({ _id }) => {
-        const currentAction = currentActions.find((action) => action._id === _id);
+      const actions = props.actions.map(({ id }) => {
+        const currentAction = currentActions.find((action) => action.id === id);
         const { isActive = false, readyForSave = false, isSaving = false } = currentAction || {};
         return {
-          _id,
+          id,
           readyForSave,
           isSaving,
           isActive
@@ -127,23 +127,23 @@ class CheckoutActions extends Component {
 
   _refs = {};
 
-  getCurrentActionIndex(_id) {
+  getCurrentActionIndex(id) {
     const { currentActions } = this.state;
-    return currentActions.findIndex((action) => action._id === _id);
+    return currentActions.findIndex((action) => action.id === id);
   }
 
-  getCurrentActionByID(_id) {
+  getCurrentActionByID(id) {
     const { currentActions } = this.state;
-    return currentActions[this.getCurrentActionIndex(_id)];
+    return currentActions[this.getCurrentActionIndex(id)];
   }
 
-  setStateForAction(_id, stateChanges) {
+  setStateForAction(id, stateChanges) {
     const { currentActions } = this.state;
 
     // We are being careful to create a new array with new objects here to prevent
     // strange errors due to unintentional mutation of current state.
     const newCurrentActions = currentActions.map((currentAction) => {
-      const updates = currentAction._id === _id ? stateChanges : {};
+      const updates = currentAction.id === id ? stateChanges : {};
       return {
         ...currentAction,
         ...updates
@@ -155,12 +155,12 @@ class CheckoutActions extends Component {
     });
   }
 
-  handleActionSubmit = async (_id, onSubmit, actionValue) => {
-    this.setStateForAction(_id, { isActive: false, isSaving: true });
+  handleActionSubmit = async (id, onSubmit, actionValue) => {
+    this.setStateForAction(id, { isActive: false, isSaving: true });
 
     await onSubmit(actionValue);
 
-    this.setStateForAction(_id, { isSaving: false });
+    this.setStateForAction(id, { isSaving: false });
   };
 
   actionSubmit = (label) => {
@@ -171,8 +171,8 @@ class CheckoutActions extends Component {
     const { actions } = this.props;
     const { currentActions } = this.state;
 
-    const currentActiveActions = actions.reduce((activeList, { _id, status }) => {
-      const currentAction = currentActions.find((action) => action._id === _id);
+    const currentActiveActions = actions.reduce((activeList, { id, status }) => {
+      const currentAction = currentActions.find((action) => action.id === id);
       let { isActive } = currentAction;
 
       if (!activeList.length && status === "incomplete") {
@@ -180,7 +180,7 @@ class CheckoutActions extends Component {
       }
 
       if (isActive) {
-        activeList.push(_id);
+        activeList.push(id);
       }
 
       return activeList;
@@ -189,15 +189,15 @@ class CheckoutActions extends Component {
     return currentActiveActions;
   };
 
-  renderCompleteAction = ({ _id, status, completeLabel, component, props }) => {
+  renderCompleteAction = ({ id, status, completeLabel, component, props }) => {
     const { components: { CheckoutActionComplete } } = this.props;
     return status === "complete" ? (
       <CheckoutActionComplete
-        key={_id}
+        key={id}
         label={completeLabel}
         content={component.renderComplete(props)}
         onClickChangeButton={() => {
-          this.setStateForAction(_id, { isActive: true });
+          this.setStateForAction(id, { isActive: true });
         }}
       />
     ) : (
@@ -207,8 +207,8 @@ class CheckoutActions extends Component {
 
   renderFormActions = (action) => {
     const { actions, components: { Button } } = this.props;
-    const { readyForSave, isSaving } = this.getCurrentActionByID(action._id);
-    const lastStep = actions.length - 1 === this.getCurrentActionIndex(action._id);
+    const { readyForSave, isSaving } = this.getCurrentActionByID(action.id);
+    const lastStep = actions.length - 1 === this.getCurrentActionIndex(action.id);
 
     const saveAndContinueButtons = (
       <React.Fragment>
@@ -216,7 +216,7 @@ class CheckoutActions extends Component {
           <Button
             actionType="secondary"
             onClick={() => {
-              this.setStateForAction(action._id, { isActive: false });
+              this.setStateForAction(action.id, { isActive: false });
             }}
           >
             Cancel

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.js
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.js
@@ -41,13 +41,25 @@ class CheckoutActions extends Component {
      */
     actions: PropTypes.arrayOf(PropTypes.shape({
       /**
-         * Checkout action label
+         * Action _id
          */
-      label: PropTypes.string.isRequired,
+      _id: PropTypes.string.isRequired,
+      /**
+         * Action label when active
+         */
+      activeLabel: PropTypes.string.isRequired,
       /**
          * The checkout action's active  component
          */
       component: CustomPropTypes.component.isRequired,
+      /**
+         * Action label when completed
+         */
+      completeLabel: PropTypes.string.isRequired,
+      /**
+         * Action label when incomplete
+         */
+      incompleteLabel: PropTypes.string.isRequired,
       /**
          * Callback function called after the active action submits.
          */
@@ -92,11 +104,11 @@ class CheckoutActions extends Component {
   static getDerivedStateFromProps(props, state) {
     if (!isEqual(props.actions, state.previousActionsProp)) {
       const { currentActions = [] } = state;
-      const actions = props.actions.map(({ label }) => {
-        const currentAction = currentActions.find((action) => action.label === label);
+      const actions = props.actions.map(({ _id }) => {
+        const currentAction = currentActions.find((action) => action._id === _id);
         const { isActive = false, readyForSave = false, isSaving = false } = currentAction || {};
         return {
-          label,
+          _id,
           readyForSave,
           isSaving,
           isActive
@@ -115,23 +127,23 @@ class CheckoutActions extends Component {
 
   _refs = {};
 
-  getCurrentActionIndex(label) {
+  getCurrentActionIndex(_id) {
     const { currentActions } = this.state;
-    return currentActions.findIndex((action) => action.label === label);
+    return currentActions.findIndex((action) => action._id === _id);
   }
 
-  getCurrentActionByLabel(label) {
+  getCurrentActionByID(_id) {
     const { currentActions } = this.state;
-    return currentActions[this.getCurrentActionIndex(label)];
+    return currentActions[this.getCurrentActionIndex(_id)];
   }
 
-  setStateForAction(actionLabel, stateChanges) {
+  setStateForAction(_id, stateChanges) {
     const { currentActions } = this.state;
 
     // We are being careful to create a new array with new objects here to prevent
     // strange errors due to unintentional mutation of current state.
     const newCurrentActions = currentActions.map((currentAction) => {
-      const updates = (currentAction.label === actionLabel) ? stateChanges : {};
+      const updates = currentAction._id === _id ? stateChanges : {};
       return {
         ...currentAction,
         ...updates
@@ -143,12 +155,12 @@ class CheckoutActions extends Component {
     });
   }
 
-  handleActionSubmit = async (label, onSubmit, actionValue) => {
-    this.setStateForAction(label, { isActive: false, isSaving: true });
+  handleActionSubmit = async (_id, onSubmit, actionValue) => {
+    this.setStateForAction(_id, { isActive: false, isSaving: true });
 
     await onSubmit(actionValue);
 
-    this.setStateForAction(label, { isSaving: false });
+    this.setStateForAction(_id, { isSaving: false });
   };
 
   actionSubmit = (label) => {
@@ -159,8 +171,8 @@ class CheckoutActions extends Component {
     const { actions } = this.props;
     const { currentActions } = this.state;
 
-    const currentActiveActions = actions.reduce((activeList, { label, status }) => {
-      const currentAction = currentActions.find((action) => action.label === label);
+    const currentActiveActions = actions.reduce((activeList, { _id, status }) => {
+      const currentAction = currentActions.find((action) => action._id === _id);
       let { isActive } = currentAction;
 
       if (!activeList.length && status === "incomplete") {
@@ -168,23 +180,24 @@ class CheckoutActions extends Component {
       }
 
       if (isActive) {
-        activeList.push(label);
+        activeList.push(_id);
       }
 
       return activeList;
     }, []);
 
     return currentActiveActions;
-  }
+  };
 
-  renderCompleteAction = ({ label, status, component, props }) => {
+  renderCompleteAction = ({ _id, status, completeLabel, component, props }) => {
     const { components: { CheckoutActionComplete } } = this.props;
     return status === "complete" ? (
       <CheckoutActionComplete
-        key={label}
+        key={_id}
+        label={completeLabel}
         content={component.renderComplete(props)}
         onClickChangeButton={() => {
-          this.setStateForAction(label, { isActive: true });
+          this.setStateForAction(_id, { isActive: true });
         }}
       />
     ) : (
@@ -194,19 +207,24 @@ class CheckoutActions extends Component {
 
   renderFormActions = (action) => {
     const { actions, components: { Button } } = this.props;
-    const { readyForSave, isSaving } = this.getCurrentActionByLabel(action.label);
-    const lastStep = ((actions.length - 1) === this.getCurrentActionIndex(action.label));
+    const { readyForSave, isSaving } = this.getCurrentActionByID(action._id);
+    const lastStep = actions.length - 1 === this.getCurrentActionIndex(action._id);
 
     const saveAndContinueButtons = (
       <React.Fragment>
         {action.props ? (
-          <Button actionType="secondary" onClick={() => { this.setStateForAction(action.label, { isActive: false }); }}>
+          <Button
+            actionType="secondary"
+            onClick={() => {
+              this.setStateForAction(action._id, { isActive: false });
+            }}
+          >
             Cancel
           </Button>
         ) : (
           ""
         )}
-        <Button onClick={() => this.actionSubmit(action.label)} isDisabled={!readyForSave} isWaiting={isSaving}>
+        <Button onClick={() => this.actionSubmit(action._id)} isDisabled={!readyForSave} isWaiting={isSaving}>
           Save and continue
         </Button>
       </React.Fragment>
@@ -214,45 +232,32 @@ class CheckoutActions extends Component {
 
     const placeOrderButton = (
       <PlaceOrderButtonContainer>
-        <Button
-          onClick={() => this.actionSubmit(action.label)}
-          actionType="important"
-          isWaiting={isSaving}
-          isFullWidth
-        >
-          { isSaving ? "Placing your order..." : "Place your order" }
+        <Button onClick={() => this.actionSubmit(action._id)} actionType="important" isWaiting={isSaving} isFullWidth>
+          {isSaving ? "Placing your order..." : "Place your order"}
         </Button>
       </PlaceOrderButtonContainer>
     );
 
-    return (
-      <FormActions>
-        { lastStep ?
-          placeOrderButton
-          :
-          saveAndContinueButtons
-        }
-      </FormActions>
-    );
-  }
+    return <FormActions>{lastStep ? placeOrderButton : saveAndContinueButtons}</FormActions>;
+  };
 
   renderActiveAction = ({ component: Comp, ...action }) => {
-    const { isSaving } = this.getCurrentActionByLabel(action.label);
+    const { isSaving } = this.getCurrentActionByID(action._id);
 
     return (
       <Fragment>
         <Comp
           {...action.props}
           onReadyForSaveChange={(ready) => {
-            this.setStateForAction(action.label, { readyForSave: ready });
+            this.setStateForAction(action._id, { readyForSave: ready });
           }}
           isSaving={isSaving}
           ref={(el) => {
-            this._refs[action.label] = el;
+            this._refs[action._id] = el;
           }}
-          label={action.label}
-          stepNumber={this.getCurrentActionIndex(action.label) + 1}
-          onSubmit={(value) => this.handleActionSubmit(action.label, action.onSubmit, value)}
+          label={action.activeLabel}
+          stepNumber={this.getCurrentActionIndex(action._id) + 1}
+          onSubmit={(value) => this.handleActionSubmit(action._id, action.onSubmit, value)}
         />
         {this.renderFormActions(action)}
       </Fragment>
@@ -261,16 +266,16 @@ class CheckoutActions extends Component {
 
   renderAction = (action, currentActiveActions) => {
     const { components: { CheckoutAction, CheckoutActionIncomplete } } = this.props;
-
-    const isActive = currentActiveActions.find((label) => label === action.label);
+    const isActive = currentActiveActions.find((_id) => _id === action._id);
     const actionStatus = isActive ? "active" : action.status;
+    const { activeLabel, completeLabel, incompleteLabel } = action;
 
     return (
-      <Action key={action.label}>
+      <Action key={action._id}>
         <CheckoutAction
           status={actionStatus}
-          label={action.label}
-          stepNumber={this.getCurrentActionIndex(action.label) + 1}
+          {...{ activeLabel, completeLabel, incompleteLabel }}
+          stepNumber={this.getCurrentActionIndex(action._id) + 1}
           activeStepElement={this.renderActiveAction(action)}
           completeStepElement={this.renderCompleteAction(action)}
           incompleteStepElement={<CheckoutActionIncomplete />}
@@ -283,7 +288,7 @@ class CheckoutActions extends Component {
     const { actions } = this.props;
     const activeActions = this.determineActiveActions();
 
-    return actions.map((action) => (this.renderAction(action, activeActions)));
+    return actions.map((action) => this.renderAction(action, activeActions));
   }
 }
 

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -12,7 +12,10 @@ The `CheckoutActions` component is responsible for:
 ```js static
 const actions = [
   {
-    label: "Shipping Information",
+    _id: "1",
+    activeLabel: "Enter a shipping Address",
+    completeLabel: "Shipping Address",
+    incompleteLabel: "Shipping Address",
     status: "incomplete",
     component: ShippingAddressCheckoutAction,
     onSubmit: setShippingAddress
@@ -21,7 +24,10 @@ const actions = [
     }
   },
   {
-    label: "Shipping Options",
+    _id: "2",
+    activeLabel: "Choose a shipping method",
+    completeLabel: "Shipping method",
+    incompleteLabel: "Shipping Method",
     status: "incomplete",
     component: FulfillmentOptionsCheckoutAction,
     onSubmit: setFulfillmentOption
@@ -30,7 +36,10 @@ const actions = [
     }
   },
   {
-    label: "Payment Information",
+    _id: "3",
+    activeLabel: "Enter payment information",
+    completeLabel: "Payment Information",
+    incompleteLabel: "Payment Information",
     status: "incomplete",
     component: PaymentCheckoutAction,
     onSubmit: setPayment,
@@ -39,7 +48,10 @@ const actions = [
     }
   },
   {
-    label: "Review and place order",
+    _id: "4",
+    activeLabel: "Review and place order",
+    completeLabel: "Review and place order",
+    incompleteLabel: "Review and place order",
     status: "incomplete",
     component: FinalReviewCheckoutAction,
     onSubmit: placeOrder,
@@ -278,7 +290,10 @@ class CheckoutActionsExample extends React.Component {
 
     const actions = [
       {
-        label: "Shipping information",
+        _id: "1",
+        activeLabel: "Enter a shipping Address",
+        completeLabel: "Shipping Address",
+        incompleteLabel: "Shipping Address",
         status: this.getShippingStatus(),
         component: ShippingAddressCheckoutAction,
         onSubmit: this.setShippingAddress,
@@ -287,7 +302,10 @@ class CheckoutActionsExample extends React.Component {
         }
       },
       {
-        label: "Fulfillment information",
+        _id: "2",
+        activeLabel: "Choose a shipping method",
+        completeLabel: "Shipping method",
+        incompleteLabel: "Shipping Method",
         status: this.getFulfillmentOptionStatus(),
         component: FulfillmentOptionsCheckoutAction,
         onSubmit: this.setFulfillmentOption,
@@ -297,7 +315,10 @@ class CheckoutActionsExample extends React.Component {
         }
       },
       {
-        label: "Payment information",
+        _id: "3",
+        activeLabel: "Enter payment information",
+        completeLabel: "Payment Information",
+        incompleteLabel: "Payment Information",
         status: this.getPaymentStatus(),
         component: StripePaymentCheckoutAction,
         onSubmit: this.setPaymentMethod,
@@ -306,7 +327,10 @@ class CheckoutActionsExample extends React.Component {
         }
       },
       {
-        label: "Review and place order",
+        _id: "4",
+        activeLabel: "Review and place order",
+        completeLabel: "Review and place order",
+        incompleteLabel: "Review and place order",
         status: "incomplete",
         component: FinalReviewCheckoutAction,
         onSubmit: this.placeOrder,

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -13,9 +13,9 @@ The `CheckoutActions` component is responsible for:
 const actions = [
   {
     _id: "1",
-    activeLabel: "Enter a shipping Address",
-    completeLabel: "Shipping Address",
-    incompleteLabel: "Shipping Address",
+    activeLabel: "Enter a shipping address",
+    completeLabel: "Shipping address",
+    incompleteLabel: "Shipping address",
     status: "incomplete",
     component: ShippingAddressCheckoutAction,
     onSubmit: setShippingAddress
@@ -27,7 +27,7 @@ const actions = [
     _id: "2",
     activeLabel: "Choose a shipping method",
     completeLabel: "Shipping method",
-    incompleteLabel: "Shipping Method",
+    incompleteLabel: "Shipping method",
     status: "incomplete",
     component: FulfillmentOptionsCheckoutAction,
     onSubmit: setFulfillmentOption
@@ -38,8 +38,8 @@ const actions = [
   {
     _id: "3",
     activeLabel: "Enter payment information",
-    completeLabel: "Payment Information",
-    incompleteLabel: "Payment Information",
+    completeLabel: "Payment information",
+    incompleteLabel: "Payment information",
     status: "incomplete",
     component: PaymentCheckoutAction,
     onSubmit: setPayment,
@@ -291,9 +291,9 @@ class CheckoutActionsExample extends React.Component {
     const actions = [
       {
         _id: "1",
-        activeLabel: "Enter a shipping Address",
-        completeLabel: "Shipping Address",
-        incompleteLabel: "Shipping Address",
+        activeLabel: "Enter a shipping address",
+        completeLabel: "Shipping address",
+        incompleteLabel: "Shipping address",
         status: this.getShippingStatus(),
         component: ShippingAddressCheckoutAction,
         onSubmit: this.setShippingAddress,
@@ -305,7 +305,7 @@ class CheckoutActionsExample extends React.Component {
         _id: "2",
         activeLabel: "Choose a shipping method",
         completeLabel: "Shipping method",
-        incompleteLabel: "Shipping Method",
+        incompleteLabel: "Shipping method",
         status: this.getFulfillmentOptionStatus(),
         component: FulfillmentOptionsCheckoutAction,
         onSubmit: this.setFulfillmentOption,
@@ -317,8 +317,8 @@ class CheckoutActionsExample extends React.Component {
       {
         _id: "3",
         activeLabel: "Enter payment information",
-        completeLabel: "Payment Information",
-        incompleteLabel: "Payment Information",
+        completeLabel: "Payment information",
+        incompleteLabel: "Payment information",
         status: this.getPaymentStatus(),
         component: StripePaymentCheckoutAction,
         onSubmit: this.setPaymentMethod,

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -12,7 +12,7 @@ The `CheckoutActions` component is responsible for:
 ```js static
 const actions = [
   {
-    _id: "1",
+    id: "1",
     activeLabel: "Enter a shipping address",
     completeLabel: "Shipping address",
     incompleteLabel: "Shipping address",
@@ -24,7 +24,7 @@ const actions = [
     }
   },
   {
-    _id: "2",
+    id: "2",
     activeLabel: "Choose a shipping method",
     completeLabel: "Shipping method",
     incompleteLabel: "Shipping method",
@@ -36,7 +36,7 @@ const actions = [
     }
   },
   {
-    _id: "3",
+    id: "3",
     activeLabel: "Enter payment information",
     completeLabel: "Payment information",
     incompleteLabel: "Payment information",
@@ -48,7 +48,7 @@ const actions = [
     }
   },
   {
-    _id: "4",
+    id: "4",
     activeLabel: "Review and place order",
     completeLabel: "Review and place order",
     incompleteLabel: "Review and place order",
@@ -65,14 +65,14 @@ const actions = [
 
 ```jsx
 const fulfillmentGroups = [{
-  _id: 1,
+  id: 1,
   type: "shipping",
   data: {
     shippingAddress: null
   },
   availableFulfillmentOptions: [{
     fulfillmentMethod: {
-      _id: "111",
+      id: "111",
       name: "Standard",
       displayName: "Standard (5-9 Days)"
     },
@@ -83,7 +83,7 @@ const fulfillmentGroups = [{
   },
   {
     fulfillmentMethod: {
-      _id: "222",
+      id: "222",
       name: "Priority",
       displayName: "Priority (3-5 Days)"
     },
@@ -94,7 +94,7 @@ const fulfillmentGroups = [{
   },
   {
     fulfillmentMethod: {
-      _id: "333",
+      id: "333",
       name: "Express",
       displayName: "Express 2 Day"
     },
@@ -105,7 +105,7 @@ const fulfillmentGroups = [{
   },
   {
     fulfillmentMethod: {
-      _id: "444",
+      id: "444",
       name: "Overnight",
       displayName: "Overnight Expedited"
     },
@@ -122,7 +122,7 @@ const checkoutSummary = {
   displayTotal: "$135.58",
   displayTax: "$12.33",
   items: [{
-    _id: "123",
+    id: "123",
     attributes: [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }],
     compareAtPrice: {
       displayAmount: "$45.00"
@@ -142,7 +142,7 @@ const checkoutSummary = {
     quantity: 2
   },
   {
-    _id: "456",
+    id: "456",
     attributes: [{ label: "Color", value: "Black" }, { label: "Size", value: "10" }],
     currentQuantity: 500,
     imageURLs: {
@@ -161,7 +161,7 @@ const checkoutSummary = {
 };
 
 const paymentMethods = [{
-  _id: 1,
+  id: 1,
   name: "reactionstripe",
   data: {
     billingAddress: null,
@@ -290,7 +290,7 @@ class CheckoutActionsExample extends React.Component {
 
     const actions = [
       {
-        _id: "1",
+        id: "1",
         activeLabel: "Enter a shipping address",
         completeLabel: "Shipping address",
         incompleteLabel: "Shipping address",
@@ -302,7 +302,7 @@ class CheckoutActionsExample extends React.Component {
         }
       },
       {
-        _id: "2",
+        id: "2",
         activeLabel: "Choose a shipping method",
         completeLabel: "Shipping method",
         incompleteLabel: "Shipping method",
@@ -315,7 +315,7 @@ class CheckoutActionsExample extends React.Component {
         }
       },
       {
-        _id: "3",
+        id: "3",
         activeLabel: "Enter payment information",
         completeLabel: "Payment information",
         incompleteLabel: "Payment information",
@@ -327,7 +327,7 @@ class CheckoutActionsExample extends React.Component {
         }
       },
       {
-        _id: "4",
+        id: "4",
         activeLabel: "Review and place order",
         completeLabel: "Review and place order",
         incompleteLabel: "Review and place order",

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.test.js
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.test.js
@@ -12,7 +12,9 @@ class mockCheckoutAction extends React.Component {
 
 const mockActions = [
   {
-    label: "mock action one",
+    activeLabel: "mock active action one",
+    completeLabel: "mock complete action one",
+    incompleteLabel: "mock inactive action one",
     status: "incomplete",
     component: mockCheckoutAction,
     onSubmit: () => true,


### PR DESCRIPTION
Resolves #265 
Impact: **minor**  
Type: **feature|refactor**

## Component
`CheckoutActions` needed a way to display different labels by "status". 
  * `CheckoutAction` now accepts a `activeLabel, completeLabel, incompleteLabel` to show different labels durring each "status".
  * `CheckoutActions` now expects these "status" labels from each `props.action` and passes them down to the `CheckoutAction` component.

## Breaking changes
The `CheckoutActions` component now requires each `action` object to:
  * include each "status" label.
  * include a unique `_id`.

## Testing
  1. Verify `CheckoutAction` is still working as expected with new "status" labels.
  2. Verify `CheckoutActions` is still working as expected with new "status" labels.
  3. Verify documentation changes are correct