### PR TITLE
(feat): AccountProfileInfo component

### DIFF
--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -21,16 +21,16 @@ const ViewerEmailText = styled.span`
   color: ${applyTheme("accountProfileInfoEmailFontColor")};
   font-size: ${applyTheme("accountProfileInfoEmailFontSize")};
   align-self: left;
-  margin-bottom: 0.25rem;
-  margin-left: 1.0rem;
+  margin-bottom: 4px;
+  margin-left: 16px;
 `;
 
 const ViewerNameText = styled.span`
   ${addTypographyStyles("ViewerInfoInitials", "labelText")}
   font-size: ${applyTheme("accountProfileInfoNameFontSize")};
   align-self: left;
-  margin-bottom: 0.25rem;
-  margin-left: 1.0rem;
+  margin-bottom: 4px;
+  margin-left: 16px;
 `;
 
 class AccountProfileInfo extends Component {

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -4,13 +4,6 @@ import styled from "styled-components";
 import { withComponents } from "@reactioncommerce/components-context";
 import { addTypographyStyles, applyTheme } from "../../../utils";
 
-const AccountProfileImageContainer = styled.div`
-  display: flex;
-  height: 80px;
-  position: relative;
-  width: 80px;
-`;
-
 const AccountProfileInfoContainer = styled.div`
   display: flex;
   position: relative;
@@ -118,9 +111,7 @@ class AccountProfileInfo extends Component {
 
     return (
       <AccountProfileInfoContainer>
-        <AccountProfileImageContainer>
-          <ProfileImage viewer={viewer} />
-        </AccountProfileImageContainer>
+        <ProfileImage size={80} viewer={viewer} />
         <AccountProfileInfoTextContainer>
           <ViewerNameText>
             {this.viewerName}

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -17,7 +17,7 @@ const AccountProfileInfoTextContainer = styled.div`
 `;
 
 const ViewerEmailText = styled.span`
-  ${addTypographyStyles("AccountProfileInfoEmail", "captionText")}
+  ${addTypographyStyles("AccountProfileInfoEmail", "labelText")}
   align-self: left;
   margin-bottom: ${applyTheme("accountProfileInfoSpacingAfterEmail")};
   margin-left: ${applyTheme("accountProfileInfoSpacingBetweenImageAndContent")};

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -35,8 +35,21 @@ const ViewerNameText = styled.span`
 
 class AccountProfileInfo extends Component {
   static propTypes = {
+    /**
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
     components: PropTypes.shape({
+      /**
+       * An element to show to link to the edit profile page
+       */
       Button: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      /**
+     * Profile image component to display
+     */
       ProfileImage: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
     }),
     /**

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -21,7 +21,7 @@ const ViewerEmailText = styled.span`
   color: ${applyTheme("accountProfileInfoEmailFontColor")};
   font-size: ${applyTheme("accountProfileInfoEmailFontSize")};
   align-self: left;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.25rem;
   margin-left: 1.0rem;
 `;
 
@@ -53,9 +53,13 @@ class AccountProfileInfo extends Component {
       ProfileImage: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
     }),
     /**
+     * Function to pass to button onClick
+     */
+    onClickEdit: PropTypes.func,
+    /**
      * Enable this prop when you only want to display the Edit account link
      */
-    editable: PropTypes.bool,
+    shouldShowEditButton: PropTypes.bool,
     /**
      * An object containing basic user information.
      */
@@ -69,7 +73,7 @@ class AccountProfileInfo extends Component {
   };
 
   static defaultProps = {
-    editable: false
+    shouldShowEditButton: false
   };
 
   /**
@@ -96,11 +100,11 @@ class AccountProfileInfo extends Component {
   }
 
   viewerProfileEditLink = () => {
-    const { components: { Button }, editable } = this.props;
+    const { components: { Button }, onClickEdit, shouldShowEditButton } = this.props;
 
-    if (editable) {
+    if (shouldShowEditButton) {
       return (
-        <Button isShortHeight={true} isTextOnly={true}>Edit Account</Button>
+        <Button isShortHeight={true} isTextOnly={true} onClick={onClickEdit} style={{ padding: "5px 15px" }}>Edit Account</Button>
       );
     }
     return null;

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -4,6 +4,13 @@ import styled from "styled-components";
 import { withComponents } from "@reactioncommerce/components-context";
 import { addTypographyStyles, applyTheme } from "../../../utils";
 
+const AccountProfileImageContainer = styled.div`
+  display: flex;
+  height: 80px;
+  position: relative;
+  width: 80px;
+`;
+
 const AccountProfileInfoContainer = styled.div`
   display: flex;
   position: relative;
@@ -111,7 +118,9 @@ class AccountProfileInfo extends Component {
 
     return (
       <AccountProfileInfoContainer>
-        <ProfileImage viewer={viewer} />
+        <AccountProfileImageContainer>
+          <ProfileImage viewer={viewer} />
+        </AccountProfileImageContainer>
         <AccountProfileInfoTextContainer>
           <ViewerNameText>
             {this.viewerName}

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -69,6 +69,7 @@ class AccountProfileInfo extends Component {
     viewer: PropTypes.shape({
       firstName: PropTypes.string.isRequired,
       lastName: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
       primaryEmailAddress: PropTypes.string.isRequired
     }).isRequired
   };

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -1,40 +1,148 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { applyTheme } from "../../../utils";
+import { addTypographyStyles, applyTheme } from "../../../utils";
 
-const StyledDiv = styled.div`
-  color: ${applyTheme("accountProfileInfoColor")};
+const AccountProfileInfoContainer = styled.div`
+  display: flex;
+  position: relative;
 `;
+
+const AccountProfileInfoTextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  position: relative;
+`;
+
+const ViewerInitialsCircle = styled.div`
+  background-color: ${applyTheme("viewerInfoInitialsBackgroundColor")};
+  border-radius: 50%;
+  height: ${applyTheme("accountProfileInfoInitialsSize")};
+  text-align: center;
+  width: ${applyTheme("accountProfileInfoInitialsSize")};
+`;
+
+const ViewerInitialsText = styled.div`
+  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
+  color: ${applyTheme("viewerInfoInitialsColor")};
+  line-height: 1;
+  position: relative;
+  top: calc(${applyTheme("viewerInfoInitialsSize")} / 4);
+`;
+
+const ViewerEmailText = styled.span`
+  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
+  color: ${applyTheme("accountProfileInfoEmailFontColor")};
+  font-size: ${applyTheme("accountProfileInfoEmailFontSize")};
+  align-self: left;
+  margin-bottom: 0.75rem;
+  margin-left: 1.0rem;
+`;
+
+const ViewerNameText = styled.span`
+  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
+  font-size: ${applyTheme("accountProfileInfoNameFontSize")};
+  align-self: left;
+  margin-bottom: 0.25rem;
+  margin-left: 1.0rem;
+`;
+
+const ViewerProfileEditText = styled.span`
+  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
+  color: ${applyTheme("accountProfileInfoEmailFontColor")};
+  font-size: ${applyTheme("accountProfileInfoEmailFontSize")};
+  align-self: left;
+  margin-left: 1.0rem;
+`;
+
 
 class AccountProfileInfo extends Component {
   static propTypes = {
     /**
-     * You can provide a `className` prop that will be applied to the outermost DOM element
-     * rendered by this component. We do not recommend using this for styling purposes, but
-     * it can be useful as a selector in some situations.
+     * Enable this prop when you only want to display the Edit account link
      */
-    className: PropTypes.string,
+    editable: PropTypes.bool,
     /**
-     * If you've set up a components context using
-     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
-     * (recommended), then this prop will come from there automatically. If you have not
-     * set up a components context or you want to override one of the components in a
-     * single spot, you can pass in the components prop directly.
+     * An object containing basic user information.
      */
-    components: PropTypes.shape({
+    viewer: PropTypes.shape({
+      firstName: PropTypes.string.isRequired,
+      lastName: PropTypes.string.isRequired,
+      primaryEmailAddress: PropTypes.string.isRequired
     }).isRequired
   };
 
   static defaultProps = {
-
+    editable: false
   };
 
-  render() {
-    const { className } = this.props;
+  /**
+   *
+   * @name viewerInitials
+   * @summary Build the initials string from the `viewer` first and last name
+   * If those props are not availible use the first letter of the primary email address.
+   * @return {String} the viewers initials. (Patricia Smith => PS, Olamide => O, james.booker@ponderosafarms.com => J)
+   */
+  get viewerInitials() {
+    const { viewer: { firstName, lastName, primaryEmailAddress } } = this.props;
+    const firstInitial = (firstName && firstName.charAt()) || primaryEmailAddress.charAt().toUpperCase();
+    const lastInitial = (lastName && lastName.charAt()) || "";
+    return `${firstInitial}${lastInitial}`;
+  }
 
+  /**
+   *
+   * @name viewerEmail
+   * @summary Return viewer email address
+   * @return {String} the viewers email address.
+   */
+  get viewerPrimaryEmailAddress() {
+    const { viewer: { primaryEmailAddress } } = this.props;
+    return primaryEmailAddress;
+  }
+
+  /**
+   *
+   * @name viewerName
+   * @summary If `firstName` is availible on the `viewer` object
+   * return that else return the email address
+   * @return {String} the viewers name.
+   */
+  get viewerName() {
+    const { viewer: { name } } = this.props;
+    return name;
+  }
+
+  viewerProfileEditLink = () => {
+    const { editable } = this.props;
+
+    if (editable) {
+      return (
+        <ViewerProfileEditText>
+          Edit account
+        </ViewerProfileEditText>
+      );
+    }
+    return null;
+  }
+
+  render() {
     return (
-      <StyledDiv className={className}>TEST</StyledDiv>
+      <AccountProfileInfoContainer>
+        <ViewerInitialsCircle>
+          <ViewerInitialsText>{this.viewerInitials}</ViewerInitialsText>
+        </ViewerInitialsCircle>
+        <AccountProfileInfoTextContainer>
+          <ViewerNameText>
+            {this.viewerName}
+          </ViewerNameText>
+          <ViewerEmailText>
+            {this.viewerPrimaryEmailAddress}
+          </ViewerEmailText>
+          {this.viewerProfileEditLink()}
+        </AccountProfileInfoTextContainer>
+      </AccountProfileInfoContainer>
     );
   }
 }

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -14,6 +14,7 @@ const AccountProfileInfoTextContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  margin-left: ${applyTheme("accountProfileInfoSpacingBetweenImageAndContent")};
   position: relative;
 `;
 
@@ -21,14 +22,12 @@ const ViewerEmailText = styled.span`
   ${addTypographyStyles("AccountProfileInfoEmail", "labelText")}
   align-self: left;
   margin-bottom: ${applyTheme("accountProfileInfoSpacingAfterEmail")};
-  margin-left: ${applyTheme("accountProfileInfoSpacingBetweenImageAndContent")};
 `;
 
 const ViewerNameText = styled.span`
   ${addTypographyStyles("AccountProfileInfoName", "titleTextBold")}
   align-self: left;
   margin-bottom: ${applyTheme("accountProfileInfoSpacingAfterName")};
-  margin-left: ${applyTheme("accountProfileInfoSpacingBetweenImageAndContent")};
 `;
 
 class AccountProfileInfo extends Component {

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -2,7 +2,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { withComponents } from "@reactioncommerce/components-context";
-import { addTypographyStyles, applyTheme } from "../../../utils";
+import { addTypographyStyles, applyTheme, CustomPropTypes } from "../../../utils";
+
 
 const AccountProfileInfoContainer = styled.div`
   display: flex;
@@ -43,7 +44,7 @@ class AccountProfileInfo extends Component {
       /**
        * An element to show to link to the edit profile page
        */
-      Button: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      Button: CustomPropTypes.component,
       /**
      * Profile image component to display
      */

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -101,7 +101,7 @@ class AccountProfileInfo extends Component {
 
     if (shouldShowEditButton) {
       return (
-        <Button isShortHeight isTextOnly onClick={onClickEdit}>Edit Account</Button>
+        <Button isShortHeight isTextOnly isTextOnlyNoPadding onClick={onClickEdit}>Edit Account</Button>
       );
     }
     return null;

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import { withComponents } from "@reactioncommerce/components-context";
 import { addTypographyStyles, applyTheme } from "../../../utils";
 
 const AccountProfileInfoContainer = styled.div`
@@ -13,20 +14,6 @@ const AccountProfileInfoTextContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   position: relative;
-`;
-
-const ViewerImageCircle = styled.div`
-  background-color: ${applyTheme("viewerInfoInitialsBackgroundColor")};
-  border-radius: 50%;
-  height: ${applyTheme("accountProfileInfoInitialsSize")};
-  text-align: center;
-  width: ${applyTheme("accountProfileInfoInitialsSize")};
-`;
-
-const ViewerImage = styled.img`
-  border-radius: 50%;
-  height: ${applyTheme("accountProfileInfoInitialsSize")};
-  width: ${applyTheme("accountProfileInfoInitialsSize")};
 `;
 
 const ViewerEmailText = styled.span`
@@ -46,17 +33,12 @@ const ViewerNameText = styled.span`
   margin-left: 1.0rem;
 `;
 
-const ViewerProfileEditText = styled.span`
-  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
-  color: ${applyTheme("accountProfileInfoEmailFontColor")};
-  font-size: ${applyTheme("accountProfileInfoEmailFontSize")};
-  align-self: left;
-  margin-left: 1.0rem;
-`;
-
-
 class AccountProfileInfo extends Component {
   static propTypes = {
+    components: PropTypes.shape({
+      Button: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      ProfileImage: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+    }),
     /**
      * Enable this prop when you only want to display the Edit account link
      */
@@ -69,27 +51,13 @@ class AccountProfileInfo extends Component {
       lastName: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       primaryEmailAddress: PropTypes.string.isRequired,
-      profileImage: PropTypes.string.isRequired
+      profileImage: PropTypes.string
     }).isRequired
   };
 
   static defaultProps = {
     editable: false
   };
-
-  /**
-   *
-   * @name viewerInitials
-   * @summary Build the initials string from the `viewer` first and last name
-   * If those props are not availible use the first letter of the primary email address.
-   * @return {String} the viewers initials. (Patricia Smith => PS, Olamide => O, james.booker@ponderosafarms.com => J)
-   */
-  get viewerInitials() {
-    const { viewer: { firstName, lastName, primaryEmailAddress } } = this.props;
-    const firstInitial = (firstName && firstName.charAt()) || primaryEmailAddress.charAt().toUpperCase();
-    const lastInitial = (lastName && lastName.charAt()) || "";
-    return `${firstInitial}${lastInitial}`;
-  }
 
   /**
    *
@@ -114,33 +82,23 @@ class AccountProfileInfo extends Component {
     return name;
   }
 
-  viewerProfileImage = () => {
-    const { viewer: { name, profileImage } } = this.props;
-
-    return (
-      <ViewerImage alt={name} src={profileImage} />
-    );
-  }
-
   viewerProfileEditLink = () => {
-    const { editable } = this.props;
+    const { components: { Button }, editable } = this.props;
 
     if (editable) {
       return (
-        <ViewerProfileEditText>
-          Edit account
-        </ViewerProfileEditText>
+        <Button isShortHeight={true} isTextOnly={true}>Edit Account</Button>
       );
     }
     return null;
   }
 
   render() {
+    const { components: { ProfileImage }, viewer } = this.props;
+
     return (
       <AccountProfileInfoContainer>
-        <ViewerImageCircle>
-          {this.viewerProfileImage()}
-        </ViewerImageCircle>
+        <ProfileImage viewer={viewer} />
         <AccountProfileInfoTextContainer>
           <ViewerNameText>
             {this.viewerName}
@@ -155,4 +113,4 @@ class AccountProfileInfo extends Component {
   }
 }
 
-export default AccountProfileInfo;
+export default withComponents(AccountProfileInfo);

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -17,20 +17,17 @@ const AccountProfileInfoTextContainer = styled.div`
 `;
 
 const ViewerEmailText = styled.span`
-  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
-  color: ${applyTheme("accountProfileInfoEmailFontColor")};
-  font-size: ${applyTheme("accountProfileInfoEmailFontSize")};
+  ${addTypographyStyles("AccountProfileInfoEmail", "captionText")}
   align-self: left;
-  margin-bottom: 4px;
-  margin-left: 16px;
+  margin-bottom: ${applyTheme("accountProfileInfoSpacingAfterEmail")};
+  margin-left: ${applyTheme("accountProfileInfoSpacingBetweenImageAndContent")};
 `;
 
 const ViewerNameText = styled.span`
-  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
-  font-size: ${applyTheme("accountProfileInfoNameFontSize")};
+  ${addTypographyStyles("AccountProfileInfoName", "titleTextBold")}
   align-self: left;
-  margin-bottom: 4px;
-  margin-left: 16px;
+  margin-bottom: ${applyTheme("accountProfileInfoSpacingAfterName")};
+  margin-left: ${applyTheme("accountProfileInfoSpacingBetweenImageAndContent")};
 `;
 
 class AccountProfileInfo extends Component {
@@ -104,7 +101,7 @@ class AccountProfileInfo extends Component {
 
     if (shouldShowEditButton) {
       return (
-        <Button isShortHeight={true} isTextOnly={true} onClick={onClickEdit} style={{ padding: "5px 15px" }}>Edit Account</Button>
+        <Button isShortHeight isTextOnly onClick={onClickEdit}>Edit Account</Button>
       );
     }
     return null;

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -15,7 +15,7 @@ const AccountProfileInfoTextContainer = styled.div`
   position: relative;
 `;
 
-const ViewerInitialsCircle = styled.div`
+const ViewerImageCircle = styled.div`
   background-color: ${applyTheme("viewerInfoInitialsBackgroundColor")};
   border-radius: 50%;
   height: ${applyTheme("accountProfileInfoInitialsSize")};
@@ -23,12 +23,10 @@ const ViewerInitialsCircle = styled.div`
   width: ${applyTheme("accountProfileInfoInitialsSize")};
 `;
 
-const ViewerInitialsText = styled.div`
-  ${addTypographyStyles("ViewerInfoInitials", "labelText")}
-  color: ${applyTheme("viewerInfoInitialsColor")};
-  line-height: 1;
-  position: relative;
-  top: calc(${applyTheme("viewerInfoInitialsSize")} / 4);
+const ViewerImage = styled.img`
+  border-radius: 50%;
+  height: ${applyTheme("accountProfileInfoInitialsSize")};
+  width: ${applyTheme("accountProfileInfoInitialsSize")};
 `;
 
 const ViewerEmailText = styled.span`
@@ -70,7 +68,8 @@ class AccountProfileInfo extends Component {
       firstName: PropTypes.string.isRequired,
       lastName: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      primaryEmailAddress: PropTypes.string.isRequired
+      primaryEmailAddress: PropTypes.string.isRequired,
+      profileImage: PropTypes.string.isRequired
     }).isRequired
   };
 
@@ -115,6 +114,14 @@ class AccountProfileInfo extends Component {
     return name;
   }
 
+  viewerProfileImage = () => {
+    const { viewer: { name, profileImage } } = this.props;
+
+    return (
+      <ViewerImage alt={name} src={profileImage} />
+    );
+  }
+
   viewerProfileEditLink = () => {
     const { editable } = this.props;
 
@@ -131,9 +138,9 @@ class AccountProfileInfo extends Component {
   render() {
     return (
       <AccountProfileInfoContainer>
-        <ViewerInitialsCircle>
-          <ViewerInitialsText>{this.viewerInitials}</ViewerInitialsText>
-        </ViewerInitialsCircle>
+        <ViewerImageCircle>
+          {this.viewerProfileImage()}
+        </ViewerImageCircle>
         <AccountProfileInfoTextContainer>
           <ViewerNameText>
             {this.viewerName}

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -1,0 +1,42 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { applyTheme } from "../../../utils";
+
+const StyledDiv = styled.div`
+  color: ${applyTheme("accountProfileInfoColor")};
+`;
+
+class AccountProfileInfo extends Component {
+  static propTypes = {
+    /**
+     * You can provide a `className` prop that will be applied to the outermost DOM element
+     * rendered by this component. We do not recommend using this for styling purposes, but
+     * it can be useful as a selector in some situations.
+     */
+    className: PropTypes.string,
+    /**
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
+    components: PropTypes.shape({
+    }).isRequired
+  };
+
+  static defaultProps = {
+
+  };
+
+  render() {
+    const { className } = this.props;
+
+    return (
+      <StyledDiv className={className}>TEST</StyledDiv>
+    );
+  }
+}
+
+export default AccountProfileInfo;

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
@@ -1,0 +1,4 @@
+### Overview
+#### Usage
+
+Document component here. See https://react-styleguidist.js.org/docs/documenting.html

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
@@ -29,7 +29,6 @@ const viewer = {
 **With edit link**
 ```jsx
 const viewer = {
-  editable: true,
   firstName: "John",
   lastName: "Doe",
   name: "John Doe",
@@ -37,5 +36,7 @@ const viewer = {
   profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
 };
 
-<AccountProfileInfo editable={true} viewer={viewer} />
+const onClick = () => { console.log("Edit Account button click") };
+
+<AccountProfileInfo onClickEdit={onClick} shouldShowEditButton={true} viewer={viewer} />
 ```

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
@@ -7,7 +7,8 @@ const viewer = {
   firstName: "John",
   lastName: "Doe",
   name: "John Doe",
-  primaryEmailAddress: "john@doe.com"
+  primaryEmailAddress: "john@doe.com",
+  profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
 };
 
 <AccountProfileInfo viewer={viewer} />
@@ -20,7 +21,8 @@ const viewer = {
   firstName: "John",
   lastName: "Doe",
   name: "John Doe",
-  primaryEmailAddress: "john@doe.com"
+  primaryEmailAddress: "john@doe.com",
+  profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
 };
 
 <AccountProfileInfo editable={true} viewer={viewer} />

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
@@ -1,5 +1,5 @@
 ### Overview
-Renders the current users ("viewer") name, email address, profile image (provided by gravatar), and an optional link to edit this information.
+Renders the viewers name, email address, profile image (via the [ProfileImage](/#!/ProfileImage) component), and an optional link to edit this information.
 
 #### Usage
 ```jsx
@@ -14,6 +14,18 @@ const viewer = {
 <AccountProfileInfo viewer={viewer} />
 ```
 
+**With initials (when profileImage is null)**
+```jsx
+const viewer = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com"
+};
+
+<AccountProfileInfo viewer={viewer} />
+
+```
 **With edit link**
 ```jsx
 const viewer = {

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
@@ -1,4 +1,27 @@
 ### Overview
-#### Usage
+Renders the current users ("viewer") name, email address, profile image (provided by gravatar), and an optional link to edit this information.
 
-Document component here. See https://react-styleguidist.js.org/docs/documenting.html
+#### Usage
+```jsx
+const viewer = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com"
+};
+
+<AccountProfileInfo viewer={viewer} />
+```
+
+**With edit link**
+```jsx
+const viewer = {
+  editable: true,
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com"
+};
+
+<AccountProfileInfo editable={true} viewer={viewer} />
+```

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
@@ -1,5 +1,5 @@
 ### Overview
-Renders the viewers name, email address, profile image (via the [ProfileImage](/#!/ProfileImage) component), and an optional link to edit this information.
+Renders the viewer's name, email address, profile image (via the [ProfileImage](/#!/ProfileImage) component), and an optional link to edit this information.
 
 #### Usage
 ```jsx

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
@@ -1,11 +1,51 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow } from "enzyme";
-import AccountProfileInfo from "./AccountProfileInfo";
+import ViewerInfo from "./ViewerInfo";
 
-test("basic snapshot", () => {
-  const component = renderer.create(<AccountProfileInfo />);
+test("Render with only required props", () => {
+  const mockViewer = {
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
 
+test("Render with only email & first name props", () => {
+  const mockViewer = {
+    firstName: "Issac",
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Render with full name and email props", () => {
+  const mockViewer = {
+    firstName: "Issac",
+    lastName: "Newton",
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Render with full prop", () => {
+  const mockViewer = {
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} full />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Render with compact prop", () => {
+  const mockViewer = {
+    primaryEmailAddress: "email@domain.com"
+  };
+  const component = renderer.create(<ViewerInfo viewer={mockViewer} compact />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
@@ -1,51 +1,46 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import ViewerInfo from "./ViewerInfo";
+import AccountProfileInfo from "./AccountProfileInfo";
 
-test("Render with only required props", () => {
+test("Render default display, with profile image and no edit link", () => {
   const mockViewer = {
-    primaryEmailAddress: "email@domain.com"
+    firstName: "John",
+    lastName: "Doe",
+    name: "John Doe",
+    primaryEmailAddress: "john@doe.com",
+    profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
   };
-  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
+
+  const component = renderer.create(<AccountProfileInfo viewer={mockViewer} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-test("Render with only email & first name props", () => {
+test("Render with initials instead of profile image", () => {
   const mockViewer = {
-    firstName: "Issac",
-    primaryEmailAddress: "email@domain.com"
+    firstName: "John",
+    lastName: "Doe",
+    name: "John Doe",
+    primaryEmailAddress: "john@doe.com"
   };
-  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
+
+  const component = renderer.create(<AccountProfileInfo viewer={mockViewer} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-test("Render with full name and email props", () => {
+test("Render with edit link", () => {
   const mockViewer = {
-    firstName: "Issac",
-    lastName: "Newton",
-    primaryEmailAddress: "email@domain.com"
+    firstName: "John",
+    lastName: "Doe",
+    name: "John Doe",
+    primaryEmailAddress: "john@doe.com",
+    profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
   };
-  const component = renderer.create(<ViewerInfo viewer={mockViewer} />);
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
 
-test("Render with full prop", () => {
-  const mockViewer = {
-    primaryEmailAddress: "email@domain.com"
-  };
-  const component = renderer.create(<ViewerInfo viewer={mockViewer} full />);
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  const clickSpy = jest.fn();
 
-test("Render with compact prop", () => {
-  const mockViewer = {
-    primaryEmailAddress: "email@domain.com"
-  };
-  const component = renderer.create(<ViewerInfo viewer={mockViewer} compact />);
+  const component = renderer.create(<AccountProfileInfo onClickEdit={clickSpy} shouldShowEditButton={true} viewer={mockViewer} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import AccountProfileInfo from "./AccountProfileInfo";
+
+test("basic snapshot", () => {
+  const component = renderer.create(<AccountProfileInfo />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import mockComponents from "../../../tests/mockComponents";
 import AccountProfileInfo from "./AccountProfileInfo";
 
 test("Render default display, with profile image and no edit link", () => {
@@ -11,7 +12,7 @@ test("Render default display, with profile image and no edit link", () => {
     profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
   };
 
-  const component = renderer.create(<AccountProfileInfo viewer={mockViewer} />);
+  const component = renderer.create(<AccountProfileInfo components={mockComponents} viewer={mockViewer} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -24,7 +25,7 @@ test("Render with initials instead of profile image", () => {
     primaryEmailAddress: "john@doe.com"
   };
 
-  const component = renderer.create(<AccountProfileInfo viewer={mockViewer} />);
+  const component = renderer.create(<AccountProfileInfo components={mockComponents} viewer={mockViewer} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -40,7 +41,7 @@ test("Render with edit link", () => {
 
   const clickSpy = jest.fn();
 
-  const component = renderer.create(<AccountProfileInfo onClickEdit={clickSpy} shouldShowEditButton={true} viewer={mockViewer} />);
+  const component = renderer.create(<AccountProfileInfo components={mockComponents} onClickEdit={clickSpy} shouldShowEditButton={true} viewer={mockViewer} />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/package/src/components/AccountProfileInfo/v1/__snapshots__/AccountProfileInfo.test.js.snap
+++ b/package/src/components/AccountProfileInfo/v1/__snapshots__/AccountProfileInfo.test.js.snap
@@ -21,6 +21,7 @@ exports[`Render default display, with profile image and no edit link 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-left: 16px;
   position: relative;
 }
 
@@ -41,7 +42,6 @@ exports[`Render default display, with profile image and no edit link 1`] = `
   -ms-flex-item-align: left;
   align-self: left;
   margin-bottom: 4px;
-  margin-left: 16px;
 }
 
 .c2 {
@@ -61,7 +61,6 @@ exports[`Render default display, with profile image and no edit link 1`] = `
   -ms-flex-item-align: left;
   align-self: left;
   margin-bottom: 4px;
-  margin-left: 16px;
 }
 
 <div
@@ -106,6 +105,7 @@ exports[`Render with edit link 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-left: 16px;
   position: relative;
 }
 
@@ -126,7 +126,6 @@ exports[`Render with edit link 1`] = `
   -ms-flex-item-align: left;
   align-self: left;
   margin-bottom: 4px;
-  margin-left: 16px;
 }
 
 .c2 {
@@ -146,7 +145,6 @@ exports[`Render with edit link 1`] = `
   -ms-flex-item-align: left;
   align-self: left;
   margin-bottom: 4px;
-  margin-left: 16px;
 }
 
 <div
@@ -192,6 +190,7 @@ exports[`Render with initials instead of profile image 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-left: 16px;
   position: relative;
 }
 
@@ -212,7 +211,6 @@ exports[`Render with initials instead of profile image 1`] = `
   -ms-flex-item-align: left;
   align-self: left;
   margin-bottom: 4px;
-  margin-left: 16px;
 }
 
 .c2 {
@@ -232,7 +230,6 @@ exports[`Render with initials instead of profile image 1`] = `
   -ms-flex-item-align: left;
   align-self: left;
   margin-bottom: 4px;
-  margin-left: 16px;
 }
 
 <div

--- a/package/src/components/AccountProfileInfo/v1/__snapshots__/AccountProfileInfo.test.js.snap
+++ b/package/src/components/AccountProfileInfo/v1/__snapshots__/AccountProfileInfo.test.js.snap
@@ -26,7 +26,7 @@ exports[`Render default display, with profile image and no edit link 1`] = `
 
 .c3 {
   -webkit-font-smoothing: antialiased;
-  color: #b3b3b3;
+  color: #505558;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   font-style: normal;
@@ -111,7 +111,7 @@ exports[`Render with edit link 1`] = `
 
 .c3 {
   -webkit-font-smoothing: antialiased;
-  color: #b3b3b3;
+  color: #505558;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   font-style: normal;
@@ -197,7 +197,7 @@ exports[`Render with initials instead of profile image 1`] = `
 
 .c3 {
   -webkit-font-smoothing: antialiased;
-  color: #b3b3b3;
+  color: #505558;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   font-style: normal;

--- a/package/src/components/AccountProfileInfo/v1/__snapshots__/AccountProfileInfo.test.js.snap
+++ b/package/src/components/AccountProfileInfo/v1/__snapshots__/AccountProfileInfo.test.js.snap
@@ -1,0 +1,257 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render default display, with profile image and no edit link 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+}
+
+.c3 {
+  -webkit-font-smoothing: antialiased;
+  color: #b3b3b3;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  -webkit-align-self: left;
+  -ms-flex-item-align: left;
+  align-self: left;
+  margin-bottom: 4px;
+  margin-left: 16px;
+}
+
+.c2 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 24px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 700;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.25;
+  -webkit-align-self: left;
+  -ms-flex-item-align: left;
+  align-self: left;
+  margin-bottom: 4px;
+  margin-left: 16px;
+}
+
+<div
+  className="c0"
+>
+  ProfileImage(undefined)
+  <div
+    className="c1"
+  >
+    <span
+      className="c2"
+    >
+      John Doe
+    </span>
+    <span
+      className="c3"
+    >
+      john@doe.com
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Render with edit link 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+}
+
+.c3 {
+  -webkit-font-smoothing: antialiased;
+  color: #b3b3b3;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  -webkit-align-self: left;
+  -ms-flex-item-align: left;
+  align-self: left;
+  margin-bottom: 4px;
+  margin-left: 16px;
+}
+
+.c2 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 24px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 700;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.25;
+  -webkit-align-self: left;
+  -ms-flex-item-align: left;
+  align-self: left;
+  margin-bottom: 4px;
+  margin-left: 16px;
+}
+
+<div
+  className="c0"
+>
+  ProfileImage(undefined)
+  <div
+    className="c1"
+  >
+    <span
+      className="c2"
+    >
+      John Doe
+    </span>
+    <span
+      className="c3"
+    >
+      john@doe.com
+    </span>
+    Button(undefined)
+  </div>
+</div>
+`;
+
+exports[`Render with initials instead of profile image 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+}
+
+.c3 {
+  -webkit-font-smoothing: antialiased;
+  color: #b3b3b3;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  -webkit-align-self: left;
+  -ms-flex-item-align: left;
+  align-self: left;
+  margin-bottom: 4px;
+  margin-left: 16px;
+}
+
+.c2 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 24px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 700;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.25;
+  -webkit-align-self: left;
+  -ms-flex-item-align: left;
+  align-self: left;
+  margin-bottom: 4px;
+  margin-left: 16px;
+}
+
+<div
+  className="c0"
+>
+  ProfileImage(undefined)
+  <div
+    className="c1"
+  >
+    <span
+      className="c2"
+    >
+      John Doe
+    </span>
+    <span
+      className="c3"
+    >
+      john@doe.com
+    </span>
+  </div>
+</div>
+`;

--- a/package/src/components/AccountProfileInfo/v1/index.js
+++ b/package/src/components/AccountProfileInfo/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AccountProfileInfo";

--- a/package/src/components/Button/v1/Button.js
+++ b/package/src/components/Button/v1/Button.js
@@ -40,8 +40,20 @@ const ButtonDiv = styled.div`
   margin: 0;
   min-width: ${applyTheme("buttonMinimumWidth")};
   outline: none;
-  padding-left: ${applyTheme("buttonHorizontalPadding")};
-  padding-right: ${applyTheme("buttonHorizontalPadding")};
+  padding-left: ${(props) => {
+    const { isTextOnlyNoPadding } = props;
+    if (isTextOnlyNoPadding) {
+      return "0px";
+    }
+    return applyTheme("buttonHorizontalPadding");
+  }};
+  padding-right: ${(props) => {
+    const { isTextOnlyNoPadding } = props;
+    if (isTextOnlyNoPadding) {
+      return "0px";
+    }
+    return applyTheme("buttonHorizontalPadding");
+  }};
   padding-top: ${paddingFunc};
   padding-bottom: ${paddingFunc};
   position: relative;
@@ -126,6 +138,10 @@ class Button extends Component {
      */
     isTextOnly: PropTypes.bool,
     /**
+     * Enable this in rare cases where left and right padding should be removed from a button to better align the button.
+     */
+    isTextOnlyNoPadding: PropTypes.bool,
+    /**
      * Set to `true` to prevent clicks, use waiting styles, and show a spinner
      */
     isWaiting: PropTypes.bool,
@@ -161,7 +177,7 @@ class Button extends Component {
   };
 
   render() {
-    const { actionType, children, className, components, isDisabled, isFullWidth, isShortHeight, isTextOnly, isWaiting, title } = this.props;
+    const { actionType, children, className, components, isDisabled, isFullWidth, isShortHeight, isTextOnly, isTextOnlyNoPadding, isWaiting, title } = this.props;
     const { spinner } = components || {};
 
     const moreButtonDivProps = {};
@@ -195,6 +211,7 @@ class Button extends Component {
         isDisabled={isDisabled}
         isShortHeight={isShortHeight}
         isTextOnly={isTextOnly}
+        isTextOnlyNoPadding={isTextOnlyNoPadding}
         onClick={this.handleClick}
         onKeyPress={this.handleKeyPress}
         role="button"
@@ -208,6 +225,7 @@ class Button extends Component {
             actionType={actionType}
             isDisabled={isDisabled}
             isTextOnly={isTextOnly}
+            isTextOnlyNoPadding={isTextOnlyNoPadding}
             style={spinnerStyles}
           >
             {spinner}

--- a/package/src/components/Button/v1/Button.js
+++ b/package/src/components/Button/v1/Button.js
@@ -29,8 +29,8 @@ const ButtonDiv = styled.div`
     return "pointer";
   }};
   display: ${(props) => {
-    const { fullWidth } = props;
-    if (fullWidth) {
+    const { isFullWidth } = props;
+    if (isFullWidth) {
       return "flex";
     }
     return "inline-flex";
@@ -207,8 +207,8 @@ class Button extends Component {
       <ButtonDiv
         actionType={actionType}
         className={className}
-        fullWidth={isFullWidth}
         isDisabled={isDisabled}
+        isFullWidth={isFullWidth}
         isShortHeight={isShortHeight}
         isTextOnly={isTextOnly}
         isTextOnlyNoPadding={isTextOnlyNoPadding}

--- a/package/src/components/Button/v1/Button.js
+++ b/package/src/components/Button/v1/Button.js
@@ -38,26 +38,27 @@ const ButtonDiv = styled.div`
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, sans-serif;
   justify-content: center;
   margin: 0;
-  min-width: ${applyTheme("buttonMinimumWidth")};
+  min-width: ${(props) => (props.isTextOnlyNoPadding ? 0 : applyTheme("buttonMinimumWidth")(props))};
   outline: none;
   padding-left: ${(props) => {
     const { isTextOnlyNoPadding } = props;
     if (isTextOnlyNoPadding) {
       return "0px";
     }
-    return applyTheme("buttonHorizontalPadding");
+    return applyTheme("buttonHorizontalPadding")(props);
   }};
   padding-right: ${(props) => {
     const { isTextOnlyNoPadding } = props;
     if (isTextOnlyNoPadding) {
       return "0px";
     }
-    return applyTheme("buttonHorizontalPadding");
+    return applyTheme("buttonHorizontalPadding")(props);
   }};
   padding-top: ${paddingFunc};
   padding-bottom: ${paddingFunc};
   position: relative;
   text-align: center;
+  width: ${(props) => (props.isFullWidth ? "100%" : "fit-content")};
 
   &:hover {
     background-color: ${applyThemeWithActionType("buttonBackgroundColor", "hover")};

--- a/package/src/components/Button/v1/Button.md
+++ b/package/src/components/Button/v1/Button.md
@@ -308,7 +308,7 @@ const onClick = () => { setState({ isWaiting: true }); setTimeout(() => { setSta
 
 ##### Full Width Button
 
-To make any button take up the full width of its container, add `fullWidth` prop.
+To make any button take up the full width of its container, add `isFullWidth` prop.
 
 ```jsx
 const divStyles = {
@@ -326,8 +326,8 @@ const divStyles = {
 };
 
 <div style={divStyles}>
-  <Button className="myBtn" fullWidth>Full Width Default</Button>
-  <Button className="myBtn" isShortHeight fullWidth>Full Width Default Short</Button>
+  <Button className="myBtn" isFullWidth>Full Width Default</Button>
+  <Button className="myBtn" isShortHeight isFullWidth>Full Width Default Short</Button>
   <Button className="myBtn" isWaiting={state.isWaiting} onClick={() => { setState({ isWaiting: true }); setTimeout(() => { setState({ isWaiting: false }); }, 3000); }}>Click to See Waiting</Button>
 </div>
 ```

--- a/package/src/components/Button/v1/Button.md
+++ b/package/src/components/Button/v1/Button.md
@@ -32,6 +32,7 @@ And there are a couple possible variations:
 
 - **Short**: Any of these button types can be rendered with less height using the "short" variant.
 - **Text-only**: The default button can be rendered as text only (similar to a link) by using the "text" style variant. Use this in rare cases where having a solid or outline button for an action would be cluttered and visually confusing.
+- **Text-only, no padding**: This expands on the text-only version of the button, and removes the left and right padding to create a more inline look, when needed.
 - **Waiting**: This disables clicks and shows a spinner to the right of the button content when `isWaiting` is set to `true`.
 
 ```jsx noeditor
@@ -41,6 +42,9 @@ And there are a couple possible variations:
   </div>
   <div style={{ marginRight: "1rem" }}>
     <Button title="Default" className="myBtn" isTextOnly>Default Text-Only</Button>
+  </div>
+  <div style={{ marginRight: "1rem" }}>
+    <Button title="Default" className="myBtn" isTextOnly isTextOnlyNoPadding>Default Text-Only No Padding</Button>
   </div>
   <div style={{ marginRight: "1rem" }}>
     <Button actionType="default" isWaiting={true}>Default Waiting</Button>

--- a/package/src/components/Button/v1/Button.md
+++ b/package/src/components/Button/v1/Button.md
@@ -327,8 +327,8 @@ const divStyles = {
 
 <div style={divStyles}>
   <Button className="myBtn" isFullWidth>Full Width Default</Button>
-  <Button className="myBtn" isShortHeight isFullWidth>Full Width Default Short</Button>
-  <Button className="myBtn" isWaiting={state.isWaiting} onClick={() => { setState({ isWaiting: true }); setTimeout(() => { setState({ isWaiting: false }); }, 3000); }}>Click to See Waiting</Button>
+  <Button className="myBtn" isFullWidth isShortHeight>Full Width Default Short</Button>
+  <Button className="myBtn" isFullWidth isWaiting={state.isWaiting} onClick={() => { setState({ isWaiting: true }); setTimeout(() => { setState({ isWaiting: false }); }, 3000); }}>Click to See Waiting</Button>
 </div>
 ```
 

--- a/package/src/components/Button/v1/__snapshots__/Button.test.js.snap
+++ b/package/src/components/Button/v1/__snapshots__/Button.test.js.snap
@@ -33,6 +33,9 @@ exports[`basic snapshot 1`] = `
   padding-bottom: 10px;
   position: relative;
   text-align: center;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
 }
 
 .c0:hover {

--- a/package/src/components/CartEmptyMessage/v1/__snapshots__/CartEmptyMessage.test.js.snap
+++ b/package/src/components/CartEmptyMessage/v1/__snapshots__/CartEmptyMessage.test.js.snap
@@ -63,6 +63,9 @@ Array [
   padding-bottom: 10px;
   position: relative;
   text-align: center;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
 }
 
 .c1:hover {
@@ -196,6 +199,9 @@ Array [
   padding-bottom: 10px;
   position: relative;
   text-align: center;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
 }
 
 .c1:hover {

--- a/package/src/components/ProfileImage/v1/ProfileImage.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.js
@@ -14,7 +14,6 @@ const ViewerImageCircle = styled.div`
 
 const ViewerInitialsText = styled.div`
   ${addTypographyStyles("ProfileImageInitials", "labelText")}
-  color: ${applyTheme("profileImageInitialsColor")};
   display: flex;
   line-height: 1;
 `;

--- a/package/src/components/ProfileImage/v1/ProfileImage.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.js
@@ -8,10 +8,8 @@ const ViewerImageCircle = styled.div`
   background-color: ${applyTheme("profileImageBackgroundColor")};
   border-radius: 50%;
   display: flex;
-  height: 100%;
   justify-content: center;
   text-align: center;
-  width: 100%;
 `;
 
 const ViewerInitialsText = styled.div`
@@ -30,6 +28,10 @@ const ViewerImage = styled.img`
 class ProfileImage extends Component {
   static propTypes = {
     /**
+     * Size of profile image, in pixels
+     */
+    size: PropTypes.number,
+    /**
      * An object containing basic user information.
      */
     viewer: PropTypes.shape({
@@ -42,7 +44,7 @@ class ProfileImage extends Component {
   };
 
   static defaultProps = {
-
+    size: 80
   };
 
   /**
@@ -73,8 +75,10 @@ class ProfileImage extends Component {
 
 
   render() {
+    const { size } = this.props;
+
     return (
-      <ViewerImageCircle>
+      <ViewerImageCircle style={{ height: `${size}px`, width: `${size}px` }}>
         {this.viewerProfileImage()}
       </ViewerImageCircle>
     );

--- a/package/src/components/ProfileImage/v1/ProfileImage.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.js
@@ -1,28 +1,42 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { applyTheme } from "../../../utils";
+import { addTypographyStyles, applyTheme } from "../../../utils";
 
-const StyledDiv = styled.div`
-  color: ${applyTheme("profileImageColor")};
+const ViewerImageCircle = styled.div`
+  background-color: ${applyTheme("profileImageBackgroundColor")};
+  border-radius: 50%;
+  height: ${applyTheme("profileImageInitialsSize")};
+  text-align: center;
+  width: ${applyTheme("profileImageInitialsSize")};
+`;
+
+const ViewerInitialsText = styled.div`
+  ${addTypographyStyles("ProfileImageInitials", "labelText")}
+  color: ${applyTheme("profileImageInitialsColor")};
+  font-size: 2.5em;
+  line-height: 1;
+  position: relative;
+  top: calc(${applyTheme("profileImageInitialsSize")} / 4);
+`;
+
+const ViewerImage = styled.img`
+  border-radius: 50%;
+  height: ${applyTheme("profileImageInitialsSize")};
+  width: ${applyTheme("profileImageInitialsSize")};
 `;
 
 class ProfileImage extends Component {
   static propTypes = {
     /**
-     * You can provide a `className` prop that will be applied to the outermost DOM element
-     * rendered by this component. We do not recommend using this for styling purposes, but
-     * it can be useful as a selector in some situations.
+     * An object containing basic user information.
      */
-    className: PropTypes.string,
-    /**
-     * If you've set up a components context using
-     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
-     * (recommended), then this prop will come from there automatically. If you have not
-     * set up a components context or you want to override one of the components in a
-     * single spot, you can pass in the components prop directly.
-     */
-    components: PropTypes.shape({
+    viewer: PropTypes.shape({
+      firstName: PropTypes.string.isRequired,
+      lastName: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      primaryEmailAddress: PropTypes.string.isRequired,
+      profileImage: PropTypes.string.isRequired
     }).isRequired
   };
 
@@ -30,11 +44,38 @@ class ProfileImage extends Component {
 
   };
 
-  render() {
-    const { className } = this.props;
+  /**
+   *
+   * @name viewerInitials
+   * @summary Build the initials string from the `viewer` first and last name
+   * If those props are not availible use the first letter of the primary email address.
+   * @return {String} the viewers initials. (Patricia Smith => PS, Olamide => O, james.booker@ponderosafarms.com => J)
+   */
+  get viewerInitials() {
+    const { viewer: { firstName, lastName, primaryEmailAddress } } = this.props;
+    const firstInitial = (firstName && firstName.charAt()) || primaryEmailAddress.charAt().toUpperCase();
+    const lastInitial = (lastName && lastName.charAt()) || "";
+    return `${firstInitial}${lastInitial}`;
+  }
 
+  viewerProfileImage = () => {
+    const { viewer: { name, profileImage } } = this.props;
+
+    if (profileImage) {
+      return (
+        <ViewerImage alt={name} src={profileImage} />
+      );
+    }
+
+    return <ViewerInitialsText>{this.viewerInitials}</ViewerInitialsText>;
+  }
+
+
+  render() {
     return (
-      <StyledDiv className={className}>TEST</StyledDiv>
+      <ViewerImageCircle>
+        {this.viewerProfileImage()}
+      </ViewerImageCircle>
     );
   }
 }

--- a/package/src/components/ProfileImage/v1/ProfileImage.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.js
@@ -1,0 +1,42 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { applyTheme } from "../../../utils";
+
+const StyledDiv = styled.div`
+  color: ${applyTheme("profileImageColor")};
+`;
+
+class ProfileImage extends Component {
+  static propTypes = {
+    /**
+     * You can provide a `className` prop that will be applied to the outermost DOM element
+     * rendered by this component. We do not recommend using this for styling purposes, but
+     * it can be useful as a selector in some situations.
+     */
+    className: PropTypes.string,
+    /**
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
+    components: PropTypes.shape({
+    }).isRequired
+  };
+
+  static defaultProps = {
+
+  };
+
+  render() {
+    const { className } = this.props;
+
+    return (
+      <StyledDiv className={className}>TEST</StyledDiv>
+    );
+  }
+}
+
+export default ProfileImage;

--- a/package/src/components/ProfileImage/v1/ProfileImage.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.js
@@ -4,26 +4,27 @@ import styled from "styled-components";
 import { addTypographyStyles, applyTheme } from "../../../utils";
 
 const ViewerImageCircle = styled.div`
+  align-items: center;
   background-color: ${applyTheme("profileImageBackgroundColor")};
   border-radius: 50%;
-  height: ${applyTheme("profileImageInitialsSize")};
+  display: flex;
+  height: 100%;
+  justify-content: center;
   text-align: center;
-  width: ${applyTheme("profileImageInitialsSize")};
+  width: 100%;
 `;
 
 const ViewerInitialsText = styled.div`
   ${addTypographyStyles("ProfileImageInitials", "labelText")}
   color: ${applyTheme("profileImageInitialsColor")};
-  font-size: 2.5em;
+  display: flex;
   line-height: 1;
-  position: relative;
-  top: calc(${applyTheme("profileImageInitialsSize")} / 4);
 `;
 
 const ViewerImage = styled.img`
   border-radius: 50%;
-  height: ${applyTheme("profileImageInitialsSize")};
-  width: ${applyTheme("profileImageInitialsSize")};
+  height: 100%;
+  width: 100%;
 `;
 
 class ProfileImage extends Component {

--- a/package/src/components/ProfileImage/v1/ProfileImage.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.js
@@ -62,7 +62,7 @@ class ProfileImage extends Component {
   }
 
   viewerProfileImage = () => {
-    const { viewer: { name, profileImage } } = this.props;
+    const { size, viewer: { name, profileImage } } = this.props;
 
     if (profileImage) {
       return (
@@ -70,7 +70,7 @@ class ProfileImage extends Component {
       );
     }
 
-    return <ViewerInitialsText>{this.viewerInitials}</ViewerInitialsText>;
+    return <ViewerInitialsText style= {{ fontSize: size / 2 }}>{this.viewerInitials}</ViewerInitialsText>;
   }
 
 

--- a/package/src/components/ProfileImage/v1/ProfileImage.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.js
@@ -35,8 +35,8 @@ class ProfileImage extends Component {
       firstName: PropTypes.string.isRequired,
       lastName: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      primaryEmailAddress: PropTypes.string.isRequired,
-      profileImage: PropTypes.string.isRequired
+      primaryEmailAddress: PropTypes.string,
+      profileImage: PropTypes.string
     }).isRequired
   };
 

--- a/package/src/components/ProfileImage/v1/ProfileImage.md
+++ b/package/src/components/ProfileImage/v1/ProfileImage.md
@@ -1,0 +1,4 @@
+### Overview
+#### Usage
+
+Document component here. See https://react-styleguidist.js.org/docs/documenting.html

--- a/package/src/components/ProfileImage/v1/ProfileImage.md
+++ b/package/src/components/ProfileImage/v1/ProfileImage.md
@@ -26,3 +26,28 @@ const viewer = {
 <ProfileImage viewer={viewer} />
 
 ```
+
+**With custom sizes**
+```jsx
+const viewer = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com"
+};
+
+<ProfileImage size={100} viewer={viewer} />
+
+```
+
+```jsx
+const viewer = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com"
+};
+
+<ProfileImage size={30} viewer={viewer} />
+
+```

--- a/package/src/components/ProfileImage/v1/ProfileImage.md
+++ b/package/src/components/ProfileImage/v1/ProfileImage.md
@@ -1,4 +1,28 @@
 ### Overview
-#### Usage
+Renders the viewers profile image, if provided. Renders the viewers initials if no image is provided.
 
-Document component here. See https://react-styleguidist.js.org/docs/documenting.html
+#### Usage
+```jsx
+const viewer = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com",
+  profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
+};
+
+<ProfileImage viewer={viewer} />
+```
+
+**With initials**
+```jsx
+const viewer = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com"
+};
+
+<ProfileImage viewer={viewer} />
+
+```

--- a/package/src/components/ProfileImage/v1/ProfileImage.test.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.test.js
@@ -25,6 +25,13 @@ test("ProfileImage component with image snapshot", () => {
   expect(tree).toMatchSnapshot();
 });
 
+test("ProfileImage component with custom size", () => {
+  const component = renderer.create(<ProfileImage size={30} viewer={viewer} />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test("ProfileImage component with initials snapshot", () => {
   const component = renderer.create(<ProfileImage viewer={viewerInitials} />);
 

--- a/package/src/components/ProfileImage/v1/ProfileImage.test.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import ProfileImage from "./ProfileImage";
+
+test("basic snapshot", () => {
+  const component = renderer.create(<ProfileImage />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/ProfileImage/v1/ProfileImage.test.js
+++ b/package/src/components/ProfileImage/v1/ProfileImage.test.js
@@ -1,10 +1,32 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow } from "enzyme";
 import ProfileImage from "./ProfileImage";
 
-test("basic snapshot", () => {
-  const component = renderer.create(<ProfileImage />);
+const viewer = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com",
+  profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
+};
+
+const viewerInitials = {
+  firstName: "John",
+  lastName: "Doe",
+  name: "John Doe",
+  primaryEmailAddress: "john@doe.com"
+};
+
+
+test("ProfileImage component with image snapshot", () => {
+  const component = renderer.create(<ProfileImage viewer={viewer} />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("ProfileImage component with initials snapshot", () => {
+  const component = renderer.create(<ProfileImage viewer={viewerInitials} />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/ProfileImage/v1/__snapshots__/ProfileImage.test.js.snap
+++ b/package/src/components/ProfileImage/v1/__snapshots__/ProfileImage.test.js.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProfileImage component with custom size 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #8ce0c9;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.c1 {
+  border-radius: 50%;
+  height: 100%;
+  width: 100%;
+}
+
+<div
+  className="c0"
+  style={
+    Object {
+      "height": "30px",
+      "width": "30px",
+    }
+  }
+>
+  <img
+    alt="John Doe"
+    className="c1"
+    src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
+  />
+</div>
+`;
+
+exports[`ProfileImage component with image snapshot 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #8ce0c9;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.c1 {
+  border-radius: 50%;
+  height: 100%;
+  width: 100%;
+}
+
+<div
+  className="c0"
+  style={
+    Object {
+      "height": "80px",
+      "width": "80px",
+    }
+  }
+>
+  <img
+    alt="John Doe"
+    className="c1"
+    src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
+  />
+</div>
+`;
+
+exports[`ProfileImage component with initials snapshot 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #8ce0c9;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.c1 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  line-height: 1;
+}
+
+<div
+  className="c0"
+  style={
+    Object {
+      "height": "80px",
+      "width": "80px",
+    }
+  }
+>
+  <div
+    className="c1"
+    style={
+      Object {
+        "fontSize": 40,
+      }
+    }
+  >
+    JD
+  </div>
+</div>
+`;

--- a/package/src/components/ProfileImage/v1/__snapshots__/ProfileImage.test.js.snap
+++ b/package/src/components/ProfileImage/v1/__snapshots__/ProfileImage.test.js.snap
@@ -105,7 +105,7 @@ exports[`ProfileImage component with initials snapshot 1`] = `
 
 .c1 {
   -webkit-font-smoothing: antialiased;
-  color: #505558;
+  color: #ffffff;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
   font-size: 14px;
   font-style: normal;
@@ -116,7 +116,6 @@ exports[`ProfileImage component with initials snapshot 1`] = `
   -ms-letter-spacing: .02em;
   letter-spacing: .02em;
   line-height: 1.25;
-  color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/package/src/components/ProfileImage/v1/index.js
+++ b/package/src/components/ProfileImage/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ProfileImage";

--- a/package/src/tests/mockComponents.js
+++ b/package/src/tests/mockComponents.js
@@ -53,6 +53,7 @@ function stringifyJSONCircularSafe(obj) {
   "PhoneNumberInput",
   "Price",
   "ProgressiveImage",
+  "ProfileImage",
   "QuantityInput",
   "Select",
   "StockWarning",

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -293,7 +293,7 @@ const selectableList = {
 const viewerInfo = {
   rui_viewerInfoInitialsBackgroundColor: colors.teal,
   rui_viewerInfoInitialsColor: colors.white,
-  rui_viewerInfoInitialsSize: "30px"
+  rui_viewerInfoInitialsSize: "80px"
 };
 
 // AccountProfileInfo
@@ -304,6 +304,13 @@ const accountProfileInfo = {
   rui_accountProfileInfoEmailFontColor: colors.black50,
   rui_accountProfileInfoEmailFontSize: "14px",
   rui_accountProfileInfoNameFontSize: "24px"
+};
+
+// ProfileImage
+const profileImage = {
+  rui_profileImageBackgroundColor: colors.teal,
+  rui_profileImageInitialsColor: colors.white,
+  rui_profileImageInitialsSize: "80px"
 };
 
 const cartSummary = {
@@ -583,6 +590,7 @@ export default {
   ...selectableItem,
   ...selectableList,
   ...accountProfileInfo,
+  ...profileImage,
   ...viewerInfo,
   ...catalogGrid,
   ...miniCart,

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -558,6 +558,11 @@ const rui_components = {
       color: colors.black25
     }
   },
+  ProfileImageInitials: {
+    typography: {
+      color: colors.white
+    }
+  },
   StockWarning: {
     typography: {
       color: colors.red

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -296,6 +296,16 @@ const viewerInfo = {
   rui_viewerInfoInitialsSize: "30px"
 };
 
+// AccountProfileInfo
+const accountProfileInfo = {
+  rui_accountProfileInfoInitialsBackgroundColor: colors.teal,
+  rui_accountProfileInfoInitialsColor: colors.white,
+  rui_accountProfileInfoInitialsSize: "80px",
+  rui_accountProfileInfoEmailFontColor: colors.black50,
+  rui_accountProfileInfoEmailFontSize: "14px",
+  rui_accountProfileInfoNameFontSize: "24px"
+};
+
 const cartSummary = {
   rui_cartSummaryBackgroundColor: colors.black02,
   rui_cartSummaryBorderColor: colors.black10,
@@ -572,6 +582,7 @@ export default {
   ...checkbox,
   ...selectableItem,
   ...selectableList,
+  ...accountProfileInfo,
   ...viewerInfo,
   ...catalogGrid,
   ...miniCart,

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -309,8 +309,7 @@ const accountProfileInfo = {
 // ProfileImage
 const profileImage = {
   rui_profileImageBackgroundColor: colors.teal,
-  rui_profileImageInitialsColor: colors.white,
-  rui_profileImageInitialsSize: "80px"
+  rui_profileImageInitialsColor: colors.white
 };
 
 const cartSummary = {

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -293,7 +293,7 @@ const selectableList = {
 const viewerInfo = {
   rui_viewerInfoInitialsBackgroundColor: colors.teal,
   rui_viewerInfoInitialsColor: colors.white,
-  rui_viewerInfoInitialsSize: "80px"
+  rui_viewerInfoInitialsSize: "30px"
 };
 
 // AccountProfileInfo

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -298,12 +298,9 @@ const viewerInfo = {
 
 // AccountProfileInfo
 const accountProfileInfo = {
-  rui_accountProfileInfoInitialsBackgroundColor: colors.teal,
-  rui_accountProfileInfoInitialsColor: colors.white,
-  rui_accountProfileInfoInitialsSize: "80px",
-  rui_accountProfileInfoEmailFontColor: colors.black50,
-  rui_accountProfileInfoEmailFontSize: "14px",
-  rui_accountProfileInfoNameFontSize: "24px"
+  rui_accountProfileInfoSpacingAfterEmail: "4px",
+  rui_accountProfileInfoSpacingAfterName: "4px",
+  rui_accountProfileInfoSpacingBetweenImageAndContent: "16px"
 };
 
 // ProfileImage

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -480,6 +480,13 @@ module.exports = {
           ],
           content: "styleguide/src/sections/StorefrontForms.md",
           name: "Forms"
+        }),
+        generateSection({
+          componentNames: [
+            "AccountProfileInfo"
+          ],
+          content: "styleguide/src/sections/Account.md",
+          name: "Account"
         })
       ]
     }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -483,7 +483,8 @@ module.exports = {
         }),
         generateSection({
           componentNames: [
-            "AccountProfileInfo"
+            "AccountProfileInfo",
+            "ProfileImage"
           ],
           content: "styleguide/src/sections/Account.md",
           name: "Account"

--- a/styleguide/src/appComponents.js
+++ b/styleguide/src/appComponents.js
@@ -26,6 +26,7 @@ import Link from "../../package/src/components/Link/v1";
 import MiniCartSummary from "../../package/src/components/MiniCartSummary/v1";
 import PhoneNumberInput from "../../package/src/components/PhoneNumberInput/v1";
 import Price from "../../package/src/components/Price/v1";
+import ProfileImage from "../../package/src/components/ProfileImage/v1";
 import ProgressiveImage from "../../package/src/components/ProgressiveImage/v1";
 import QuantityInput from "../../package/src/components/QuantityInput/v1";
 import Select from "../../package/src/components/Select/v1";
@@ -69,6 +70,7 @@ export default {
   MiniCartSummary,
   PhoneNumberInput,
   Price,
+  ProfileImage,
   ProgressiveImage,
   QuantityInput,
   Select,

--- a/styleguide/src/sections/Account.md
+++ b/styleguide/src/sections/Account.md
@@ -1,0 +1,1 @@
+These are components related to your account profile.


### PR DESCRIPTION
Resolves #250 
Impact: **minor**  
Type: **feature**

## Component
- Create an AccountProfileInfo component which shows user icon, name, email address, and link to edit account info
- Image is taken from Gravatar
- Similar to ViewerInfo component that displays info in the Nav

## Screenshots
ProfileImage component with Image:
![profileimage_ _reaction_design_system](https://user-images.githubusercontent.com/4482263/46550601-66c48f80-c88a-11e8-8d56-4bc719c8386f.png)

ProfileImage component with initials:
![profileimage_ _reaction_design_system](https://user-images.githubusercontent.com/4482263/46550618-7348e800-c88a-11e8-9d95-681a13052882.png)

AccountProfileInfo component:
![accountprofileinfo_ _reaction_design_system](https://user-images.githubusercontent.com/4482263/46550645-8491f480-c88a-11e8-9ac3-528a1b884532.png)

With edit link:
![accountprofileinfo_ _reaction_design_system](https://user-images.githubusercontent.com/4482263/46550660-8e1b5c80-c88a-11e8-9a29-870398ca8389.png)

## Breaking changes
None

## Testing
#### Profile Image component
- Verify an image shows in the ProfileImage component when `profileImage` is provided
- Verify initials are shown when no `profileImage` is provided
- Verify you can change the size of the image (or initials) with the `size` prop
- Verify that the initials change size with the `size` prop

#### AccountProfileInfo component
- Verify the data shows correctly
- Verify edit link shows when `shouldShowEditButton` prop is `true`
- Verify `onClickEdit` prop works and passes the onClick to the button correctly