### PR TITLE
fix: change label from Full Name to Name

### DIFF
--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -347,11 +347,11 @@ class AddressForm extends Component {
           </ColFull>
 
           <ColFull>
-            <Field name="fullName" label="Full Name" labelFor={fullNameInputId} isRequired>
+            <Field name="fullName" label="Name" labelFor={fullNameInputId} isRequired>
               <TextInput
                 id={fullNameInputId}
                 name="fullName"
-                placeholder="Full Name"
+                placeholder="Name"
                 isOnDarkBackground={isOnDarkBackground}
                 isReadOnly={isSaving}
               />


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Component
Inside of <AddressForm>, updating a label to be “Name” instead of “Full Name”

## Breaking changes
None 

## Testing
See that field displays Name as the label instead of Full Name
