### PR TITLE
feat: address CustomPropTypes

### DIFF
--- a/package/src/components/AddressBook/v1/AddressBook.js
+++ b/package/src/components/AddressBook/v1/AddressBook.js
@@ -88,7 +88,7 @@ class AddressBook extends Component {
       /**
        * Users saved addresses
        */
-      addressBook: PropTypes.arrayOf(PropTypes.object)
+      addressBook: CustomPropTypes.addressBook
     }),
     /**
      * You can provide a `className` prop that will be applied to the outermost DOM element

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -141,18 +141,7 @@ class AddressForm extends Component {
     /**
      * Address object to be edited
      */
-    value: PropTypes.shape({
-      addressName: PropTypes.string,
-      address1: PropTypes.string,
-      address2: PropTypes.string,
-      country: PropTypes.string,
-      city: PropTypes.string,
-      fullName: PropTypes.string,
-      isCommercial: PropTypes.bool,
-      postal: PropTypes.string,
-      region: PropTypes.string,
-      phone: PropTypes.string
-    })
+    value: CustomPropTypes.address
   };
 
   static defaultProps = {

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -33,7 +33,7 @@ class ShippingAddressCheckoutAction extends Component {
      */
     fulfillmentGroup: PropTypes.shape({
       data: PropTypes.shape({
-        shippingAddress: PropTypes.object
+        shippingAddress: CustomPropTypes.address
       })
     }),
     /**

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -2,7 +2,7 @@
 The `ShippingAddressCheckoutAction` serves 4 purposes:
   * To normalize data input/editing between the `CheckoutActions` component and the `AddressForm` components.
   * To provide `CheckoutActions` with a `renderComplete` method that renders the captured checkout data.
-  * To provide `ChecoutActions` a way to know the action is ready for save,
+  * To provide `CheckoutActions` a way to know the action is ready for save,
   * To Provide `CheckoutActions` a way to capture the `AddressForm` values.
 
 For a full implementation example see the [CheckoutActions](/#!/CheckoutActions)

--- a/package/src/utils/CustomPropTypes.js
+++ b/package/src/utils/CustomPropTypes.js
@@ -60,7 +60,7 @@ const addressSyntax = PropTypes.shape({
   /**
    * Street information for address
    */
-  address1: PropTypes.string.isRequired,
+  address1: PropTypes.string,
   /**
    * Additional street information for address
    */
@@ -68,11 +68,11 @@ const addressSyntax = PropTypes.shape({
   /**
    * Country code for address
    */
-  country: PropTypes.string.isRequired,
+  country: PropTypes.string,
   /**
    * City information for address
    */
-  city: PropTypes.string.isRequired,
+  city: PropTypes.string,
   /**
    * User's name
    */
@@ -84,11 +84,11 @@ const addressSyntax = PropTypes.shape({
   /**
    * Postal code information for address
    */
-  postal: PropTypes.string.isRequired,
+  postal: PropTypes.string,
   /**
    * Region information for address
    */
-  region: PropTypes.string.isRequired,
+  region: PropTypes.string,
   /**
    * User's associated phone number
    */

--- a/package/src/utils/CustomPropTypes.js
+++ b/package/src/utils/CustomPropTypes.js
@@ -17,15 +17,13 @@ PropTypeError.prototype = Error.prototype;
 
 // These follow the composable form specification
 // http://forms.dairystatedesigns.com/user/input/#selection-inputs
-const optionsSyntax = PropTypes.arrayOf(PropTypes.shape({
-  id: PropTypes.string,
-  label: PropTypes.string.isRequired,
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool
-  ]).isRequired
-}));
+const optionsSyntax = PropTypes.arrayOf(
+  PropTypes.shape({
+    id: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired
+  })
+);
 
 // See https://github.com/facebook/prop-types/issues/200.
 // If that gets added to prop-types package, we won't need this.
@@ -35,13 +33,19 @@ function getComponentValidator() {
     if (val === null || val === undefined) {
       if (isRequired) {
         if (val === null) {
-          return new PropTypeError(`The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'null'.`);
+          return new PropTypeError(
+            `The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'null'.`
+          );
         }
-        return new PropTypeError(`The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'undefined'.`);
+        return new PropTypeError(
+          `The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'undefined'.`
+        );
       }
     } else if (!isValidElementType(val)) {
-      return new PropTypeError(`Invalid ${location} '${propFullName}' supplied to ${componentName}. ` +
-        "Expected a string (for built-in components) or a class/function (for composite components).");
+      return new PropTypeError(
+        `Invalid ${location} '${propFullName}' supplied to ${componentName}. ` +
+          "Expected a string (for built-in components) or a class/function (for composite components)."
+      );
     }
     return null;
   }
@@ -51,13 +55,32 @@ function getComponentValidator() {
   return chainedCheckType;
 }
 
+// address
+const addressSyntax = PropTypes.shape({
+  addressName: PropTypes.string,
+  address1: PropTypes.string,
+  address2: PropTypes.string,
+  country: PropTypes.string,
+  city: PropTypes.string,
+  fullName: PropTypes.string,
+  isCommercial: PropTypes.bool,
+  postal: PropTypes.string,
+  region: PropTypes.string,
+  phone: PropTypes.string
+});
+
+// address book
+
 export default {
+  address: addressSyntax,
   component: getComponentValidator(),
   options: PropTypes.oneOfType([
     optionsSyntax,
-    PropTypes.arrayOf(PropTypes.shape({
-      optgroup: PropTypes.string,
-      options: optionsSyntax
-    }))
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        optgroup: PropTypes.string,
+        options: optionsSyntax
+      })
+    )
   ])
 };

--- a/package/src/utils/CustomPropTypes.js
+++ b/package/src/utils/CustomPropTypes.js
@@ -17,13 +17,11 @@ PropTypeError.prototype = Error.prototype;
 
 // These follow the composable form specification
 // http://forms.dairystatedesigns.com/user/input/#selection-inputs
-const optionsSyntax = PropTypes.arrayOf(
-  PropTypes.shape({
-    id: PropTypes.string,
-    label: PropTypes.string.isRequired,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired
-  })
-);
+const optionsSyntax = PropTypes.arrayOf(PropTypes.shape({
+  id: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired
+}));
 
 // See https://github.com/facebook/prop-types/issues/200.
 // If that gets added to prop-types package, we won't need this.
@@ -33,19 +31,13 @@ function getComponentValidator() {
     if (val === null || val === undefined) {
       if (isRequired) {
         if (val === null) {
-          return new PropTypeError(
-            `The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'null'.`
-          );
+          return new PropTypeError(`The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'null'.`);
         }
-        return new PropTypeError(
-          `The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'undefined'.`
-        );
+        return new PropTypeError(`The ${location} '${propFullName}' is marked as required in '${componentName}', but its value is 'undefined'.`);
       }
     } else if (!isValidElementType(val)) {
-      return new PropTypeError(
-        `Invalid ${location} '${propFullName}' supplied to ${componentName}. ` +
-          "Expected a string (for built-in components) or a class/function (for composite components)."
-      );
+      return new PropTypeError(`Invalid ${location} '${propFullName}' supplied to ${componentName}. ` +
+          "Expected a string (for built-in components) or a class/function (for composite components).");
     }
     return null;
   }
@@ -55,32 +47,66 @@ function getComponentValidator() {
   return chainedCheckType;
 }
 
-// address
+// address proptype
 const addressSyntax = PropTypes.shape({
+  /**
+   * Address ID (not all addreses will have an ID)
+   */
+  _id: PropTypes.string,
+  /**
+   * Name identifier for address (example: "Mom's House", "Work")
+   */
   addressName: PropTypes.string,
-  address1: PropTypes.string,
+  /**
+   * Street information for address
+   */
+  address1: PropTypes.string.isRequired,
+  /**
+   * Additional street information for address
+   */
   address2: PropTypes.string,
-  country: PropTypes.string,
-  city: PropTypes.string,
+  /**
+   * Country code for address
+   */
+  country: PropTypes.string.isRequired,
+  /**
+   * City information for address
+   */
+  city: PropTypes.string.isRequired,
+  /**
+   * User's name
+   */
   fullName: PropTypes.string,
+  /**
+   * Is this address a commercial property
+   */
   isCommercial: PropTypes.bool,
-  postal: PropTypes.string,
-  region: PropTypes.string,
+  /**
+   * Postal code information for address
+   */
+  postal: PropTypes.string.isRequired,
+  /**
+   * Region information for address
+   */
+  region: PropTypes.string.isRequired,
+  /**
+   * User's associated phone number
+   */
   phone: PropTypes.string
 });
 
-// address book
+// address book proptype
+const addressBookSyntax = PropTypes.arrayOf(addressSyntax);
 
 export default {
   address: addressSyntax,
+  addressBook: addressBookSyntax,
   component: getComponentValidator(),
   options: PropTypes.oneOfType([
     optionsSyntax,
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        optgroup: PropTypes.string,
-        options: optionsSyntax
-      })
-    )
+    PropTypes.arrayOf(PropTypes.shape({
+      optgroup: PropTypes.string,
+      options: optionsSyntax
+    }))
   ])
 };


### PR DESCRIPTION
Resolves #331 
Impact: **minor**  
Type: **refactor**

## Component
Added `address` and `addressBook` ProptTpes to CustomPropTypes

## Breaking changes
N/A

## Testing
1. View [AddressForm](https://deploy-preview-333--stoic-hodgkin-c0179e.netlify.com/#!/AddressForm) PropTypes table.
2. View [AddressBook](https://deploy-preview-333--stoic-hodgkin-c0179e.netlify.com/#!/AddressBook) PropTypes table.
3. View [ShippingAddressCheckoutAction](https://deploy-preview-333--stoic-hodgkin-c0179e.netlify.com/#!/ShippingAddressCheckoutAction) PropTypes table.
4. See components all use a "Custom" PropType description.