### PR TITLE
refactor: remove `isRequired` from name, firstName, lastName fields of ProfileInfo

### DIFF
--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -92,13 +92,15 @@ class AccountProfileInfo extends Component {
   /**
    *
    * @name viewerName
-   * @summary If `firstName` is availible on the `viewer` object
-   * return that else return the email address
+   * @summary If `name` is availible on the `viewer` object
+   * return that else return `fistName` and `lastName`,
+   * else return `firstName`, else return null
    * @return {String} the viewers name.
    */
   get viewerName() {
-    const { viewer: { name } } = this.props;
-    return name;
+    const { viewer: { firstName, lastName, name } } = this.props;
+
+    return name || (firstName && lastName && `${firstName} ${lastName}`) || firstName || null;
   }
 
   viewerProfileEditLink = () => {

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -66,9 +66,9 @@ class AccountProfileInfo extends Component {
      * An object containing basic user information.
      */
     viewer: PropTypes.shape({
-      firstName: PropTypes.string.isRequired,
-      lastName: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+      name: PropTypes.string,
       primaryEmailAddress: PropTypes.string.isRequired,
       profileImage: PropTypes.string
     }).isRequired

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.md
@@ -14,6 +14,17 @@ const viewer = {
 <AccountProfileInfo viewer={viewer} />
 ```
 
+#### With `firstName` only
+```jsx
+const viewer = {
+  firstName: "John",
+  primaryEmailAddress: "john@doe.com",
+  profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
+};
+
+<AccountProfileInfo viewer={viewer} />
+```
+
 #### With initials (when profileImage is null)
 ```jsx
 const viewer = {

--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.test.js
@@ -17,6 +17,18 @@ test("Render default display, with profile image and no edit link", () => {
   expect(tree).toMatchSnapshot();
 });
 
+test("Render with first name only", () => {
+  const mockViewer = {
+    firstName: "John",
+    primaryEmailAddress: "john@doe.com",
+    profileImage: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=identicon&f=y"
+  };
+
+  const component = renderer.create(<AccountProfileInfo components={mockComponents} viewer={mockViewer} />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test("Render with initials instead of profile image", () => {
   const mockViewer = {
     firstName: "John",


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

After working with the AccountProfileInfo component with live data, we've seen that `name`, `firstName` and `lastName` fields are not always present on an account. For instance a brand new account has none of the fields attached to it.

This PR removes the `isRequired` from these fields so that the component will display without error even when a name is not present.

It also adds a check to display the fields in the following order: `name`, `firstName + lastName`, `firstName`, `null`.

## Breaking changes
None

## Testing
- Try different combinations of having `name`, `firstName`, and `lastName` fields on a `viewer` object and make sure the component renders at all times, either with a full name (name OR firstName + lastName), first name only, or no name at all.