### PR TITLE
feat: AddressReview component

### DIFF
--- a/package/src/components/Address/v1/Address.js
+++ b/package/src/components/Address/v1/Address.js
@@ -1,0 +1,55 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { addTypographyStyles, CustomPropTypes } from "../../../utils";
+
+const AddressElement = styled.address`
+  ${addTypographyStyles("ShippingAddressCheckoutActionAddress", "bodyText")};
+`;
+
+class Address extends Component {
+  static propTypes = {
+    /**
+     * Address data
+     */
+    address: CustomPropTypes.address.isRequired,
+    /**
+     * You can provide a `className` prop that will be applied to the outermost DOM element
+     * rendered by this component. We do not recommend using this for styling purposes, but
+     * it can be useful as a selector in some situations.
+     */
+    className: PropTypes.string,
+    /**
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
+    components: PropTypes.shape({}).isRequired
+  };
+
+  static defaultProps = {};
+
+  render() {
+    const { address, className } = this.props;
+
+    return (
+      <AddressElement className={className}>
+        {address.fullName}
+        <br />
+        {address.address1}
+        <br />
+        {address.address2 !== null && address.address2 !== "" ? (
+          <span>
+            {address.address2} <br />
+          </span>
+        ) : null}
+        {address.city}, {address.region} {address.postal} <br />
+        {address.country}
+      </AddressElement>
+    );
+  }
+}
+
+export default Address;

--- a/package/src/components/Address/v1/Address.js
+++ b/package/src/components/Address/v1/Address.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { addTypographyStyles, CustomPropTypes } from "../../../utils";
 
 const AddressElement = styled.address`
-  ${addTypographyStyles("ShippingAddressCheckoutActionAddress", "bodyText")};
+  ${addTypographyStyles("Address", "bodyText")};
 `;
 
 class Address extends Component {

--- a/package/src/components/Address/v1/Address.js
+++ b/package/src/components/Address/v1/Address.js
@@ -1,10 +1,24 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { addTypographyStyles, CustomPropTypes } from "../../../utils";
+import { applyTheme, addTypographyStyles, CustomPropTypes } from "../../../utils";
 
 const AddressElement = styled.address`
   ${addTypographyStyles("Address", "bodyText")};
+`;
+
+const AddressPropertyError = styled.span`
+  ${addTypographyStyles("AddressPropertyError", "bodyTextBold")};
+  background-color: ${applyTheme("Address.addressPropertyErrorBackgroundColor")};
+  border-color: ${applyTheme("Address.addressPropertyErrorBorderColor")};
+  border-style: ${applyTheme("Address.addressPropertyErrorBorderStyle")};
+  border-width: ${applyTheme("Address.addressPropertyErrorBorderWidth")};
+  border-radius: ${applyTheme("Address.addressPropertyErrorBorderRadius")};
+  color: ${applyTheme("Address.addressPropertyErrorColor")};
+  padding-bottom: ${applyTheme("Address.addressPropertyErrorPaddingBottom")};
+  padding-left: ${applyTheme("Address.addressPropertyErrorPaddingLeft")};
+  padding-right: ${applyTheme("Address.addressPropertyErrorPaddingRight")};
+  padding-top: ${applyTheme("Address.addressPropertyErrorPaddingTop")};
 `;
 
 class Address extends Component {
@@ -19,34 +33,37 @@ class Address extends Component {
      * it can be useful as a selector in some situations.
      */
     className: PropTypes.string,
-    /**
-     * If you've set up a components context using
-     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
-     * (recommended), then this prop will come from there automatically. If you have not
-     * set up a components context or you want to override one of the components in a
-     * single spot, you can pass in the components prop directly.
-     */
-    components: PropTypes.shape({}).isRequired
+    invalidAddressProperties: PropTypes.arrayOf(PropTypes.string)
   };
 
-  static defaultProps = {};
+  static defaultProps = {
+    invalidAddressProperties: []
+  };
+
+  renderAddressProperty(key, value) {
+    const { invalidAddressProperties } = this.props;
+    const invalid = invalidAddressProperties.includes(key);
+    return invalid ? <AddressPropertyError>{value}</AddressPropertyError> : value;
+  }
 
   render() {
     const { address, className } = this.props;
 
     return (
       <AddressElement className={className}>
-        {address.fullName}
+        {this.renderAddressProperty("fullName", address.fullName)}
         <br />
-        {address.address1}
+        {this.renderAddressProperty("address1", address.address1)}
         <br />
         {address.address2 !== null && address.address2 !== "" ? (
           <span>
-            {address.address2} <br />
+            {this.renderAddressProperty("address2", address.address2)}
+            <br />
           </span>
         ) : null}
-        {address.city}, {address.region} {address.postal} <br />
-        {address.country}
+        {this.renderAddressProperty("city", address.city)}, {this.renderAddressProperty("region", address.region)}{" "}
+        {this.renderAddressProperty("postal", address.postal)} <br />
+        {this.renderAddressProperty("country", address.country)}
       </AddressElement>
     );
   }

--- a/package/src/components/Address/v1/Address.md
+++ b/package/src/components/Address/v1/Address.md
@@ -1,0 +1,29 @@
+### Overview
+
+### Usage
+
+Document various live component examples here. See https://react-styleguidist.js.org/docs/documenting.html
+
+```jsx
+const address = {
+  _id: "1",
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+  
+}
+
+<Address address={address} />
+
+```
+
+### Theme
+
+Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
+
+| Theme Prop | Default | Description |

--- a/package/src/components/Address/v1/Address.md
+++ b/package/src/components/Address/v1/Address.md
@@ -1,28 +1,43 @@
 ### Overview
+This component is used when there is a need to display an `address`.
 
 ### Usage
-
-Document various live component examples here. See https://react-styleguidist.js.org/docs/documenting.html
+The `Address` component is just a simple block element that formats and renders an `address`.
 
 ```jsx
 const address = {
-  _id: "1",
-  address1: "7742 Hwy 23",
-  address2: "",
+  _id: "5",
+  address1: "2110 Main Street",
+  address2: "Suite 207",
   country: "US",
-  city: "Belle Chasse",
-  fullName: "Salvos Seafood",
-  postal: "70037",
-  region: "LA",
-  phone: "(504) 393-7303"
+  city: "Santa Monica",
+  fullName: "Reaction Commerce, Inc.",
+  postal: "90405",
+  region: "US-CA"
 };
 
 <Address address={address} />
-
 ```
 
-**With invalid address properties**
+`Address` will skip rendering empty `address` properties.
+```jsx
+const address = {
+  _id: "21",
+  address1: "35 Akin Adesola St",
+  address2: "",
+  country: "NG",
+  city: "Lagos",
+  fullName: "Ocean Basket Victoria Island",
+  postal: "101241",
+  region: "NG-LA",
+  phone: "234 816 059 1821"
+};
 
+<Address address={address} />
+```
+
+#### With invalid address properties
+Call out invalid `address` properties by passing an array of `address` property keys.
 ```jsx
 const address = {
   _id: "1",
@@ -32,7 +47,7 @@ const address = {
   city: "Belle Chasse",
   fullName: "Salvos Seafood",
   postal: "70037",
-  region: "LA",
+  region: "US-LA",
   phone: "(504) 393-7303"
 };
 
@@ -41,10 +56,60 @@ const invalidAddressProperties = ["fullName", "address1", "region"];
 <Address address={address} invalidAddressProperties={invalidAddressProperties} />
 
 ```
+Reorder or limit which `address` properties render by providing an array of `address` property keys.
+#### Address Order
+```jsx
+const address = {
+  address1: "46 Avenue N",
+  address2: "",
+  country: "HT",
+  city: "Port-au-Prince",
+  fullName: "Yanvalou",
+  postal: "6110",
+  region: "HT-OU",
+  phone: "+509 38 01 7051"
+};
+
+const addressOrder = ["fullName", "phone", "city", "region"];
+
+<Address address={address} addressOrder={addressOrder} />
+
+```
+
+#### Flat Address
+Render the `Address` in a flat string format by providing the `isFlat` prop.
+```jsx
+const address = {
+  _id: "1",
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "US-LA",
+  phone: "(504) 393-7303"
+};
+
+<Address address={address} isFlat />
+
+```
 
 ### Theme
 
-See [Theming Components](./#!/Theming%20Components).
+Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
+
+| Theme Prop           | Default | Description                                                                              |
+| -------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `Address.addressPropertyErrorBorderColor` | yellow400   | Warning message border color |
+| `Address.addressPropertyErrorBorderStyle` | solid   | Warning message border style |
+| `Address.addressPropertyErrorBorderWidth` | 1px   | Warning message border width |
+| `Address.addressPropertyErrorBackgroundColor` | yellow100   | Warning message background color |
+| `Address.addressPropertyErrorColor` | yellow600  | Warning message color |
+| `Address.addressPropertyErrorPaddingBottom` | 14px   | Warning message bottom padding |
+| `Address.addressPropertyErrorPaddingLeft` | 20px   | Warning message left padding |
+| `Address.addressPropertyErrorPaddingRight` | 20px   | Warning message right padding |
+| `Address.addressPropertyErrorPaddingTop` | 14px   | Warning message top padding |
 
 #### Typography
 

--- a/package/src/components/Address/v1/Address.md
+++ b/package/src/components/Address/v1/Address.md
@@ -101,15 +101,16 @@ Assume that any theme prop that does not begin with "rui" is within `rui_compone
 
 | Theme Prop           | Default | Description                                                                              |
 | -------------------- | ------- | ---------------------------------------------------------------------------------------- |
-| `Address.addressPropertyErrorBorderColor` | yellow400   | Warning message border color |
-| `Address.addressPropertyErrorBorderStyle` | solid   | Warning message border style |
-| `Address.addressPropertyErrorBorderWidth` | 1px   | Warning message border width |
-| `Address.addressPropertyErrorBackgroundColor` | yellow100   | Warning message background color |
-| `Address.addressPropertyErrorColor` | yellow600  | Warning message color |
-| `Address.addressPropertyErrorPaddingBottom` | 14px   | Warning message bottom padding |
-| `Address.addressPropertyErrorPaddingLeft` | 20px   | Warning message left padding |
-| `Address.addressPropertyErrorPaddingRight` | 20px   | Warning message right padding |
-| `Address.addressPropertyErrorPaddingTop` | 14px   | Warning message top padding |
+| `Address.addressPropertyErrorBorderColor` | red400   | Address property error border color |
+| `Address.addressPropertyErrorBorderRadius` | 2px | Address property error border radius |
+| `Address.addressPropertyErrorBorderStyle` | solid   | Address property error border style |
+| `Address.addressPropertyErrorBorderWidth` | 1px   | Address property error border width |
+| `Address.addressPropertyErrorBackgroundColor` | red100   | Address property error background color |
+| `Address.addressPropertyErrorColor` | red400  | Address property error color |
+| `Address.addressPropertyErrorPaddingBottom` | 0   | Address property error bottom padding |
+| `Address.addressPropertyErrorPaddingLeft` | padding.four   | Address property error left padding |
+| `Address.addressPropertyErrorPaddingRight` | padding.four   | Address property error right padding |
+| `Address.addressPropertyErrorPaddingTop` | 0  | Address property error top padding |
 
 #### Typography
 

--- a/package/src/components/Address/v1/Address.md
+++ b/package/src/components/Address/v1/Address.md
@@ -21,6 +21,27 @@ const address = {
 
 ```
 
+**With invalid address properties**
+
+```jsx
+const address = {
+  _id: "1",
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const invalidAddressProperties = ["fullName", "address1", "region"];
+
+<Address address={address} invalidAddressProperties={invalidAddressProperties} />
+
+```
+
 ### Theme
 
 See [Theming Components](./#!/Theming%20Components).

--- a/package/src/components/Address/v1/Address.md
+++ b/package/src/components/Address/v1/Address.md
@@ -15,8 +15,7 @@ const address = {
   postal: "70037",
   region: "LA",
   phone: "(504) 393-7303"
-  
-}
+};
 
 <Address address={address} />
 
@@ -24,6 +23,8 @@ const address = {
 
 ### Theme
 
-Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
+See [Theming Components](./#!/Theming%20Components).
 
-| Theme Prop | Default | Description |
+#### Typography
+
+- The address preview text uses `bodyText` style with `rui_components.Address` override

--- a/package/src/components/Address/v1/Address.test.js
+++ b/package/src/components/Address/v1/Address.test.js
@@ -23,7 +23,7 @@ test("basic snapshot with required props", () => {
 });
 
 test("basic snapshot with is flat prop", () => {
-  const component = renderer.create(<Address address={mockAddress} isflat />);
+  const component = renderer.create(<Address address={mockAddress} isFlat />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/Address/v1/Address.test.js
+++ b/package/src/components/Address/v1/Address.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Address from "./Address";
+
+test("basic snapshot", () => {
+  const component = renderer.create(<Address />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/Address/v1/Address.test.js
+++ b/package/src/components/Address/v1/Address.test.js
@@ -15,8 +15,33 @@ const mockAddress = {
   phone: "(504) 393-7303"
 };
 
-test("basic snapshot", () => {
+test("basic snapshot with required props", () => {
   const component = renderer.create(<Address address={mockAddress} />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with is flat prop", () => {
+  const component = renderer.create(<Address address={mockAddress} isflat />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with address order prop", () => {
+  const addressOrder = ["fullName", "phone"];
+  const address = mockAddress;
+  const component = renderer.create(<Address {...{ address, addressOrder }} />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with invalid address properties prop", () => {
+  const invalidAddressProperties = ["country", "address1"];
+  const address = mockAddress;
+  const component = renderer.create(<Address {...{ address, invalidAddressProperties }} />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/Address/v1/Address.test.js
+++ b/package/src/components/Address/v1/Address.test.js
@@ -1,10 +1,22 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow } from "enzyme";
+// import { shallow } from "enzyme";
 import Address from "./Address";
 
+const mockAddress = {
+  _id: "1",
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
 test("basic snapshot", () => {
-  const component = renderer.create(<Address />);
+  const component = renderer.create(<Address address={mockAddress} />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/Address/v1/__snapshots__/Address.test.js.snap
+++ b/package/src/components/Address/v1/__snapshots__/Address.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot 1`] = `
+exports[`basic snapshot with address order prop 1`] = `
 .c0 {
   -webkit-font-smoothing: antialiased;
   color: #3c3c3c;
@@ -20,8 +20,130 @@ exports[`basic snapshot 1`] = `
   className="c0"
 >
   Salvos Seafood
+   
+  <br />
+  (504) 393-7303
+   
+  <br />
+</address>
+`;
+
+exports[`basic snapshot with invalid address properties prop 1`] = `
+.c0 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
+}
+
+.c1 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 700;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
+  background-color: #ffeeef;
+  border-color: #bc1d2b;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 2px;
+  color: #bc1d2b;
+  padding-bottom: 0;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 0;
+}
+
+<address
+  className="c0"
+>
+  Salvos Seafood
+   
+  <br />
+  <span
+    className="c1"
+  >
+    7742 Hwy 23
+  </span>
+   
+  <br />
+  Belle Chasse
+  , 
+  LA
+   
+  70037
+   
+  <br />
+  <span
+    className="c1"
+  >
+    US
+  </span>
+</address>
+`;
+
+exports[`basic snapshot with is flat prop 1`] = `
+.c0 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
+}
+
+<address
+  className="c0"
+>
+  7742 Hwy 23, Belle Chasse, LA 70037 US
+</address>
+`;
+
+exports[`basic snapshot with required props 1`] = `
+.c0 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
+}
+
+<address
+  className="c0"
+>
+  Salvos Seafood
+   
   <br />
   7742 Hwy 23
+   
   <br />
   Belle Chasse
   , 

--- a/package/src/components/Address/v1/__snapshots__/Address.test.js.snap
+++ b/package/src/components/Address/v1/__snapshots__/Address.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+.c0 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
+}
+
+<address
+  className="c0"
+>
+  Salvos Seafood
+  <br />
+  7742 Hwy 23
+  <br />
+  Belle Chasse
+  , 
+  LA
+   
+  70037
+   
+  <br />
+  US
+</address>
+`;

--- a/package/src/components/Address/v1/index.js
+++ b/package/src/components/Address/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Address";

--- a/package/src/components/AddressBook/v1/AddressBook.js
+++ b/package/src/components/AddressBook/v1/AddressBook.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import isEmpty from "lodash.isempty";
 import isEqual from "lodash.isequal";
 import { withComponents } from "@reactioncommerce/components-context";
-import { applyTheme, addTypographyStyles, CustomPropTypes } from "../../../utils";
+import { addressToString, applyTheme, addTypographyStyles, CustomPropTypes } from "../../../utils";
 
 const AddressBookAddNewAddressAction = styled.div`
   border-color: ${applyTheme("AddressBook.borderColor")};
@@ -157,7 +157,9 @@ class AddressBook extends Component {
     isSaving: false,
     onAddressAdded() {},
     onAddressDeleted() {},
-    onAddressEdited() {}
+    onAddressEdited() {},
+    validatedValue: {},
+    value: {}
   };
 
   state = {
@@ -179,17 +181,12 @@ class AddressBook extends Component {
   //
   get currentStatus() {
     // eslint-disable-next-line
-    return this.props.validatedValue ? REVIEW : this.hasAddress ? OVERVIEW : ENTRY;
+    return !isEmpty(this.props.validatedValue) ? REVIEW : this.hasAddress ? OVERVIEW : ENTRY;
   }
 
   get hasAddress() {
     const { account: { addressBook } } = this.props;
     return !isEmpty(addressBook);
-  }
-
-  addressToString({ address1, address2, city, country, postal, region }) {
-    const addressString = `${address1}${address2 ? `, ${address2}` : ""}, ${city}, ${region} ${postal} ${country}`;
-    return addressString;
   }
 
   //
@@ -234,7 +231,7 @@ class AddressBook extends Component {
           <Accordion
             key={_id}
             label={address.fullName}
-            detail={this.addressToString(address)}
+            detail={addressToString(address)}
             ref={(el) => {
               this._refs[`accordion_${_id}`] = el;
             }}
@@ -289,12 +286,14 @@ class AddressBook extends Component {
   }
 
   renderAddressReview() {
-    const { components: { AddressReview } } = this.props;
+    const { components: { AddressReview }, value, validatedValue } = this.props;
     return (
       <AddressReview
         ref={(el) => {
           this._addressReview = el;
         }}
+        addressEntered={value}
+        addressSuggestion={validatedValue}
       />
     );
   }

--- a/package/src/components/AddressBook/v1/AddressBook.md
+++ b/package/src/components/AddressBook/v1/AddressBook.md
@@ -43,7 +43,6 @@ const account = {
 <AddressBook account={account} />
 ```
 
-**WIP**
 If the`AddressBook` is provided an `validatedValue` the address review view will display.
 ```jsx
 const props = {

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -21,6 +21,10 @@ const WarningMessage = styled.div`
   white-space: pre-wrap;
 `;
 
+const FormWrapper = styled.div`
+  margin-top: ${applyTheme("AddressReview.formSpacingTop")};
+`;
+
 const ENTERED = "entered";
 const SUGGESTED = "suggested";
 
@@ -96,6 +100,11 @@ class AddressReview extends Component {
 
   uniqueInstanceIdentifier = uniqueId("AddressReviewForm_");
 
+  get invalidAddressProperties() {
+    const { addressEntered, addressSuggestion } = this.props;
+    return Object.keys(addressEntered).filter((key) => (addressEntered[key] !== addressSuggestion[key] ? key : null));
+  }
+
   submit = () => this._form.submit();
 
   handleSubmit = (value) => {
@@ -119,7 +128,7 @@ class AddressReview extends Component {
     const options = [
       {
         id: `${ENTERED}_${this.uniqueInstanceIdentifier}`,
-        detail: <Address address={addressEntered} />,
+        detail: <Address address={addressEntered} invalidAddressProperties={this.invalidAddressProperties} />,
         label: "Entered Address:",
         value: ENTERED
       },
@@ -134,21 +143,23 @@ class AddressReview extends Component {
     return (
       <div className={className}>
         <WarningMessage>{warningMessage}</WarningMessage>
-        <Form
-          ref={(formEl) => {
-            this._form = formEl;
-          }}
-          onSubmit={onSubmit}
-        >
-          <SelectableList
-            isHorizontal
-            isStacked
-            options={options}
-            name="AddressReview"
-            value={value}
-            isReadOnly={isSaving}
-          />
-        </Form>
+        <FormWrapper>
+          <Form
+            ref={(formEl) => {
+              this._form = formEl;
+            }}
+            onSubmit={onSubmit}
+          >
+            <SelectableList
+              isHorizontal
+              isStacked
+              options={options}
+              name="AddressReview"
+              value={value}
+              isReadOnly={isSaving}
+            />
+          </Form>
+        </FormWrapper>
       </div>
     );
   }

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -1,20 +1,131 @@
 import React, { Component } from "react";
-// import PropTypes from "prop-types";
+import PropTypes from "prop-types";
+import uniqueId from "lodash.uniqueid";
+import { Form } from "reacto-form";
 import styled from "styled-components";
-// import { applyTheme } from "../../../utils";
+import { withComponents } from "@reactioncommerce/components-context";
+import { applyTheme, addTypographyStyles, CustomPropTypes } from "../../../utils";
 
-const StyledDiv = styled.div`
-  color: #333333;
+// TODO: make grid utiil
+const Grid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: ${applyTheme("AddressReview.warningMessagePaddingLeft")};
+`;
+
+const ColHalf = styled.div`
+  flex: 1 1 100%;
+
+  @media (min-width: ${applyTheme("sm", "breakpoints")}px) {
+    flex: 0 1 calc(50% - 9px);
+  }
+`;
+
+// component styles
+const WarningMessage = styled.div`
+  ${addTypographyStyles("WarningMessage", "labelText")};
+  border-color: ${applyTheme("AddressReview.warningMessageBorderColor")};
+  border-style: ${applyTheme("AddressReview.warningMessageBorderStyle")};
+  border-width: ${applyTheme("AddressReview.warningMessageBorderWidth")};
+  background-color: ${applyTheme("AddressReview.warningMessageBackgroundColor")};
+  color: ${applyTheme("AddressReview.warningMessageColor")};
+  padding-bottom: ${applyTheme("AddressReview.warningMessagePaddingBottom")};
+  padding-left: ${applyTheme("AddressReview.warningMessagePaddingLeft")};
+  padding-right: ${applyTheme("AddressReview.warningMessagePaddingRight")};
+  padding-top: ${applyTheme("AddressReview.warningMessagePaddingTop")};
 `;
 
 class AddressReview extends Component {
-  static propTypes = {};
+  static propTypes = {
+    /**
+     * Address entered
+     */
+    addressEntered: CustomPropTypes.address.isRequired,
+    /**
+     * Address validations address suggestion
+     */
+    addressSuggestion: CustomPropTypes.address.isRequired,
+    /**
+     * You can provide a `className` prop that will be applied to the outermost DOM element
+     * rendered by this component. We do not recommend using this for styling purposes, but
+     * it can be useful as a selector in some situations.
+     */
+    className: PropTypes.string,
+    /**
+     * If you've set up a components context using @reactioncommerce/components-context
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
+    components: PropTypes.shape({
+      /**
+       * Pass either the Reaction Address component or your own component that
+       * accepts compatible props.
+       */
+      Address: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction Checkbox component or your own component that
+       * accepts compatible props.
+       */
+      Checkbox: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction Field component or your own component that
+       * accepts compatible props.
+       */
+      Field: CustomPropTypes.component.isRequired
+    }).isRequired,
+    /**
+     * Is data being saved
+     */
+    isSaving: PropTypes.bool,
+    value: PropTypes.string
+  };
 
-  static defaultProps = {};
+  static defaultProps = {
+    isSaving: false
+  };
+
+  _addressReviewForm = null;
+
+  uniqueInstanceIdentifier = uniqueId("AddressReviewForm_");
 
   render() {
-    return <StyledDiv>Address Review</StyledDiv>;
+    const {
+      addressEntered,
+      addressSuggestion,
+      className,
+      components: { Address, SelectableItem, Field },
+      isSaving
+    } = this.props;
+
+    return (
+      <div className={className}>
+        <WarningMessage>Dat address be wrong!</WarningMessage>
+        <Form
+          ref={(formEl) => {
+            this._addressReviewForm = formEl;
+          }}
+        >
+          <Grid>
+            <ColHalf>
+              {" "}
+              <Field>
+                <SelectableItem label="Entered Address:" isReadOnly={isSaving} />
+                <Address address={addressEntered} />
+              </Field>
+            </ColHalf>
+            <ColHalf>
+              <Field>
+                <SelectableItem label="Suggested Address:" isChecked isReadOnly={isSaving} />
+                <Address address={addressSuggestion} />
+              </Field>
+            </ColHalf>
+          </Grid>
+        </Form>
+      </div>
+    );
   }
 }
 
-export default AddressReview;
+export default withComponents(AddressReview);

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -7,20 +7,20 @@ import { withComponents } from "@reactioncommerce/components-context";
 import { applyTheme, addTypographyStyles, CustomPropTypes } from "../../../utils";
 
 // TODO: make grid utiil
-const Grid = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  padding: ${applyTheme("AddressReview.warningMessagePaddingLeft")};
-`;
+// const Grid = styled.div`
+//   display: flex;
+//   flex-wrap: wrap;
+//   justify-content: space-between;
+//   padding: ${applyTheme("AddressReview.warningMessagePaddingLeft")};
+// `;
 
-const ColHalf = styled.div`
-  flex: 1 1 100%;
+// const ColHalf = styled.div`
+//   flex: 1 1 100%;
 
-  @media (min-width: ${applyTheme("sm", "breakpoints")}px) {
-    flex: 0 1 calc(50% - 9px);
-  }
-`;
+//   @media (min-width: ${applyTheme("sm", "breakpoints")}px) {
+//     flex: 0 1 calc(50% - 9px);
+//   }
+// `;
 
 // component styles
 const WarningMessage = styled.div`
@@ -35,6 +35,9 @@ const WarningMessage = styled.div`
   padding-right: ${applyTheme("AddressReview.warningMessagePaddingRight")};
   padding-top: ${applyTheme("AddressReview.warningMessagePaddingTop")};
 `;
+
+const ENTERED = "entered";
+const SUGGESTED = "suggested";
 
 class AddressReview extends Component {
   static propTypes = {
@@ -79,49 +82,74 @@ class AddressReview extends Component {
      * Is data being saved
      */
     isSaving: PropTypes.bool,
+    /**
+     * Form name
+     */
+    name: PropTypes.string,
+    /**
+     * Form submit event callback
+     */
+    onSubmit: PropTypes.func,
+    /**
+     * The selected address option
+     */
     value: PropTypes.string
   };
 
   static defaultProps = {
-    isSaving: false
+    isSaving: false,
+    value: SUGGESTED
   };
 
-  _addressReviewForm = null;
+  _form = null;
 
   uniqueInstanceIdentifier = uniqueId("AddressReviewForm_");
+
+  submit = () => this._form.submit();
 
   render() {
     const {
       addressEntered,
       addressSuggestion,
       className,
-      components: { Address, SelectableItem, Field },
-      isSaving
+      components: { Address, SelectableList },
+      isSaving,
+      onSubmit,
+      value
     } = this.props;
+
+    const options = [
+      {
+        id: `${ENTERED}_${this.uniqueInstanceIdentifier}`,
+        detail: <Address address={addressEntered} />,
+        label: "Entered Address:",
+        value: ENTERED
+      },
+      {
+        id: `${SUGGESTED}_${this.uniqueInstanceIdentifier}`,
+        detail: <Address address={addressSuggestion} />,
+        label: "Suggested Address:",
+        value: SUGGESTED
+      }
+    ];
 
     return (
       <div className={className}>
         <WarningMessage>Dat address be wrong!</WarningMessage>
         <Form
           ref={(formEl) => {
-            this._addressReviewForm = formEl;
+            this._form = formEl;
           }}
+          onSubmit={onSubmit}
         >
-          <Grid>
-            <ColHalf>
-              {" "}
-              <Field>
-                <SelectableItem label="Entered Address:" isReadOnly={isSaving} />
-                <Address address={addressEntered} />
-              </Field>
-            </ColHalf>
-            <ColHalf>
-              <Field>
-                <SelectableItem label="Suggested Address:" isChecked isReadOnly={isSaving} />
-                <Address address={addressSuggestion} />
-              </Field>
-            </ColHalf>
-          </Grid>
+          <SelectableList
+            isBordered
+            isLeftAligned
+            options={options}
+            name="AddressReview"
+            value={value}
+            isReadOnly={isSaving}
+          />
         </Form>
       </div>
     );

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -132,7 +132,7 @@ class AddressReview extends Component {
    * @param {String} value - "entered" or "seggested"
    * @return {Undefined} - Nothing
    */
-  handleSubmit = (value) => {
+  handleSubmit = ({ AddressReview: value }) => {
     const { addressEntered, addressSuggestion, onSubmit } = this.props;
     const selectedAddress = value === ENTERED ? addressEntered : addressSuggestion;
     onSubmit(selectedAddress);

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -100,13 +100,38 @@ class AddressReview extends Component {
 
   uniqueInstanceIdentifier = uniqueId("AddressReviewForm_");
 
+  /**
+   *
+   * @name submit
+   * @summary Instance method that submits the form, this allows a parent component access to the Form submit event.
+   * @return {Undefined} - Nothing
+   */
+  submit = () => {
+    this._form.submit();
+  };
+
+  /**
+   *
+   * @name invalidAddressProperties
+   * @summary Creates an array of invalid address property keys.
+   * @return {Array} - `["address1", "postal"]`
+   */
   get invalidAddressProperties() {
     const { addressEntered, addressSuggestion } = this.props;
-    return Object.keys(addressEntered).filter((key) => (addressEntered[key] !== addressSuggestion[key] ? key : null));
+    return (
+      addressEntered &&
+      Object.keys(addressEntered).filter((key) => (addressEntered[key] !== addressSuggestion[key] ? key : null))
+    );
   }
 
-  submit = () => this._form.submit();
-
+  /**
+   *
+   * @name handleSubmit
+   * @summary Form `onSubmit` callback that check the submitted value
+   * and passes the correct address object to the `props.onSubmit` function.
+   * @param {String} value - "entered" or "seggested"
+   * @return {Undefined} - Nothing
+   */
   handleSubmit = (value) => {
     const { addressEntered, addressSuggestion, onSubmit } = this.props;
     const selectedAddress = value === ENTERED ? addressEntered : addressSuggestion;
@@ -120,7 +145,6 @@ class AddressReview extends Component {
       className,
       components: { Address, SelectableList },
       isSaving,
-      onSubmit,
       value,
       warningMessage
     } = this.props;
@@ -148,7 +172,7 @@ class AddressReview extends Component {
             ref={(formEl) => {
               this._form = formEl;
             }}
-            onSubmit={onSubmit}
+            onSubmit={this.handleSubmit}
           >
             <SelectableList
               isHorizontal

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -107,6 +107,12 @@ class AddressReview extends Component {
 
   submit = () => this._form.submit();
 
+  handleSubmit = (value) => {
+    const { addressEntered, addressSuggestion, onSubmit } = this.props;
+    const selectedAddress = value === ENTERED ? addressEntered : addressSuggestion;
+    onSubmit(selectedAddress);
+  };
+
   render() {
     const {
       addressEntered,
@@ -142,14 +148,7 @@ class AddressReview extends Component {
           }}
           onSubmit={onSubmit}
         >
-          <SelectableList
-            isBordered
-            isLeftAligned
-            options={options}
-            name="AddressReview"
-            value={value}
-            isReadOnly={isSaving}
-          />
+          <SelectableList isHorizontal options={options} name="AddressReview" value={value} isReadOnly={isSaving} />
         </Form>
       </div>
     );

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -6,22 +6,6 @@ import styled from "styled-components";
 import { withComponents } from "@reactioncommerce/components-context";
 import { applyTheme, addTypographyStyles, CustomPropTypes } from "../../../utils";
 
-// TODO: make grid utiil
-// const Grid = styled.div`
-//   display: flex;
-//   flex-wrap: wrap;
-//   justify-content: space-between;
-//   padding: ${applyTheme("AddressReview.warningMessagePaddingLeft")};
-// `;
-
-// const ColHalf = styled.div`
-//   flex: 1 1 100%;
-
-//   @media (min-width: ${applyTheme("sm", "breakpoints")}px) {
-//     flex: 0 1 calc(50% - 9px);
-//   }
-// `;
-
 // component styles
 const WarningMessage = styled.div`
   ${addTypographyStyles("WarningMessage", "labelText")};
@@ -34,6 +18,7 @@ const WarningMessage = styled.div`
   padding-left: ${applyTheme("AddressReview.warningMessagePaddingLeft")};
   padding-right: ${applyTheme("AddressReview.warningMessagePaddingRight")};
   padding-top: ${applyTheme("AddressReview.warningMessagePaddingTop")};
+  white-space: pre-wrap;
 `;
 
 const ENTERED = "entered";
@@ -93,12 +78,18 @@ class AddressReview extends Component {
     /**
      * The selected address option
      */
-    value: PropTypes.string
+    value: PropTypes.string,
+    /**
+     * Warning message to display above the form
+     */
+    warningMessage: PropTypes.string
   };
 
   static defaultProps = {
     isSaving: false,
-    value: SUGGESTED
+    value: SUGGESTED,
+    // eslint-disable-next-line
+    warningMessage: `The address you entered may be incorrect or incomplete.\n\nPlease review our suggestion below, and choose which version you’d like to use. Errors are shown in red.`
   };
 
   _form = null;
@@ -121,7 +112,8 @@ class AddressReview extends Component {
       components: { Address, SelectableList },
       isSaving,
       onSubmit,
-      value
+      value,
+      warningMessage
     } = this.props;
 
     const options = [
@@ -141,14 +133,21 @@ class AddressReview extends Component {
 
     return (
       <div className={className}>
-        <WarningMessage>Dat address be wrong!</WarningMessage>
+        <WarningMessage>{warningMessage}</WarningMessage>
         <Form
           ref={(formEl) => {
             this._form = formEl;
           }}
           onSubmit={onSubmit}
         >
-          <SelectableList isHorizontal options={options} name="AddressReview" value={value} isReadOnly={isSaving} />
+          <SelectableList
+            isHorizontal
+            isStacked
+            options={options}
+            name="AddressReview"
+            value={value}
+            isReadOnly={isSaving}
+          />
         </Form>
       </div>
     );

--- a/package/src/components/AddressReview/v1/AddressReview.md
+++ b/package/src/components/AddressReview/v1/AddressReview.md
@@ -2,5 +2,27 @@
 #### Usage
 
 ```jsx
-<AddressReview />
+const addressEntered = {
+  address1: "7742 Hwy 25",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70047",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const addressSuggestion = {
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+<AddressReview {...{ addressEntered, addressSuggestion }} />
 ```

--- a/package/src/components/AddressReview/v1/AddressReview.md
+++ b/package/src/components/AddressReview/v1/AddressReview.md
@@ -1,5 +1,6 @@
 ### Overview
 #### Usage
+The `AddressReview` is a simple form that requires two address objects, `addressEntered` and `addressSuggestion` will be used to create the `SelectableList` options. The "selected" address will be returned on submit.
 
 ```jsx
 const addressEntered = {
@@ -24,7 +25,127 @@ const addressSuggestion = {
   phone: "(504) 393-7303"
 };
 
-<div style={{width: "550px"}} >
-  <AddressReview {...{ addressEntered, addressSuggestion }} />
-</div>
+const props = { addressEntered, addressSuggestion };
+
+<AddressReview {...props} />
+```
+
+##### Value
+By default the suggested address is selected but it can easily be changed by pasing a `value` string of "entered" to pre select the entered address.
+```jsx
+const addressEntered = {
+  address1: "7742 Hwy 25",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70047",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const addressSuggestion = {
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const props = { addressEntered, addressSuggestion, value: "entered" };
+
+<AddressReview {...props} />
+```
+
+##### Warning Message
+The displayed warning message can be changed by providing a `warningMessage` string as a prop. The text of this element respects line breaks via `\n` within the strings text.
+```jsx
+const addressEntered = {
+  address1: "46 Avenue M",
+  address2: "",
+  country: "HT",
+  city: "Port-au-Prince",
+  fullName: "Yanvalou",
+  postal: "6111",
+  region: "OU",
+  phone: "509 38 01 7051"
+};
+
+const addressSuggestion = {
+  address1: "46 Avenue N",
+  address2: "",
+  country: "HT",
+  city: "Port-au-Prince",
+  fullName: "Yanvalou",
+  postal: "6110",
+  region: "OU",
+  phone: "509 38 01 7051"
+};
+
+const props = { 
+  addressEntered, 
+  addressSuggestion, 
+  warningMessage: "Adrès ou te antre a ka kòrèk oswa enkonplè.\n\nTanpri revize sijesyon nou anba a, epi chwazi ki vèsyon ou ta renmen itilize. Erè yo montre nan wouj." 
+};
+
+<AddressReview {...props} />
+```
+
+#### Example implamentation
+Simple `AddressReview` example.
+```jsx
+const addressEntered = {
+  address1: "7742 Hwy 25",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70047",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const addressSuggestion = {
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+class AddressExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this._addressForm;
+    this.bindForm.bind(this);
+  }
+
+  bindForm(formEl) {
+    if (formEl) {
+      this._addressReview = formEl;
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <AddressReview
+          ref={(formEl) => { this.bindForm(formEl) }}
+          onSubmit={(selectAddress) => console.log("Address selected", selectAddress)}
+          addressEntered={addressEntered}
+          addressSuggestion={addressSuggestion}
+        />
+        <Button onClick={() => this._addressReview.submit()}>Submit</Button>
+      </div>
+    );
+  }
+}
+
+<AddressExample />
 ```

--- a/package/src/components/AddressReview/v1/AddressReview.md
+++ b/package/src/components/AddressReview/v1/AddressReview.md
@@ -24,5 +24,7 @@ const addressSuggestion = {
   phone: "(504) 393-7303"
 };
 
-<AddressReview {...{ addressEntered, addressSuggestion }} />
+<div style={{width: "550px"}} >
+  <AddressReview {...{ addressEntered, addressSuggestion }} />
+</div>
 ```

--- a/package/src/components/AddressReview/v1/AddressReview.md
+++ b/package/src/components/AddressReview/v1/AddressReview.md
@@ -149,3 +149,24 @@ class AddressExample extends React.Component {
 
 <AddressExample />
 ```
+
+### Theme
+
+Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
+
+| Theme Prop           | Default | Description                                                                              |
+| -------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `AddressReview.warningMessageBorderColor` | yellow400   | Warning message border color |
+| `AddressReview.warningMessageBorderStyle` | solid   | Warning message border style |
+| `AddressReview.warningMessageBorderWidth` | 1px   | Warning message border width |
+| `AddressReview.warningMessageBackgroundColor` | yellow100   | Warning message background color |
+| `AddressReview.warningMessageColor` | yellow600  | Warning message color |
+| `AddressReview.warningMessagePaddingBottom` | 14px   | Warning message bottom padding |
+| `AddressReview.warningMessagePaddingLeft` | 20px   | Warning message left padding |
+| `AddressReview.warningMessagePaddingRight` | 20px   | Warning message right padding |
+| `AddressReview.warningMessagePaddingTop` | 14px   | Warning message top padding |
+| `AddressReview.formSpacingTop` | 40px   | Space between form and warning message |
+
+#### Typography
+
+- The warning message text uses `labelText` style with `rui_components.WarningMessage` override

--- a/package/src/components/AddressReview/v1/AddressReview.test.js
+++ b/package/src/components/AddressReview/v1/AddressReview.test.js
@@ -1,10 +1,37 @@
 import React from "react";
 import renderer from "react-test-renderer";
 // import { shallow } from "enzyme";
+import mockComponents from "../../../tests/mockComponents";
 import AddressReview from "./AddressReview";
 
+const mockAddressEntered = {
+  address1: "7742 Hwy 25",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70047",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const mockAddressSuggestion = {
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
 test("basic snapshot", () => {
-  const component = renderer.create(<AddressReview />);
+  const component = renderer.create(<AddressReview
+    addressEntered={mockAddressEntered}
+    addressSugestion={mockAddressSuggestion}
+    components={mockComponents}
+  />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/AddressReview/v1/AddressReview.test.js
+++ b/package/src/components/AddressReview/v1/AddressReview.test.js
@@ -26,12 +26,25 @@ const mockAddressSuggestion = {
   phone: "(504) 393-7303"
 };
 
-test("basic snapshot", () => {
+test("basic snapshot with only required props", () => {
   const component = renderer.create(<AddressReview
     addressEntered={mockAddressEntered}
-    addressSugestion={mockAddressSuggestion}
+    addressSuggestion={mockAddressSuggestion}
     components={mockComponents}
-  />);
+                                    />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with all props", () => {
+  const component = renderer.create(<AddressReview
+    addressEntered={mockAddressEntered}
+    addressSuggestion={mockAddressSuggestion}
+    components={mockComponents}
+    value="entered"
+    warningMessage="Something is wrong"
+                                    />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/AddressReview/v1/AddressReview.test.js
+++ b/package/src/components/AddressReview/v1/AddressReview.test.js
@@ -31,7 +31,7 @@ test("basic snapshot with only required props", () => {
     addressEntered={mockAddressEntered}
     addressSuggestion={mockAddressSuggestion}
     components={mockComponents}
-                                    />);
+  />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
@@ -44,7 +44,7 @@ test("basic snapshot with all props", () => {
     components={mockComponents}
     value="entered"
     warningMessage="Something is wrong"
-                                    />);
+  />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/AddressReview/v1/__snapshots__/AddressReview.test.js.snap
+++ b/package/src/components/AddressReview/v1/__snapshots__/AddressReview.test.js.snap
@@ -2,12 +2,42 @@
 
 exports[`basic snapshot 1`] = `
 .c0 {
-  color: #333333;
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  border-color: #fbc120;
+  border-style: solid;
+  border-width: 1px;
+  background-color: #fcf3dc;
+  color: #7a6322;
+  padding-bottom: 14px;
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-top: 14px;
 }
 
 <div
-  className="c0"
+  className={undefined}
 >
-  Address Review
+  <div
+    className="c0"
+  >
+    Dat address be wrong!
+  </div>
+  <div
+    className={null}
+    style={Object {}}
+  >
+    SelectableList(undefined)
+  </div>
 </div>
 `;

--- a/package/src/components/AddressReview/v1/__snapshots__/AddressReview.test.js.snap
+++ b/package/src/components/AddressReview/v1/__snapshots__/AddressReview.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot 1`] = `
+exports[`basic snapshot with all props 1`] = `
 .c0 {
   -webkit-font-smoothing: antialiased;
   color: #505558;
@@ -23,6 +23,11 @@ exports[`basic snapshot 1`] = `
   padding-left: 20px;
   padding-right: 20px;
   padding-top: 14px;
+  white-space: pre-wrap;
+}
+
+.c1 {
+  margin-top: 40px;
 }
 
 <div
@@ -31,13 +36,70 @@ exports[`basic snapshot 1`] = `
   <div
     className="c0"
   >
-    Dat address be wrong!
+    Something is wrong
   </div>
   <div
-    className={null}
-    style={Object {}}
+    className="c1"
   >
-    SelectableList(undefined)
+    <div
+      className={null}
+      style={Object {}}
+    >
+      SelectableList(undefined)
+    </div>
+  </div>
+</div>
+`;
+
+exports[`basic snapshot with only required props 1`] = `
+.c0 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  border-color: #fbc120;
+  border-style: solid;
+  border-width: 1px;
+  background-color: #fcf3dc;
+  color: #7a6322;
+  padding-bottom: 14px;
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-top: 14px;
+  white-space: pre-wrap;
+}
+
+.c1 {
+  margin-top: 40px;
+}
+
+<div
+  className={undefined}
+>
+  <div
+    className="c0"
+  >
+    The address you entered may be incorrect or incomplete.
+
+Please review our suggestion below, and choose which version you’d like to use. Errors are shown in red.
+  </div>
+  <div
+    className="c1"
+  >
+    <div
+      className={null}
+      style={Object {}}
+    >
+      SelectableList(undefined)
+    </div>
   </div>
 </div>
 `;

--- a/package/src/components/SelectableItem/v1/SelectableItem.js
+++ b/package/src/components/SelectableItem/v1/SelectableItem.js
@@ -77,8 +77,8 @@ const StyledDetail = styled.div`
   align-items: center;
   display: flex;
   justify-content: ${(props) => (props.isStacked ? "flex-start" : "center")};
-  margin-left: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingToLabel") : "0")}
-  margin-top: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingBelowLabel") : "0")};
+  margin-left: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingToLabel")(props) : "0")};
+  margin-top: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingBelowLabel")(props) : "0")};
 `;
 
 const StyledIcon = styled.span`

--- a/package/src/components/SelectableItem/v1/SelectableItem.js
+++ b/package/src/components/SelectableItem/v1/SelectableItem.js
@@ -6,10 +6,15 @@ import { withComponents } from "@reactioncommerce/components-context";
 import { addTypographyStyles, applyTheme } from "../../../utils";
 
 const StyledLabel = styled.label`
-  ${addTypographyStyles("SelectableItemLabel", "labelText")}
   align-items: center;
   cursor: pointer;
   display: flex;
+  ${(props) => {
+    if (props.isStacked) {
+      return addTypographyStyles("SelectableItemLabel", "labelTextBold");
+    }
+    return addTypographyStyles("SelectableItemLabel", "labelText");
+  }}
 `;
 
 const StyledRadioButton = styled.span`
@@ -71,7 +76,9 @@ const StyledDetail = styled.div`
   ${addTypographyStyles("SelectableItemDetail", "bodyText")}
   align-items: center;
   display: flex;
-  justify-content: center;
+  justify-content: ${(props) => (props.isStacked ? "flex-start" : "center")};
+  margin-top: ${(props) => (props.isStacked ? "10px" : "0")};
+  margin-left: ${(props) => (props.isStacked ? "30px" : "0")}
 `;
 
 const StyledIcon = styled.span`
@@ -93,8 +100,9 @@ const StyledIcon = styled.span`
 
 const StyledItem = styled.div`
   display: flex;
-  justify-content: space-between;
-  height: ${applyTheme("SelectableList.height")};
+  justify-content: ${(props) => (props.isStacked ? "none" : "space-between")};
+  flex-direction: ${(props) => (props.isStacked ? "column" : "row")};
+  height:${(props) => (props.isStacked ? "inherit" : applyTheme("SelectableList.height"))};
   @media (max-width: 768px) {
     height: ${applyTheme("SelectableList.heightMobile")};
   }
@@ -146,6 +154,10 @@ class SelectableItem extends Component {
      */
     isReadOnly: PropTypes.bool,
     /**
+     * Stacked style, designed to be used with isHorizontal SelectableList
+     */
+    isStacked: PropTypes.bool,
+    /**
      * Label
      */
     label: PropTypes.string.isRequired,
@@ -164,7 +176,8 @@ class SelectableItem extends Component {
     onChange() { },
     isChecked: false,
     isLeftAligned: false,
-    isReadOnly: false
+    isReadOnly: false,
+    isStacked: false
   };
 
   uniqueInstanceIdentifier = uniqueId("SelectableItem_");
@@ -182,6 +195,7 @@ class SelectableItem extends Component {
       isChecked,
       isLeftAligned,
       isReadOnly,
+      isStacked,
       label,
       value
     } = this.props;
@@ -202,6 +216,7 @@ class SelectableItem extends Component {
     const labelAndButton = (
       <StyledLabel
         htmlFor={id}
+        isStacked={isStacked}
       >
         <StyledRadioButton />
         {icon ? <StyledIcon>{icon}</StyledIcon> : null}
@@ -212,17 +227,17 @@ class SelectableItem extends Component {
     return (
       <div className={className}>
         {isLeftAligned ?
-          <LeftAlignedItem>
+          <LeftAlignedItem isStacked={isStacked}>
             {input}
             {labelAndButton}
-            {detail ? <StyledDetail>{detail}</StyledDetail> : null}
-          </LeftAlignedItem >
+            {detail ? <StyledDetail isStacked={isStacked}>{detail}</StyledDetail> : null}
+          </LeftAlignedItem>
           :
-          <StyledItem>
+          <StyledItem isStacked={isStacked}>
             {input}
             {labelAndButton}
-            {detail ? <StyledDetail>{detail}</StyledDetail> : null}
-          </StyledItem >
+            {detail ? <StyledDetail isStacked={isStacked}>{detail}</StyledDetail> : null}
+          </StyledItem>
         }
       </div>
     );

--- a/package/src/components/SelectableItem/v1/SelectableItem.js
+++ b/package/src/components/SelectableItem/v1/SelectableItem.js
@@ -77,8 +77,8 @@ const StyledDetail = styled.div`
   align-items: center;
   display: flex;
   justify-content: ${(props) => (props.isStacked ? "flex-start" : "center")};
-  margin-top: ${(props) => (props.isStacked ? "10px" : "0")};
-  margin-left: ${(props) => (props.isStacked ? "30px" : "0")}
+  margin-left: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingToLabel") : "0")}
+  margin-top: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingBelowLabel") : "0")};
 `;
 
 const StyledIcon = styled.span`

--- a/package/src/components/SelectableItem/v1/SelectableItem.md
+++ b/package/src/components/SelectableItem/v1/SelectableItem.md
@@ -36,9 +36,9 @@ An individual item can be checked or unchecked, and read-only or editable:
 
 #### SelectableItem with `detail`
 
-Pass any element - text, SVGs or React elements - into `detail` to display a secondary action on the right-hand side.
+Pass any element - text, SVGs, other components, like `Address`,  or any React elements - into `detail` to display a secondary information and action on the right-hand side.
 
-##### Plain text
+##### Plain text as detail
 
 ```jsx
 <SelectableItem label="Free shipping" detail="$0.00" value="free"/>
@@ -48,7 +48,7 @@ Pass any element - text, SVGs or React elements - into `detail` to display a sec
 <SelectableItem label="Free shipping" detail="\u2714" value="free"/>
 ```
 
-##### Element
+##### Element as detail
 
 ```jsx
 const link = (
@@ -56,6 +56,28 @@ const link = (
 );
 
 <SelectableItem label="Default" detail={link} value="default8" />
+```
+
+##### Address as detail
+
+```jsx
+const address = {
+  _id: "1",
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const addressElement = (
+  <Address address={address} />
+);
+
+<SelectableItem isStacked label="Entered address:" detail={addressElement} value="default12" />
 ```
 
 ##### Icon as detail
@@ -74,17 +96,17 @@ const iconVisa = require("../../../../../package/src/svg/iconVisa").default;
 
 ### Specs
 
-|Property                                |Style                                |
-|----------------------------------------|:-----------------------------------:|
-|Label font                              | `@rui-label-text` capitalized       |
-|Label color                             | `@cool-grey-500`                    |
-|Border color                            | `@cool-grey-500`                    |
-|Radio button color                      | `@cool-grey-500`                    |
-|Radio button height and width           | 20px                                |
-|Radio button and label spacing          | 11px                                |
-|Radio button border                     | 2px solid `@cool-grey-500`          |
-|Selected circle size                    | 11px                                |
-|Cursor                                  | Pointer (radio button and label)    |
+| Property                       | Style                            |
+| ------------------------------ | :------------------------------: |
+| Label font                     | `@rui-label-text` capitalized    |
+| Label color                    | `@cool-grey-500`                 |
+| Border color                   | `@cool-grey-500`                 |
+| Radio button color             | `@cool-grey-500`                 |
+| Radio button height and width  | 20px                             |
+| Radio button and label spacing | 11px                             |
+| Radio button border            | 2px solid `@cool-grey-500`       |
+| Selected circle size           | 11px                             |
+| Cursor                         | Pointer (radio button and label) |
 
 ### Theme
 

--- a/package/src/components/SelectableItem/v1/SelectableItem.md
+++ b/package/src/components/SelectableItem/v1/SelectableItem.md
@@ -96,17 +96,19 @@ const iconVisa = require("../../../../../package/src/svg/iconVisa").default;
 
 ### Specs
 
-| Property                       | Style                            |
-| ------------------------------ | :------------------------------: |
-| Label font                     | `@rui-label-text` capitalized    |
-| Label color                    | `@cool-grey-500`                 |
-| Border color                   | `@cool-grey-500`                 |
-| Radio button color             | `@cool-grey-500`                 |
-| Radio button height and width  | 20px                             |
-| Radio button and label spacing | 11px                             |
-| Radio button border            | 2px solid `@cool-grey-500`       |
-| Selected circle size           | 11px                             |
-| Cursor                         | Pointer (radio button and label) |
+| Property                       | Style                                     |
+| ------------------------------ | :---------------------------------------: |
+| Label font                     | `@rui-label-text` capitalized             |
+| Label font weight              | `400`                                     |
+| Label font weight              | `700` when `isStacked` or `isLeftAligned` |
+| Label color                    | `@cool-grey-500`                          |
+| Border color                   | `@cool-grey-500`                          |
+| Radio button color             | `@cool-grey-500`                          |
+| Radio button height and width  | 20px                                      |
+| Radio button and label spacing | 11px                                      |
+| Radio button border            | 2px solid `@cool-grey-500`                |
+| Selected circle size           | 11px                                      |
+| Cursor                         | Pointer (radio button and label)          |
 
 ### Theme
 
@@ -142,7 +144,8 @@ Assume that any theme prop that does not begin with "rui" is within `rui_compone
 | `SelectableList.itemPaddingTop`                  | 0                          | Top padding for each item                                  |
 | `SelectableList.leftAlignedLabelFontWeight`      | 700                        | Font weight for the label when `isLeftAligned`             |
 | `SelectableList.leftAlignedDetailSpacingToLabel` | 2px                        | Spacing between label and detail text when `isLeftAligned` |
-
+| `SelectableList.stackedSpacingToLabel`           | 30px                       | Spacing between radio button and detail when `isStacked`   |
+| `SelectableList.stackedSpacingBelowLabel`        | 10px                       | Spacing between label and detail when `isStacked`          |
 #### Typography
 
 - The label text uses `labelText` style with `rui_components.SelectableItemLabel` override

--- a/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
+++ b/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
@@ -2,6 +2,15 @@
 
 exports[`basic snapshot with empty props 1`] = `
 .c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-font-smoothing: antialiased;
   color: #505558;
   font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
@@ -14,15 +23,6 @@ exports[`basic snapshot with empty props 1`] = `
   -ms-letter-spacing: .02em;
   letter-spacing: .02em;
   line-height: 1.25;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .c5 {
@@ -122,6 +122,8 @@ exports[`basic snapshot with empty props 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  margin-top: 0;
+  margin-left: 0;
 }
 
 .c0 {
@@ -133,6 +135,9 @@ exports[`basic snapshot with empty props 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   height: 50px;
 }
 

--- a/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
+++ b/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
@@ -122,8 +122,7 @@ exports[`basic snapshot with empty props 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-top: 0;
-  margin-left: 0;
+  margin-left: 0 margin-top:0;
 }
 
 .c0 {

--- a/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
+++ b/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
@@ -122,7 +122,8 @@ exports[`basic snapshot with empty props 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0 margin-top:0;
+  margin-left: 0;
+  margin-top: 0;
 }
 
 .c0 {

--- a/package/src/components/SelectableList/v1/SelectableList.js
+++ b/package/src/components/SelectableList/v1/SelectableList.js
@@ -156,7 +156,6 @@ class SelectableList extends Component {
      * Adds styles and blocks users from selecting items
      */
     isReadOnly: PropTypes.bool,
-    isStacked: PropTypes.bool,
     /**
      * An extra row at the bottom of the list for an action, like Add an address
      */
@@ -176,31 +175,29 @@ class SelectableList extends Component {
     /**
      * Options, an Array of SelectableItems
      */
-    options: PropTypes.arrayOf(
-      PropTypes.shape({
-        /**
+    options: PropTypes.arrayOf(PropTypes.shape({
+      /**
          * Optional text, SVG or element displayed on the right-hand side
          */
-        detail: PropTypes.node,
-        /**
+      detail: PropTypes.node,
+      /**
          * Optional icon (SVG) displayed on the left-hand side
          */
-        icon: PropTypes.node,
-        /**
+      icon: PropTypes.node,
+      /**
          * The item ID. Each option must have a unique ID
          */
-        id: PropTypes.string.isRequired,
-        /**
+      id: PropTypes.string.isRequired,
+      /**
          * Label
          */
-        label: PropTypes.string.isRequired,
-        /**
+      label: PropTypes.string.isRequired,
+      /**
          * Value of this option, which will be the value passed back from SelectableList if
          * this option is selected.
          */
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired
-      })
-    ).isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired
+    })).isRequired,
     /**
      * Set this to the current saved value, if editing, or a default value if creating. The closest form implementing
      * the Composable Forms spec will pass this automatically.
@@ -224,13 +221,13 @@ class SelectableList extends Component {
     };
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
-    // eslint-disable-line camelcase
     this.handleChange(this.props.value || "");
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
-    // eslint-disable-line camelcase
     const { value } = this.props;
     const { value: nextValue } = nextProps;
 
@@ -327,7 +324,7 @@ class SelectableList extends Component {
   }
 
   renderHorizontalList() {
-    const { options, listAction, isStacked, isReadOnly, components: { SelectableItem } } = this.props;
+    const { options, listAction, isHorizontal, isReadOnly, components: { SelectableItem } } = this.props;
     return (
       <HorizontalList>
         {options.map((option) => (
@@ -336,7 +333,7 @@ class SelectableList extends Component {
               detail={option.detail}
               icon={option.icon}
               isChecked={option.value === this.state.value}
-              isStacked={isStacked}
+              isStacked={isHorizontal}
               isReadOnly={isReadOnly}
               label={option.label}
               onChange={this.onChange}
@@ -353,9 +350,10 @@ class SelectableList extends Component {
     const { className, isBordered, isHorizontal } = this.props;
     return (
       <div className={className}>
-        {isHorizontal
-          ? this.renderHorizontalList()
-          : isBordered ? this.renderBorderedList() : this.renderVerticalList()}
+        {// eslint-disable-next-line
+          isHorizontal
+            ? this.renderHorizontalList()
+            : isBordered ? this.renderBorderedList() : this.renderVerticalList()}
       </div>
     );
   }

--- a/package/src/components/SelectableList/v1/SelectableList.js
+++ b/package/src/components/SelectableList/v1/SelectableList.js
@@ -89,7 +89,6 @@ const BorderedWrapper = styled.div`
 
 const HorizontalList = styled.div`
   display: flex;
-  margin-top: 40px;
 `;
 
 const HorizontalWrapper = styled.div`

--- a/package/src/components/SelectableList/v1/SelectableList.js
+++ b/package/src/components/SelectableList/v1/SelectableList.js
@@ -87,6 +87,14 @@ const BorderedWrapper = styled.div`
   }
 `;
 
+const HorizontalList = styled.div`
+  display: flex;
+`;
+
+const HorizontalWrapper = styled.div`
+  flex: 0 1 calc(50% - 10px);
+`;
+
 class SelectableList extends Component {
   static isFormInput = true;
 
@@ -116,6 +124,10 @@ class SelectableList extends Component {
      */
     isBordered: PropTypes.bool,
     /**
+     * Displays SelectableList horizontaly
+     */
+    isHorizontal: PropTypes.bool,
+    /**
      * Is Left Aligned
      */
     isLeftAligned: PropTypes.bool,
@@ -123,6 +135,7 @@ class SelectableList extends Component {
      * Adds styles and blocks users from selecting items
      */
     isReadOnly: PropTypes.bool,
+    isStacked: PropTypes.bool,
     /**
      * An extra row at the bottom of the list for an action, like Add an address
      */
@@ -142,29 +155,31 @@ class SelectableList extends Component {
     /**
      * Options, an Array of SelectableItems
      */
-    options: PropTypes.arrayOf(PropTypes.shape({
-      /**
-       * Optional text, SVG or element displayed on the right-hand side
-       */
-      detail: PropTypes.node,
-      /**
-       * Optional icon (SVG) displayed on the left-hand side
-       */
-      icon: PropTypes.node,
-      /**
-       * The item ID. Each option must have a unique ID
-       */
-      id: PropTypes.string.isRequired,
-      /**
-       * Label
-       */
-      label: PropTypes.string.isRequired,
-      /**
-       * Value of this option, which will be the value passed back from SelectableList if
-       * this option is selected.
-       */
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired
-    })).isRequired,
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        /**
+         * Optional text, SVG or element displayed on the right-hand side
+         */
+        detail: PropTypes.node,
+        /**
+         * Optional icon (SVG) displayed on the left-hand side
+         */
+        icon: PropTypes.node,
+        /**
+         * The item ID. Each option must have a unique ID
+         */
+        id: PropTypes.string.isRequired,
+        /**
+         * Label
+         */
+        label: PropTypes.string.isRequired,
+        /**
+         * Value of this option, which will be the value passed back from SelectableList if
+         * this option is selected.
+         */
+        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired
+      })
+    ).isRequired,
     /**
      * Set this to the current saved value, if editing, or a default value if creating. The closest form implementing
      * the Composable Forms spec will pass this automatically.
@@ -174,10 +189,11 @@ class SelectableList extends Component {
 
   static defaultProps = {
     isBordered: false,
+    isHorizontal: false,
     isLeftAligned: false,
     isReadOnly: false,
-    onChange() { },
-    onChanging() { }
+    onChange() {},
+    onChanging() {}
   };
 
   constructor(props) {
@@ -187,11 +203,13 @@ class SelectableList extends Component {
     };
   }
 
-  UNSAFE_componentWillMount() { // eslint-disable-line camelcase
+  UNSAFE_componentWillMount() {
+    // eslint-disable-line camelcase
     this.handleChange(this.props.value || "");
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    // eslint-disable-line camelcase
     const { value } = this.props;
     const { value: nextValue } = nextProps;
 
@@ -235,59 +253,88 @@ class SelectableList extends Component {
     return this.state.value !== this.props.value;
   }
 
+  renderBorderedList() {
+    const { options, listAction, isLeftAligned, isReadOnly, components: { SelectableItem } } = this.props;
+
+    return (
+      <BorderedList>
+        <fieldset>
+          {options.map((option) => (
+            <BorderedWrapper key={option.id}>
+              <SelectableItem
+                detail={option.detail}
+                icon={option.icon}
+                isChecked={option.value === this.state.value}
+                isLeftAligned={isLeftAligned}
+                isReadOnly={isReadOnly}
+                label={option.label}
+                onChange={this.onChange}
+                value={option.value}
+              />
+            </BorderedWrapper>
+          ))}
+        </fieldset>
+        {listAction ? <BorderedListAction>{listAction}</BorderedListAction> : null}
+      </BorderedList>
+    );
+  }
+
+  renderVerticalList() {
+    const { options, listAction, isLeftAligned, isReadOnly, components: { SelectableItem } } = this.props;
+
+    return (
+      <StyledList>
+        <fieldset>
+          {options.map((option) => (
+            <StyledWrapper key={option.id}>
+              <SelectableItem
+                detail={option.detail}
+                icon={option.icon}
+                isChecked={option.value === this.state.value}
+                isLeftAligned={isLeftAligned}
+                isReadOnly={isReadOnly}
+                label={option.label}
+                onChange={this.onChange}
+                value={option.value}
+              />
+            </StyledWrapper>
+          ))}
+        </fieldset>
+        {listAction ? <StyledListAction>{listAction}</StyledListAction> : null}
+      </StyledList>
+    );
+  }
+
+  renderHorizontalList() {
+    const { options, listAction, isStacked, isReadOnly, components: { SelectableItem } } = this.props;
+    return (
+      <HorizontalList>
+        {options.map((option) => (
+          <HorizontalWrapper key={option.id}>
+            <SelectableItem
+              detail={option.detail}
+              icon={option.icon}
+              isChecked={option.value === this.state.value}
+              isStacked={isStacked}
+              isReadOnly={isReadOnly}
+              label={option.label}
+              onChange={this.onChange}
+              value={option.value}
+            />
+          </HorizontalWrapper>
+        ))}
+        {listAction ? <StyledListAction>{listAction}</StyledListAction> : null}
+      </HorizontalList>
+    );
+  }
+
   render() {
-    const {
-      className,
-      options,
-      listAction,
-      isBordered,
-      isLeftAligned,
-      isReadOnly,
-      components: { SelectableItem }
-    } = this.props;
+    const { className, isBordered, isHorizontal } = this.props;
     return (
       <div className={className}>
-        {isBordered ?
-          <BorderedList>
-            <fieldset>
-              {options.map((option) => (
-                <BorderedWrapper key={option.id}>
-                  <SelectableItem
-                    detail={option.detail}
-                    icon={option.icon}
-                    isChecked={option.value === this.state.value}
-                    isLeftAligned={isLeftAligned}
-                    isReadOnly={isReadOnly}
-                    label={option.label}
-                    onChange={this.onChange}
-                    value={option.value}
-                  />
-                </BorderedWrapper>
-              ))}
-            </fieldset>
-            {listAction ? <BorderedListAction>{listAction}</BorderedListAction> : null}
-          </BorderedList>
-          :
-          <StyledList>
-            <fieldset>
-              {options.map((option) => (
-                <StyledWrapper key={option.id}>
-                  <SelectableItem
-                    detail={option.detail}
-                    icon={option.icon}
-                    isChecked={option.value === this.state.value}
-                    isLeftAligned={isLeftAligned}
-                    isReadOnly={isReadOnly}
-                    label={option.label}
-                    onChange={this.onChange}
-                    value={option.value}
-                  />
-                </StyledWrapper>
-              ))}
-            </fieldset>
-            {listAction ? <StyledListAction>{listAction}</StyledListAction> : null}
-          </StyledList>
-        }
+        {isHorizontal
+          ? this.renderHorizontalList()
+          : isBordered ? this.renderBorderedList() : this.renderVerticalList()}
       </div>
     );
   }

--- a/package/src/components/SelectableList/v1/SelectableList.js
+++ b/package/src/components/SelectableList/v1/SelectableList.js
@@ -89,10 +89,32 @@ const BorderedWrapper = styled.div`
 
 const HorizontalList = styled.div`
   display: flex;
+  margin-top: 40px;
 `;
 
 const HorizontalWrapper = styled.div`
-  flex: 0 1 calc(50% - 10px);
+  border-left-color: ${applyTheme("SelectableList.borderColor")};
+  border-left-style: ${applyTheme("SelectableList.borderStyle")};
+  border-left-width: ${applyTheme("SelectableList.borderWidth")};
+  flex: 1 1 auto;
+  padding-bottom: ${applyTheme("SelectableList.horizontalItemPaddingBottom")};
+  padding-left: ${applyTheme("SelectableList.horizontalItemPaddingLeft")};
+  padding-right: ${applyTheme("SelectableList.horizontalItemPaddingRight")};
+  padding-top: ${applyTheme("SelectableList.horizontalItemPaddingTop")};
+
+  &:first-of-type {
+    border-left: none;
+    padding-right: ${applyTheme("SelectableList.horizontalFirstItemPaddingRight")};
+  }
+
+  &:last-of-type {
+    padding-left: ${applyTheme("SelectableList.horizontalLastItemPaddingLeft")};
+  }
+
+  div {
+    display: block;
+    height: auto;
+  }
 `;
 
 class SelectableList extends Component {

--- a/package/src/components/SelectableList/v1/SelectableList.md
+++ b/package/src/components/SelectableList/v1/SelectableList.md
@@ -111,6 +111,27 @@ const options = [{
 <SelectableList isLeftAligned options={options} value="standard" name="LeftAlignedBorderedForm"/>
 ```
 
+#### Horizontal
+
+Pass the `isHorizontal` prop to get a horizontal list:
+
+```jsx
+const options = [{
+  id: "331",
+  label: "Standard (5-9 days)",
+  detail: "Free",
+  value: "standard"
+},
+{
+  id: "232",
+  label: "Priority (3-5 days)",
+  value: "priority",
+  detail: "$5.99"
+}];
+
+<SelectableList isHorizontal options={options} name="HorizontalForm" value="standard"/>
+```
+
 ### Examples
 
 #### Shipping address list
@@ -233,6 +254,12 @@ Assume that any theme prop that does not begin with "rui" is within `rui_compone
 | `SelectableList.itemPaddingTop`                  | 0                          | Top padding for each item                                  |
 | `SelectableList.leftAlignedLabelFontWeight`      | 700                        | Font weight for the label when `isLeftAligned`             |
 | `SelectableList.leftAlignedDetailSpacingToLabel` | 2px                        | Spacing between label and detail text when `isLeftAligned` |
+| `SelectableList.horizontalItemPaddingBottom` | 20px                        | Item bottom padding when `isHorizontal` |
+| `SelectableList.horizontalItemPaddingLeft` | 20px                        | Item left padding when `isHorizontal` |
+| `SelectableList.horizontalItemPaddingRight` | 20px                        | Item right padding when `isHorizontal` |
+| `SelectableList.horizontalItemPaddingTop` | 20px                        | Item top padding when `isHorizontal` |
+| `SelectableList.horizontalFirstItemPaddingRight` | 40px                        | First item right padding when `isHorizontal` |
+| `SelectableList.horizontalLastItemPaddingLeft` | 40px                        | Last item left padding when `isHorizontal` |
 
 #### Typography
 

--- a/package/src/theme/colors.js
+++ b/package/src/theme/colors.js
@@ -71,7 +71,7 @@ export default {
   darkBlue600: "#242c30",
 
   // support colors
-  yellow: "#3fc95f",
+  yellow: "#efc95f",
   yellow100: "#fcf3dc",
   yellow200: "#e9e1cb",
   yellow300: "#fdda79",

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -100,7 +100,8 @@ const rui_components = {
     warningMessagePaddingBottom: padding.fourteen,
     warningMessagePaddingLeft: padding.twenty,
     warningMessagePaddingRight: padding.twenty,
-    warningMessagePaddingTop: padding.fourteen
+    warningMessagePaddingTop: padding.fourteen,
+    spacingTop: "40px"
   },
   BadgeOverlay: {
     fadedOpacity: "0.5"
@@ -601,7 +602,13 @@ const rui_components = {
     itemPaddingRight: "10px",
     itemPaddingTop: "0",
     leftAlignedLabelFontWeight: 700,
-    leftAlignedDetailSpacingToLabel: "2px"
+    leftAlignedDetailSpacingToLabel: "2px",
+    horizontalItemPaddingBottom: padding.twenty,
+    horizontalItemPaddingLeft: padding.twenty,
+    horizontalItemPaddingRight: padding.twenty,
+    horizontalItemPaddingTop: padding.twenty,
+    horizontalFirstItemPaddingRight: "40px",
+    horizontalLastItemPaddingLeft: "40px"
   },
   SelectMenu: {
     borderBottomColor: colors.black20,

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -64,10 +64,10 @@ const rui_components = {
     addressPropertyErrorBorderStyle: "solid",
     addressPropertyErrorBorderWidth: "1px",
     addressPropertyErrorColor: colors.red400,
-    addressPropertyErrorPaddingBottom: padding.two,
+    addressPropertyErrorPaddingBottom: "0",
     addressPropertyErrorPaddingLeft: padding.four,
     addressPropertyErrorPaddingRight: padding.four,
-    addressPropertyErrorPaddingTop: padding.two
+    addressPropertyErrorPaddingTop: "0"
   },
   AddressBook: {
     borderColor: colors.black10,

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -608,7 +608,9 @@ const rui_components = {
     horizontalItemPaddingRight: padding.twenty,
     horizontalItemPaddingTop: padding.twenty,
     horizontalFirstItemPaddingRight: "40px",
-    horizontalLastItemPaddingLeft: "40px"
+    horizontalLastItemPaddingLeft: "40px",
+    stackedSpacingToLabel: "30px",
+    stackedSpacingBelowLabel: "10px"
   },
   SelectMenu: {
     borderBottomColor: colors.black20,

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -101,7 +101,7 @@ const rui_components = {
     warningMessagePaddingLeft: padding.twenty,
     warningMessagePaddingRight: padding.twenty,
     warningMessagePaddingTop: padding.fourteen,
-    spacingTop: "40px"
+    formSpacingTop: "40px"
   },
   BadgeOverlay: {
     fadedOpacity: "0.5"

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -57,6 +57,18 @@ const rui_components = {
     spacingAfterName: "4px",
     spacingBetweenImageAndContent: "16px"
   },
+  Address: {
+    addressPropertyErrorBackgroundColor: colors.red100,
+    addressPropertyErrorBorderColor: colors.red400,
+    addressPropertyErrorBorderRadius: standardBorderRadius,
+    addressPropertyErrorBorderStyle: "solid",
+    addressPropertyErrorBorderWidth: "1px",
+    addressPropertyErrorColor: colors.red400,
+    addressPropertyErrorPaddingBottom: padding.two,
+    addressPropertyErrorPaddingLeft: padding.four,
+    addressPropertyErrorPaddingRight: padding.four,
+    addressPropertyErrorPaddingTop: padding.two
+  },
   AddressBook: {
     borderColor: colors.black10,
     borderRadius: standardBorderRadius,
@@ -78,6 +90,17 @@ const rui_components = {
     addActionPaddingTop: padding.sixteen,
     actionDeleteButtonHoverColor: colors.redHover,
     spaceBetweenActiveActionButtons: padding.sixteen
+  },
+  AddressReview: {
+    warningMessageBorderColor: colors.yellow400,
+    warningMessageBorderStyle: "solid",
+    warningMessageBorderWidth: "1px",
+    warningMessageBackgroundColor: colors.yellow100,
+    warningMessageColor: colors.yellow600,
+    warningMessagePaddingBottom: padding.fourteen,
+    warningMessagePaddingLeft: padding.twenty,
+    warningMessagePaddingRight: padding.twenty,
+    warningMessagePaddingTop: padding.fourteen
   },
   BadgeOverlay: {
     fadedOpacity: "0.5"

--- a/package/src/utils/addressToString.js
+++ b/package/src/utils/addressToString.js
@@ -1,0 +1,10 @@
+/**
+ *
+ * @method addressToString
+ * @summary Converts an `address` object to a string
+ * @param {Object} address - Address object to be converted
+ * @return {String} - address as a flat string
+ */
+export default function addressToString({ address1, address2, city, country, postal, region }) {
+  return `${address1}${address2 ? `, ${address2}` : ""}, ${city}, ${region} ${postal} ${country}`;
+}

--- a/package/src/utils/index.js
+++ b/package/src/utils/index.js
@@ -6,3 +6,4 @@ export { default as preventAccidentalDoubleClick } from "./preventAccidentalDoub
 export { default as getRequiredValidator } from "./getRequiredValidator";
 export { default as getPhoneNumberValidator } from "./getPhoneNumberValidator";
 export { default as withStripeElements } from "./withStripeElements";
+export { default as addressToString } from "./addressToString";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -404,6 +404,7 @@ module.exports = {
         generateSection({
           componentNames: [
             "Accordion",
+            "Address",
             "ProgressiveImage"
           ],
           content: "styleguide/src/sections/Content.md",
@@ -439,9 +440,6 @@ module.exports = {
       sections: [
         generateSection({
           componentNames: [
-            "Address",
-            "AddressBook",
-            "AddressReview",
             "ShopLogo"
           ],
           content: "styleguide/src/sections/General.md",
@@ -490,6 +488,7 @@ module.exports = {
         generateSection({
           componentNames: [
             "AddressForm",
+            "AddressReview",
             "GuestForm",
             "StripeForm"
           ],
@@ -499,6 +498,7 @@ module.exports = {
         generateSection({
           componentNames: [
             "AccountProfileInfo",
+            "AddressBook",
             "ProfileImage",
             "ViewerInfo"
           ],

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -439,6 +439,7 @@ module.exports = {
       sections: [
         generateSection({
           componentNames: [
+            "Address",
             "AddressBook",
             "AddressReview",
             "ShopLogo"

--- a/styleguide/src/appComponents.js
+++ b/styleguide/src/appComponents.js
@@ -10,6 +10,7 @@ import iconMastercard from "../../package/src/svg/iconMastercard";
 import iconVisa from "../../package/src/svg/iconVisa";
 import spinner from "../../package/src/svg/spinner";
 import Accordion from "../../package/src/components/Accordion/v1";
+import Address from "../../package/src/components/Address/v1";
 import AddressBook from "../../package/src/components/AddressBook/v1";
 import AddressForm from "../../package/src/components/AddressForm/v1";
 import AddressReview from "../../package/src/components/AddressReview/v1";
@@ -50,6 +51,7 @@ const AddressFormWithLocales = withLocales(AddressForm);
 
 export default {
   Accordion,
+  Address,
   AddressBook,
   AddressForm: AddressFormWithLocales,
   AddressReview,


### PR DESCRIPTION
Resolves #122 & #277 
Impact: **major**  
Type: **feature**

## Component
**AddressReview**
  *  Based on this [spec](https://github.com/reactioncommerce/reaction-component-library/issues/122)

**Address**
  *  Created an Address component that displays an Address

**SelectableList Enhancement** 
  *   Adds `isHorizontal` prop: Updated to allow a horizontal layout along with the vertical style.
  *   Adds `isStacked` prop: Updated to allow `detail` to display stacked under the label along with the right/left aligned.

## Screenshots
<img width="1065" alt="screen shot 2018-10-18 at 1 48 41 pm" src="https://user-images.githubusercontent.com/3673236/47183317-9046d780-d2dc-11e8-9c7e-b63efa19e8c7.png">
⚠️ The alert is not part of this component. The alert will be worked on next. This alert is just a mock-up.

## Breaking changes
N/A

## Testing
1. **AddressReview**: https://deploy-preview-336--stoic-hodgkin-c0179e.netlify.com/#!/AddressReview
    * Open broswer console and test the example implamentation towards the bottom of the page.
    * You should see the selected address object in the console after you click submit.
2. **Address**: https://deploy-preview-336--stoic-hodgkin-c0179e.netlify.com/#!/Address
    * Verify it's workings and looks as expected.
3. **SelectableList**: https://deploy-preview-336--stoic-hodgkin-c0179e.netlify.com/#!/SelectableList
    *  Verify the `isHorizontal` prop is working and looks as expected. 
3. **SelectableItem**: https://deploy-preview-336--stoic-hodgkin-c0179e.netlify.com/#!/SelectableItem 
    * Verify the `isStacked` prop is working and looks as expected. (see Address as detail header)