### PR TITLE
feat: 338 nnnnat shipping address review

### DIFF
--- a/package/src/components/AddressBook/v1/AddressBook.js
+++ b/package/src/components/AddressBook/v1/AddressBook.js
@@ -192,19 +192,19 @@ class AddressBook extends Component {
   //
   // Handler Methods
   //
-  handleAddAddress = (value) => {
+  handleAddAddress = async (value) => {
     const { onAddressAdded } = this.props;
-    onAddressAdded(value);
+    await onAddressAdded(value);
   };
 
-  handleDeleteAddress = (value, _id) => {
+  handleDeleteAddress = async (value, _id) => {
     const { onAddressDeleted } = this.props;
-    onAddressDeleted(_id);
+    await onAddressDeleted(_id);
   };
 
-  handleEditAddress = (value, _id) => {
+  handleEditAddress = async (value, _id) => {
     const { onAddressEdited } = this.props;
-    onAddressEdited(_id, value).then(() => {
+    await onAddressEdited(_id, value).then(() => {
       this._refs[`accordion_${_id}`].toggle();
     });
   };
@@ -332,8 +332,8 @@ class AddressBook extends Component {
       <div className={className}>
         {// eslint-disable-next-line
         status === REVIEW
-            ? this.renderAddressReview()
-            : status === OVERVIEW ? this.renderAddressSelect() : this.renderAddressForm()}
+          ? this.renderAddressReview()
+          : status === OVERVIEW ? this.renderAddressSelect() : this.renderAddressForm()}
       </div>
     );
   }

--- a/package/src/components/AddressBook/v1/AddressBook.js
+++ b/package/src/components/AddressBook/v1/AddressBook.js
@@ -332,8 +332,8 @@ class AddressBook extends Component {
       <div className={className}>
         {// eslint-disable-next-line
         status === REVIEW
-          ? this.renderAddressReview()
-          : status === OVERVIEW ? this.renderAddressSelect() : this.renderAddressForm()}
+            ? this.renderAddressReview()
+            : status === OVERVIEW ? this.renderAddressSelect() : this.renderAddressForm()}
       </div>
     );
   }

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -42,20 +42,10 @@ class AddressReview extends Component {
        */
       Address: CustomPropTypes.component.isRequired,
       /**
-       * Pass either the Reaction Checkbox component or your own component that
+       * Pass either the Reaction SelectableList component or your own component that
        * accepts compatible props.
        */
-      Checkbox: CustomPropTypes.component.isRequired,
-      /**
-       * Pass either the Reaction Field component or your own component that
-       * accepts compatible props.
-       */
-      Field: CustomPropTypes.component.isRequired,
-      /**
-       * Pass either the Reaction InlineAlert component or your own component that
-       * accepts compatible props
-       */
-      InlineAlert: CustomPropTypes.component.isRequired
+      SelectableList: CustomPropTypes.component.isRequired
     }).isRequired,
     /**
      * Is data being saved
@@ -72,23 +62,12 @@ class AddressReview extends Component {
     /**
      * The selected address option
      */
-    value: PropTypes.string,
-    /**
-     * Warning message copy to display above the form
-     */
-    warningMessage: PropTypes.string,
-    /**
-     * Warning message title to display above the form
-     */
-    warningTitle: PropTypes.string
+    value: PropTypes.string
   };
 
   static defaultProps = {
     isSaving: false,
-    value: SUGGESTED,
-    // eslint-disable-next-line
-    warningMessage: "Please review our suggestion below, and choose which version you’d like to use. Possible errors are shown in red.",
-    warningTitle: "The address you entered may be incorrect or incomplete."
+    value: SUGGESTED
   };
 
   _form = null;
@@ -138,11 +117,9 @@ class AddressReview extends Component {
       addressEntered,
       addressSuggestion,
       className,
-      components: { Address, InlineAlert, SelectableList },
+      components: { Address, SelectableList },
       isSaving,
-      value,
-      warningMessage,
-      warningTitle
+      value
     } = this.props;
 
     const options = [
@@ -162,7 +139,6 @@ class AddressReview extends Component {
 
     return (
       <div className={className}>
-        <InlineAlert alertType="warning" title={warningTitle} message={warningMessage} />
         <FormWrapper>
           <Form
             ref={(formEl) => {

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -132,7 +132,7 @@ class AddressReview extends Component {
    * @param {String} value - "entered" or "seggested"
    * @return {Undefined} - Nothing
    */
-  handleSubmit = (value) => {
+  handleSubmit = ({ AddressReview: value }) => {
     const { addressEntered, addressSuggestion, onSubmit } = this.props;
     const selectedAddress = value === ENTERED ? addressEntered : addressSuggestion;
     onSubmit(selectedAddress);

--- a/package/src/components/AddressReview/v1/AddressReview.js
+++ b/package/src/components/AddressReview/v1/AddressReview.js
@@ -132,10 +132,10 @@ class AddressReview extends Component {
    * @param {String} value - "entered" or "seggested"
    * @return {Undefined} - Nothing
    */
-  handleSubmit = ({ AddressReview: value }) => {
+  handleSubmit = async ({ AddressReview: value }) => {
     const { addressEntered, addressSuggestion, onSubmit } = this.props;
     const selectedAddress = value === ENTERED ? addressEntered : addressSuggestion;
-    onSubmit(selectedAddress);
+    await onSubmit(selectedAddress);
   };
 
   render() {

--- a/package/src/components/AddressReview/v1/AddressReview.md
+++ b/package/src/components/AddressReview/v1/AddressReview.md
@@ -60,40 +60,6 @@ const props = { addressEntered, addressSuggestion, value: "entered" };
 <AddressReview {...props} />
 ```
 
-##### Warning Message
-The displayed warning message can be changed by providing a `warningMessage` string as a prop. The text of this element respects line breaks via `\n` within the strings text.
-```jsx
-const addressEntered = {
-  address1: "46 Avenue M",
-  address2: "",
-  country: "HT",
-  city: "Port-au-Prince",
-  fullName: "Yanvalou",
-  postal: "6111",
-  region: "OU",
-  phone: "509 38 01 7051"
-};
-
-const addressSuggestion = {
-  address1: "46 Avenue N",
-  address2: "",
-  country: "HT",
-  city: "Port-au-Prince",
-  fullName: "Yanvalou",
-  postal: "6110",
-  region: "OU",
-  phone: "509 38 01 7051"
-};
-
-const props = { 
-  addressEntered, 
-  addressSuggestion, 
-  warningMessage: "Adrès ou te antre a ka kòrèk oswa enkonplè.\n\nTanpri revize sijesyon nou anba a, epi chwazi ki vèsyon ou ta renmen itilize. Erè yo montre nan wouj." 
-};
-
-<AddressReview {...props} />
-```
-
 #### Example implementation
 Simple `AddressReview` example.
 ```jsx
@@ -156,7 +122,7 @@ Assume that any theme prop that does not begin with "rui" is within `rui_compone
 
 | Theme Prop                     | Default | Description                            |
 | ------------------------------ | ------- | -------------------------------------- |
-| `AddressReview.formSpacingTop` | 40px    | Space between form and warning message |
+| `AddressReview.formSpacingTop` | 40px    | Space between form and content above |
 
 #### Typography
 

--- a/package/src/components/AddressReview/v1/__snapshots__/AddressReview.test.js.snap
+++ b/package/src/components/AddressReview/v1/__snapshots__/AddressReview.test.js.snap
@@ -8,7 +8,6 @@ exports[`basic snapshot with all props 1`] = `
 <div
   className={undefined}
 >
-  InlineAlert(undefined)
   <div
     className="c0"
   >
@@ -30,7 +29,6 @@ exports[`basic snapshot with only required props 1`] = `
 <div
   className={undefined}
 >
-  InlineAlert(undefined)
   <div
     className="c0"
   >

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.js
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.js
@@ -119,7 +119,7 @@ class CheckoutActions extends Component {
        */
       CheckoutActionComplete: CustomPropTypes.component.isRequired,
       /**
-       * Pass either the Reaction CheckboxActionIncomplete component or your own component that
+       * Pass either the Reaction CheckoutActionIncomplete component or your own component that
        * accepts compatible props.
        */
       CheckoutActionIncomplete: CustomPropTypes.component.isRequired
@@ -270,7 +270,6 @@ class CheckoutActions extends Component {
 
   renderActiveAction = ({ component: Comp, ...action }) => {
     const { isSaving } = this.getCurrentActionByID(action.id);
-
     return (
       <Fragment>
         <Comp
@@ -315,11 +314,7 @@ class CheckoutActions extends Component {
     const { className, actions } = this.props;
     const activeActions = this.determineActiveActions();
 
-    return (
-      <div className={className}>
-        {actions.map((action) => this.renderAction(action, activeActions))}
-      </div>
-    );
+    return <div className={className}>{actions.map((action) => this.renderAction(action, activeActions))}</div>;
   }
 }
 

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.js
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.js
@@ -239,7 +239,7 @@ class CheckoutActions extends Component {
 
     const saveAndContinueButtons = (
       <React.Fragment>
-        {action.props ? (
+        {(action.props.fulfillmentGroup && action.props.fulfillmentGroup.data.shippingAddress) || action.id !== "1" ? (
           <Button
             actionType="secondary"
             onClick={() => {

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -196,6 +196,12 @@ class CheckoutActionsExample extends React.Component {
     super(props)
     this.state = {
       addressValidationResults: null,
+      actionAlerts: {
+        1: null,
+        2: null,
+        3: null,
+        4: null
+      },
       checkout: {
         fulfillmentGroups,
         payments: paymentMethods
@@ -235,13 +241,20 @@ class CheckoutActionsExample extends React.Component {
     return new Promise((resolve, reject) => {
         setTimeout(() => {
           this.setState((state, props) => {
-            const { checkout } = state;
+            const { actionAlerts, checkout } = state;
+            actionAlerts["1"] = {
+              alertType: "warning",
+              title: "Invalid Address",
+              message: "Sorry but the address you entered appears to be invalid."
+            };
+            
             return {
               addressValidationResults: {
                 submittedAddress: addressEntered,
                 suggestedAddresses: [addressSuggestion],
                 validationErrors: []
               },
+              actionAlerts,
               checkout
             };
           });
@@ -254,8 +267,10 @@ class CheckoutActionsExample extends React.Component {
     return new Promise((resolve, reject) => {
         setTimeout(() => {
           this.setState((state, props) => {
-            const { checkout } = state;
+            const { actionAlerts, checkout } = state;
+            actionAlerts["1"] = null;
             return {
+              actionAlerts,
               addressValidationResults: null,
               checkout: {
               payments: checkout.payments,
@@ -330,12 +345,12 @@ class CheckoutActionsExample extends React.Component {
   }
 
   render() {
-    const { addressValidationResults, checkout } = this.state;
+    const { actionAlerts, addressValidationResults, checkout } = this.state;
 
     const actions = [
       {
         id: "1",
-        activeLabel: "Enter a shipping address",
+        activeLabel: "Enter a shipping address",        
         completeLabel: "Shipping address",
         incompleteLabel: "Shipping address",
         status: this.getShippingStatus(),
@@ -344,7 +359,8 @@ class CheckoutActionsExample extends React.Component {
         props:  {
           addressValidationResults,
           fulfillmentGroup: checkout.fulfillmentGroups[0],
-          validation: this.validateShippingAddress
+          validation: this.validateShippingAddress,
+          alert: actionAlerts["1"]
         }
       },
       {
@@ -357,7 +373,8 @@ class CheckoutActionsExample extends React.Component {
         onSubmit: this.setFulfillmentOption,
         readyForSave: true,
         props:  {
-          fulfillmentGroup: checkout.fulfillmentGroups[0]
+          fulfillmentGroup: checkout.fulfillmentGroups[0],
+          alert: actionAlerts["2"]
         }
       },
       {
@@ -369,7 +386,8 @@ class CheckoutActionsExample extends React.Component {
         component: StripePaymentCheckoutAction,
         onSubmit: this.setPaymentMethod,
         props: {
-            payment: checkout.payments[0]
+            payment: checkout.payments[0],
+            alert: actionAlerts["3"]
         }
       },
       {
@@ -381,7 +399,8 @@ class CheckoutActionsExample extends React.Component {
         component: FinalReviewCheckoutAction,
         onSubmit: this.placeOrder,
         props: {
-          checkoutSummary
+          checkoutSummary,
+          alert: actionAlerts["4"]
         }
       }
     ];

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -64,6 +64,28 @@ const actions = [
 ```
 
 ```jsx
+const addressEntered = {
+  address1: "7742 Hwy 25",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70047",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const addressSuggestion = {
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
 const fulfillmentGroups = [{
   _id: 1,
   type: "shipping",
@@ -298,6 +320,11 @@ class CheckoutActionsExample extends React.Component {
         component: ShippingAddressCheckoutAction,
         onSubmit: this.setShippingAddress,
         props:  {
+          addressValidationResults: {
+            submittedAddress: addressEntered,
+            suggestedAddresses: [addressSuggestion],
+            validationErrors: []
+          },
           fulfillmentGroup: checkout.fulfillmentGroups[0]
         }
       },

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -195,12 +195,14 @@ class CheckoutActionsExample extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
+      addressValidationResults: null,
       checkout: {
         fulfillmentGroups,
         payments: paymentMethods
       }
     }
-
+    
+    this.validateShippingAddress = this.validateShippingAddress.bind(this);
     this.setShippingAddress = this.setShippingAddress.bind(this);
     this.setFulfillmentOption = this.setFulfillmentOption.bind(this);
     this.setPaymentMethod = this.setPaymentMethod.bind(this);
@@ -228,6 +230,25 @@ class CheckoutActionsExample extends React.Component {
 
     return (paymentWithoutData) ? "incomplete" : "complete";
   }
+  
+  validateShippingAddress(data) {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          this.setState((state, props) => {
+            const { checkout } = state;
+            return {
+              addressValidationResults: {
+                submittedAddress: addressEntered,
+                suggestedAddresses: [addressSuggestion],
+                validationErrors: []
+              },
+              checkout
+            };
+          });
+        resolve(data);
+        }, 1000, { data });
+    });
+  }
 
   setShippingAddress(data) {
     return new Promise((resolve, reject) => {
@@ -235,6 +256,7 @@ class CheckoutActionsExample extends React.Component {
           this.setState((state, props) => {
             const { checkout } = state;
             return {
+              addressValidationResults: null,
               checkout: {
               payments: checkout.payments,
               fulfillmentGroups: [{
@@ -308,7 +330,7 @@ class CheckoutActionsExample extends React.Component {
   }
 
   render() {
-    const { checkout } = this.state;
+    const { addressValidationResults, checkout } = this.state;
 
     const actions = [
       {
@@ -320,12 +342,9 @@ class CheckoutActionsExample extends React.Component {
         component: ShippingAddressCheckoutAction,
         onSubmit: this.setShippingAddress,
         props:  {
-          addressValidationResults: {
-            submittedAddress: addressEntered,
-            suggestedAddresses: [addressSuggestion],
-            validationErrors: []
-          },
-          fulfillmentGroup: checkout.fulfillmentGroups[0]
+          addressValidationResults,
+          fulfillmentGroup: checkout.fulfillmentGroups[0],
+          validation: this.validateShippingAddress
         }
       },
       {

--- a/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
+++ b/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
@@ -32,6 +32,23 @@ const FulfillmentOptionShape = PropTypes.shape({
 class FulfillmentOptionsCheckoutAction extends Component {
   static propTypes = {
     /**
+     * Alert object provides alert into to InlineAlert.
+     */
+    alert: PropTypes.shape({
+      /**
+       * The type of alert: Error, Information, Success or Warning
+       */
+      alertType: PropTypes.oneOf(["error", "information", "success", "warning"]),
+      /**
+       * Alert message
+       */
+      message: PropTypes.string.isRequired,
+      /**
+       * Alert title, optional
+       */
+      title: PropTypes.string
+    }),
+    /**
      * If you've set up a components context using
      * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
@@ -43,7 +60,12 @@ class FulfillmentOptionsCheckoutAction extends Component {
        * Pass either the Reaction [`SelectableList`](#!/SelectableList) component or your own component that
        * accepts compatible props.
        */
-      SelectableList: CustomPropTypes.component.isRequired
+      SelectableList: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction InlineAlert component or your own component that
+       * accepts compatible props.
+       */
+      InlineAlert: CustomPropTypes.component.isRequired
     }).isRequired,
     /**
      * Checkout data needed for form
@@ -134,7 +156,8 @@ class FulfillmentOptionsCheckoutAction extends Component {
 
   render() {
     const {
-      components: { SelectableList },
+      alert,
+      components: { InlineAlert, SelectableList },
       isSaving,
       label,
       fulfillmentGroup: {
@@ -148,6 +171,7 @@ class FulfillmentOptionsCheckoutAction extends Component {
         <Title>
           {stepNumber}. {label}
         </Title>
+        {alert ? <InlineAlert {...alert} /> : ""}
         {availableFulfillmentOptions && availableFulfillmentOptions.length ?
           <Form
             ref={(formEl) => {

--- a/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.md
+++ b/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.md
@@ -87,6 +87,72 @@ class FulfillmentExample extends React.Component {
 <FulfillmentExample />
 ```
 
+#### With Alert
+```jsx
+const fulfillmentGroup = {
+  availableFulfillmentOptions: [
+    {
+      fulfillmentMethod: {
+        _id: "111",
+        name: "Standard",
+        displayName: "Standard (5-9 Days)"
+      },
+      price: {
+        amount: 0,
+        displayAmount: "Free"
+      }
+    },
+    {
+      fulfillmentMethod: {
+        _id: "222",
+        name: "Priority",
+        displayName: "Priority (3-5 Days)"
+      },
+      price: {
+        amount: 5.99,
+        displayAmount: "$5.99"
+      }
+    },
+    {
+      fulfillmentMethod: {
+        _id: "333",
+        name: "Express",
+        displayName: "Express 2 Day"
+      },
+      price: {
+        amount: 12.99,
+        displayAmount: "$12.99"
+      }
+    }, {
+      fulfillmentMethod: {
+        _id: "444",
+        name: "Overnight",
+        displayName: "Overnight Expedited"
+      },
+      price: {
+        amount: 24.99,
+        displayAmount: "$24.99"
+      }
+    }
+  ]
+};
+
+const alert = {
+  alertType: "information",
+  title: "Shipping Restrictions",
+  message: "Please review our shipping restrictions."
+};
+
+
+<FulfillmentOptionsCheckoutAction 
+  alert={alert}  
+  label="Choose a shipping method"
+  fulfillmentGroup={fulfillmentGroup}
+  status="incomplete"
+  stepNumber={2} 
+/>
+```
+
 #### Render complete
 
 ```jsx

--- a/package/src/components/FulfillmentOptionsCheckoutAction/v1/__snapshots__/FulfillmentOptionsCheckoutAction.test.js.snap
+++ b/package/src/components/FulfillmentOptionsCheckoutAction/v1/__snapshots__/FulfillmentOptionsCheckoutAction.test.js.snap
@@ -24,6 +24,7 @@ Array [
     . 
     Choose a shipping method
   </h3>,
+  "",
   .c0 {
   -webkit-font-smoothing: antialiased;
   color: #3c3c3c;
@@ -71,6 +72,7 @@ Array [
     . 
     Choose a shipping method
   </h3>,
+  "",
   <div
     className={null}
     style={Object {}}

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -18,7 +18,13 @@ const REVIEW = "review";
 
 class ShippingAddressCheckoutAction extends Component {
   static propTypes = {
+    /**
+     * Address validation results object
+     */
     addressValidationResults: PropTypes.object,
+    /**
+     * Alert object provides alert into to InlineAlert.
+     */
     alert: PropTypes.shape({
       alertType: PropTypes.string,
       message: PropTypes.string,
@@ -79,7 +85,11 @@ class ShippingAddressCheckoutAction extends Component {
     /**
      * Checkout process step number
      */
-    stepNumber: PropTypes.number.isRequired
+    stepNumber: PropTypes.number.isRequired,
+    /**
+     * Address validation function.
+     */
+    validation: PropTypes.func
   };
 
   static defaultProps = {

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -19,6 +19,11 @@ const REVIEW = "review";
 class ShippingAddressCheckoutAction extends Component {
   static propTypes = {
     addressValidationResults: PropTypes.object,
+    alert: PropTypes.shape({
+      alertType: PropTypes.string,
+      message: PropTypes.string,
+      title: PropTypes.string
+    }),
     /**
      * If you've set up a components context using
      * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
@@ -36,7 +41,12 @@ class ShippingAddressCheckoutAction extends Component {
        * Pass either the Reaction AddressReview component or your own component that
        * accepts compatible props.
        */
-      AddressReview: CustomPropTypes.component.isRequired
+      AddressReview: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction InlineAlert component or your own component that
+       * accepts compatible props.
+       */
+      InlineAlert: CustomPropTypes.component.isRequired
     }).isRequired,
     /**
      * Checkout data needed for form
@@ -179,13 +189,14 @@ class ShippingAddressCheckoutAction extends Component {
   }
 
   render() {
-    const { label, stepNumber } = this.props;
+    const { alert, components: { InlineAlert }, label, stepNumber } = this.props;
     const { status } = this.state;
     return (
       <Fragment>
         <Title>
           {stepNumber}. {label}
         </Title>
+        {alert ? <InlineAlert {...alert} /> : ""}
         {status === REVIEW ? this.renderAddressReview() : this.renderAddressForm()}
       </Fragment>
     );

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -14,6 +14,7 @@ const Address = styled.address`
 `;
 
 const ENTRY = "entry";
+const EDIT = "edit";
 const REVIEW = "review";
 
 class ShippingAddressCheckoutAction extends Component {
@@ -135,9 +136,26 @@ class ShippingAddressCheckoutAction extends Component {
     );
   }
 
+  get getSubmittedAddress() {
+    if (!this.hasValidationResults) return null;
+    const { addressValidationResults: { submittedAddress } } = this.props;
+    return submittedAddress;
+  }
+
+  get getShippingAddress() {
+    if (!this.hasShippingAddressOnCart) return null;
+    const { fulfillmentGroup: { data: { shippingAddress } } } = this.props;
+    return shippingAddress;
+  }
+
   get inEntry() {
     const { status } = this.state;
     return status === ENTRY;
+  }
+
+  get inEdit() {
+    const { status } = this.state;
+    return status === EDIT;
   }
 
   get inReview() {
@@ -176,23 +194,32 @@ class ShippingAddressCheckoutAction extends Component {
   renderAddressReview() {
     const {
       addressValidationResults: { submittedAddress, suggestedAddresses },
-      components: { AddressReview }
+      components: { AddressReview, Button }
     } = this.props;
     return (
-      <AddressReview
-        ref={(formEl) => {
-          this._form = formEl;
-        }}
-        addressEntered={submittedAddress}
-        addressSuggestion={suggestedAddresses[0]}
-        onSubmit={this.handleSubmit}
-      />
+      <Fragment>
+        <AddressReview
+          ref={(formEl) => {
+            this._form = formEl;
+          }}
+          addressEntered={submittedAddress}
+          addressSuggestion={suggestedAddresses[0]}
+          onSubmit={this.handleSubmit}
+        />
+        <Button
+          isTextOnly
+          onClick={() => {
+            this.toggleStatus = EDIT;
+          }}
+        >
+          Edit entered address
+        </Button>
+      </Fragment>
     );
   }
 
   renderAddressForm() {
-    const { components: { AddressForm }, fulfillmentGroup, isSaving } = this.props;
-    const shippingAddress = fulfillmentGroup ? fulfillmentGroup.data.shippingAddress : null;
+    const { components: { AddressForm }, isSaving } = this.props;
     return (
       <AddressForm
         ref={(formEl) => {
@@ -201,7 +228,7 @@ class ShippingAddressCheckoutAction extends Component {
         isSaving={isSaving}
         onChange={this.handleChange}
         onSubmit={this.handleSubmit}
-        value={shippingAddress}
+        value={this.inEdit ? this.getSubmittedAddress : this.getShippingAddress}
       />
     );
   }

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -26,8 +26,17 @@ class ShippingAddressCheckoutAction extends Component {
      * Alert object provides alert into to InlineAlert.
      */
     alert: PropTypes.shape({
-      alertType: PropTypes.string,
-      message: PropTypes.string,
+      /**
+       * The type of alert: Error, Information, Success or Warning
+       */
+      alertType: PropTypes.oneOf(["error", "information", "success", "warning"]),
+      /**
+       * Alert message
+       */
+      message: PropTypes.string.isRequired,
+      /**
+       * Alert title, optional
+       */
       title: PropTypes.string
     }),
     /**
@@ -166,7 +175,7 @@ class ShippingAddressCheckoutAction extends Component {
 
   renderAddressReview() {
     const {
-      addressValidationResults: { submittedAddress, suggestedAddresses, validationErrors },
+      addressValidationResults: { submittedAddress, suggestedAddresses },
       components: { AddressReview }
     } = this.props;
     return (
@@ -177,7 +186,6 @@ class ShippingAddressCheckoutAction extends Component {
         addressEntered={submittedAddress}
         addressSuggestion={suggestedAddresses[0]}
         onSubmit={this.handleSubmit}
-        warningMessage={validationErrors.length ? validationErrors[0].details : undefined}
       />
     );
   }

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -140,7 +140,7 @@ const props = {
 ```
 
 **With simple address validation**
-A naive exmaple to demonstrate a validation shipping address checkout action UX flow. 
+A naive example to demonstrate a validation shipping address checkout action UX flow. 
 ```jsx
 initState = {
   addressValidationResults: null,

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -91,6 +91,7 @@ action.renderComplete(capturedData);
 ```
 
 ### Implementation Examples
+A naive exmaple to demonstrate a basic shipping address checkout action UX flow. 
 **Basic set shipping address**
 ```jsx
 initState = {
@@ -139,7 +140,7 @@ const props = {
 ```
 
 **With simple address validation**
-
+A naive exmaple to demonstrate a validation shipping address checkout action UX flow. 
 ```jsx
 initState = {
   addressValidationResults: null,

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -10,18 +10,18 @@ For a full implementation example see the [CheckoutActions](/#!/CheckoutActions)
 ### Usage
 
 ```jsx
-const fullfillment = {
+const fulfillment = {
   data: {
     shippingAddress: null
   }
 };
 
-<ShippingAddressCheckoutAction fulfillmentGroup={fullfillment} label="Shipping Address" stepNumber={1} />
+<ShippingAddressCheckoutAction fulfillmentGroup={fulfillment} label="Shipping Address" stepNumber={1} />
 ```
 
 #### With Address
 ```jsx
-const fullfillment = {
+const fulfillment = {
   data: {
     shippingAddress: {
       address1: "7742 Hwy 23",
@@ -36,25 +36,93 @@ const fullfillment = {
   }
 };
 
-<ShippingAddressCheckoutAction fulfillmentGroup={fullfillment} label="Shipping Address" stepNumber={1} />
+<ShippingAddressCheckoutAction fulfillmentGroup={fulfillment} label="Shipping Address" stepNumber={1} />
 ```
 
 #### Without Address
 ```jsx
-const fullfillment = {
+const fulfillment = {
   data: {
     shippingAddress: null
   }
 };
 
 
-<ShippingAddressCheckoutAction fulfillmentGroup={fullfillment} label="Shipping Address" stepNumber={1} />
+<ShippingAddressCheckoutAction fulfillmentGroup={fulfillment} label="Shipping Address" stepNumber={1} />
+```
+
+#### With Alert
+```jsx
+const fulfillment = {
+  data: {
+    shippingAddress: null
+  }
+};
+
+const alert = {
+  alertType: "warning",
+  title: "The address you entered may be incorrect or incomplete.",
+  message: "Please review our suggestion below, and choose which version you’d like to use. Possible errors are shown in red."
+};
+
+
+<ShippingAddressCheckoutAction alert={alert} fulfillmentGroup={fulfillment} label="Shipping Address" stepNumber={1} />
+```
+
+#### With Address Validation Results
+```jsx
+const fulfillmentGroup = {
+  data: {
+    shippingAddress: null
+  }
+};
+
+const alert = {
+  alertType: "warning",
+  title: "The address you entered may be incorrect or incomplete.",
+  message: "Please review our suggestion below, and choose which version you’d like to use. Possible errors are shown in red."
+};
+
+
+const addressValidationResults = {
+  submittedAddress: {
+    address1: "7742 Hwy 25",
+    address2: "",
+    country: "US",
+    city: "Belle Chasse",
+    fullName: "Salvos Seafood",
+    postal: "70047",
+    region: "LA",
+    phone: "(504) 393-7303"
+  },
+  suggestedAddresses: [{
+    address1: "7742 Hwy 23",
+    address2: "",
+    country: "US",
+    city: "Belle Chasse",
+    fullName: "Salvos Seafood",
+    postal: "70037",
+    region: "LA",
+    phone: "(504) 393-7303"
+  }],
+  validationErrors: []
+};
+
+const props = {
+ fulfillmentGroup,
+ alert,
+ addressValidationResults,
+ label: "Shipping Address",
+ stepNumber: 1
+};
+
+<ShippingAddressCheckoutAction {...props} />
 ```
 
 #### Ready For Save
 Open the browser terminal and fill out this form to see the `onReadyForSaveChange` callback fire.
 ```jsx
-const fullfillment = {
+const fulfillment = {
   data: {
     shippingAddress: null
   }
@@ -63,7 +131,7 @@ const fullfillment = {
 
 const isReady = (ready) => console.log("is action ready for save?", ready);
 
-<ShippingAddressCheckoutAction fulfillmentGroup={fullfillment} onReadyForSaveChange={isReady} label="Shipping Address" stepNumber={1} />
+<ShippingAddressCheckoutAction fulfillmentGroup={fulfillment} onReadyForSaveChange={isReady} label="Shipping Address" stepNumber={1} />
 ```
 
 #### Render Complete Method

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -90,6 +90,135 @@ action.renderComplete(capturedData);
 
 ```
 
+### Implementation Examples
+**Basic set shipping address**
+```jsx
+initState = {
+  isReady: false,
+  fulfillmentGroup: {
+    data: {
+      shippingAddress: null
+    }
+  }
+};
+
+const action = ShippingAddressCheckoutAction;
+let _form = null;
+
+const handleSubmit = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true });
+  setTimeout(async () => {
+    setState({
+      isProcessing: false,
+      fulfillmentGroup: {
+        data: {
+          shippingAddress: value
+        }
+      }
+    });
+    resolve(value);
+  }, 2000);
+});
+
+const props = {
+  fulfillmentGroup: state.fulfillmentGroup,
+  label: "Shipping Address",
+  stepNumber: 1,
+  onSubmit: handleSubmit,
+  onReadyForSaveChange() { setState({ isReady: true }); }
+};
+
+<div>
+  {state.fulfillmentGroup && state.fulfillmentGroup.data.shippingAddress 
+    ? action.renderComplete(state)
+    : (<div>
+      <ShippingAddressCheckoutAction {...props} ref={(el) => {_form = el}} /> 
+      <Button onClick={() => {_form.submit()}} isDisabled={!state.isReady} isWaiting={state.isProcessing}>Submit</Button>
+    </div>)}
+</div>
+```
+
+**With simple address validation**
+
+```jsx
+initState = {
+  addressValidationResults: null,
+  isReady: false,
+  isProcessing: false,
+  fulfillmentGroup: {
+    data: {
+      shippingAddress: null
+    }
+  }
+};
+
+const action = ShippingAddressCheckoutAction;
+let _form = null;
+
+const salvos = {
+  address1: "7742 Hwy 23",
+  address2: "",
+  country: "US",
+  city: "Belle Chasse",
+  fullName: "Salvos Seafood",
+  postal: "70037",
+  region: "LA",
+  phone: "(504) 393-7303"
+};
+
+const handleSubmit = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true });
+  setTimeout(async () => {
+    setState({
+      isProcessing: false,
+      fulfillmentGroup: {
+        data: {
+          shippingAddress: value
+        }
+      }
+    });
+    resolve(value);
+  }, 2000);
+});
+
+const handleValidation = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true });
+  setTimeout(async () => {
+    setState({
+      addressValidationResults: {
+        submittedAddress: value,
+        suggestedAddresses: [salvos],
+        validationErrors: [{
+          details: "Sorry but we believe you meant to enter the address of Salvos Seafood",
+          type: "warning"
+        }]
+      },
+      isProcessing: false
+    });
+    resolve(value);
+  }, 2000);
+});
+
+const props = {
+  addressValidationResults: state.addressValidationResults,
+  fulfillmentGroup: state.fulfillmentGroup,
+  label: "Shipping Address",
+  stepNumber: 1,
+  onSubmit: handleSubmit,
+  onReadyForSaveChange() { setState({ isReady: true }); },
+  validation: handleValidation
+};
+
+<div>
+  {state.fulfillmentGroup && state.fulfillmentGroup.data.shippingAddress 
+    ? action.renderComplete(state)
+    : (<div>
+      <ShippingAddressCheckoutAction {...props} ref={(el) => {_form = el}} /> 
+      <Button onClick={() => {_form.submit()}} isDisabled={!state.isReady} isWaiting={state.isProcessing}>Submit</Button>
+    </div>)}
+</div>
+```
+
 ### Theme
 
 See [Theming Components](./#!/Theming%20Components).

--- a/package/src/components/ShippingAddressCheckoutAction/v1/__snapshots__/ShippingAddressCheckoutAction.test.js.snap
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/__snapshots__/ShippingAddressCheckoutAction.test.js.snap
@@ -24,6 +24,7 @@ Array [
     . 
     Shipping Address
   </h3>,
+  "",
   "AddressForm(undefined)",
 ]
 `;
@@ -52,6 +53,7 @@ Array [
     . 
     Shipping Address
   </h3>,
+  "",
   "AddressForm(undefined)",
 ]
 `;

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -37,6 +37,23 @@ const billingAddressOptions = [{
 class StripePaymentCheckoutAction extends Component {
   static propTypes = {
     /**
+     * Alert object provides alert into to InlineAlert.
+     */
+    alert: PropTypes.shape({
+      /**
+       * The type of alert: Error, Information, Success or Warning
+       */
+      alertType: PropTypes.oneOf(["error", "information", "success", "warning"]),
+      /**
+       * Alert message
+       */
+      message: PropTypes.string.isRequired,
+      /**
+       * Alert title, optional
+       */
+      title: PropTypes.string
+    }),
+    /**
      * If you've set up a components context using
      * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
@@ -61,7 +78,12 @@ class StripePaymentCheckoutAction extends Component {
        * Pass either the Reaction StripeForm component or your own component that
        * accepts compatible props.
        */
-      StripeForm: CustomPropTypes.component.isRequired
+      StripeForm: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction InlineAlert component or your own component that
+       * accepts compatible props.
+       */
+      InlineAlert: CustomPropTypes.component.isRequired
     }),
     /**
      * Is the payment method being saved?
@@ -195,7 +217,8 @@ class StripePaymentCheckoutAction extends Component {
 
   render() {
     const {
-      components: { iconLock, SelectableList, StripeForm },
+      alert,
+      components: { iconLock, InlineAlert, SelectableList, StripeForm },
       label,
       stepNumber
     } = this.props;
@@ -207,6 +230,7 @@ class StripePaymentCheckoutAction extends Component {
         <Title>
           {stepNumber}. {label}
         </Title>
+        {alert ? <InlineAlert {...alert} /> : ""}
         <StripeForm
           isComplete={this.handleStripeFormIsComplete}
           stripeRef={(stripe) => { this._stripe = stripe; }}

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.md
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.md
@@ -15,6 +15,26 @@ const isReady = (ready) => true;
 
 ```
 
+#### With Alert
+```jsx
+const isReady = (ready) => true;
+
+const alert = {
+  alertType: "error",
+  title: "The payment information you entered may be incorrect.",
+  message: "Please review our error."
+};
+
+
+<StripePaymentCheckoutAction 
+  alert={alert}  
+  label="Payment Information" 
+  status="incomplete"
+  onReadyForSaveChange={isReady}
+  stepNumber={3} 
+/>
+```
+
 #### Completed state
 
 ```jsx

--- a/package/src/components/StripePaymentCheckoutAction/v1/__snapshots__/StripePaymentCheckoutAction.test.js.snap
+++ b/package/src/components/StripePaymentCheckoutAction/v1/__snapshots__/StripePaymentCheckoutAction.test.js.snap
@@ -24,6 +24,7 @@ Array [
     . 
     Payment Information
   </h3>,
+  "",
   "StripeForm(undefined)",
   .c0 {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Resolves #338 
Impact: **minor**  
Type: **feature**

## Component
* Updated `ShippingAddressCheckoutAction` to accept a `validation` method and `alert` object as a component props, to display the `AddressReview` and an `InlineAlert` if an address validation issue.
  *  If the `validation` method is available the form will validate the entered address, 
  *  If the entered address is invalid the component will switch from the `AddressForm` to the `AddressReview` and display the entered and "suggested" addresses.
   * if there is an address validation error, the error message can be used as the alert message.
* Removed the warning from `AddressReview` in favor of the `InlineAlert` pattern.
* Updated `CheckoutActions` example to have fake address validation issues

## Breaking changes
N/A

## Testing
1. Test the two `ShippingAddressCheckoutAction` implementation examples to verify the UX flow is correct.
2. Test the `CheckoutActions` implementation example to see the `AddressReview` within the checkout process.