### PR TITLE
fix(cartitem): add productURLPath to image link

### DIFF
--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -261,7 +261,7 @@ class CartItem extends Component {
   };
 
   renderImage() {
-    const { isMiniCart, item: { imageURLs, productSlug, productURLPath } } = this.props;
+    const { isMiniCart, item: { imageURLs, productSlug }, productURLPath } = this.props;
 
     const { small, thumbnail } = imageURLs || {};
 

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -261,14 +261,14 @@ class CartItem extends Component {
   };
 
   renderImage() {
-    const { isMiniCart, item: { imageURLs, productSlug } } = this.props;
+    const { isMiniCart, item: { imageURLs, productSlug, productURLPath } } = this.props;
 
     const { small, thumbnail } = imageURLs || {};
 
     if (!small || !thumbnail) return null;
 
     return (
-      <a href={productSlug}>
+      <a href={[productURLPath, productSlug].join("")}>
         <picture>
           {isMiniCart ? "" : <source srcSet={small} media="(min-width: 768px)" />}
           <img src={thumbnail} alt="" style={{ display: "block" }} />

--- a/package/src/components/CartItem/v1/CartItem.md
+++ b/package/src/components/CartItem/v1/CartItem.md
@@ -24,7 +24,7 @@ const item = {
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -51,7 +51,7 @@ const item = {
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -81,7 +81,7 @@ const item = {
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -111,7 +111,7 @@ const item = {
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -142,7 +142,7 @@ const item = {
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -175,7 +175,7 @@ const item = {
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -183,7 +183,7 @@ const item = {
 
 <CartItem
   item={item}
-  productURLPath="/product/path/here"
+  productURLPath="product/path/here/"
   onChangeCartItemQuantity={(value, _id) => console.log("cart item quantity changed to", value, "for item", _id)}
   onRemoveItemFromCart={() => console.log("Item removed from cart")}
 />

--- a/package/src/components/CartItem/v1/CartItem.test.js
+++ b/package/src/components/CartItem/v1/CartItem.test.js
@@ -47,7 +47,7 @@ test("basic snapshot with isReadOnly prop", () => {
 });
 
 test("basic snapshot with productURLPath prop", () => {
-  const component = renderer.create(<CartItem components={mockComponents} item={mockItem} productURLPath="/product" isReadOnly />);
+  const component = renderer.create(<CartItem components={mockComponents} item={mockItem} productURLPath="product/" isReadOnly />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/CartItem/v1/CartItem.test.js
+++ b/package/src/components/CartItem/v1/CartItem.test.js
@@ -19,7 +19,7 @@ const mockItem = {
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2

--- a/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
+++ b/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
@@ -314,7 +314,7 @@ exports[`basic snapshot with isReadOnly prop 1`] = `
   className="c0"
 >
   <a
-    href="/product-slug"
+    href="product-slug"
   >
     <picture>
       <source
@@ -470,7 +470,7 @@ exports[`basic snapshot with productURLPath prop 1`] = `
   className="c0"
 >
   <a
-    href="/product-slug"
+    href="/productproduct-slug"
   >
     <picture>
       <source
@@ -680,7 +680,7 @@ exports[`basic snapshot with props 1`] = `
   className="c0"
 >
   <a
-    href="/product-slug"
+    href="product-slug"
   >
     <picture>
       <source

--- a/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
+++ b/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
@@ -470,7 +470,7 @@ exports[`basic snapshot with productURLPath prop 1`] = `
   className="c0"
 >
   <a
-    href="/productproduct-slug"
+    href="product/product-slug"
   >
     <picture>
       <source

--- a/package/src/components/CartItemDetail/v1/CartItemDetail.md
+++ b/package/src/components/CartItemDetail/v1/CartItemDetail.md
@@ -7,40 +7,40 @@ Used by [CartItem](./#!/CartItem), or can be used alone.
 
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
-<CartItemDetail title="Amazing Product Title" productSlug="/product-slug" attributes={attributes} />
+<CartItemDetail title="Amazing Product Title" productSlug="product-slug" attributes={attributes} />
 ```
 
 #### With Product Vendor
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
-<CartItemDetail title="Amazing Product Title" productSlug="/product-slug" productVendor="Patagonia" attributes={attributes} />
+<CartItemDetail title="Amazing Product Title" productSlug="product-slug" productVendor="Patagonia" attributes={attributes} />
 ```
 
 #### With Quantity
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
-<CartItemDetail title="Amazing Product Title" productSlug="/product-slug" productVendor="Patagonia" attributes={attributes} quantity={3} />
+<CartItemDetail title="Amazing Product Title" productSlug="product-slug" productVendor="Patagonia" attributes={attributes} quantity={3} />
 ```
 
 #### In Mini Cart
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
-<CartItemDetail title="Amazing Product Title" productSlug="/product-slug" productVendor="Patagonia" attributes={attributes} isMiniCart />
+<CartItemDetail title="Amazing Product Title" productSlug="product-slug" productVendor="Patagonia" attributes={attributes} isMiniCart />
 ```
 
 #### With `ProductURLPath`
 Pass a custom URL path into `productURLPath` to customize the product link:
 
-- With a `productURLPath` of "/products"
+- With a `productURLPath` of "products/"
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
-<CartItemDetail title="Amazing Product Title" productSlug="/product-slug" productURLPath="/products" productVendor="Patagonia" attributes={attributes} isMiniCart />
+<CartItemDetail title="Amazing Product Title" productSlug="product-slug" productURLPath="products/" productVendor="Patagonia" attributes={attributes} isMiniCart />
 ```
 
 - With a longer `productURLPath`
 ```jsx
 const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
-<CartItemDetail title="Amazing Product Title" productSlug="/product-slug" productURLPath="/fall-winter/women/products" productVendor="Patagonia" attributes={attributes} isMiniCart />
+<CartItemDetail title="Amazing Product Title" productSlug="product-slug" productURLPath="fall-winter/women/products" productVendor="Patagonia" attributes={attributes} isMiniCart />
 ```
 
 ### Theme

--- a/package/src/components/CartItemDetail/v1/CartItemDetail.test.js
+++ b/package/src/components/CartItemDetail/v1/CartItemDetail.test.js
@@ -11,7 +11,7 @@ test("basic snapshot without props", () => {
 
 test("basic snapshot with props", () => {
   const attributes = [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }];
-  const component = renderer.create(<CartItemDetail title="Mock Product Title" productSlug="/product-slug" attributes={attributes} />);
+  const component = renderer.create(<CartItemDetail title="Mock Product Title" productSlug="product-slug" attributes={attributes} />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
@@ -25,7 +25,7 @@ test("basic snapshot with vendor attribute", () => {
   const component = renderer.create((
     <CartItemDetail
       title="Mock Product Title"
-      productSlug="/product-slug"
+      productSlug="product-slug"
       productVendor="Patagonia"
       attributes={attributes}
     />
@@ -43,7 +43,7 @@ test("basic snapshot with quantity attribute", () => {
   const component = renderer.create((
     <CartItemDetail
       title="Mock Product Title"
-      productSlug="/product-slug"
+      productSlug="product-slug"
       attributes={attributes}
       quantity={3}
     />
@@ -61,8 +61,8 @@ test("basic snapshot with product url path prop", () => {
   const component = renderer.create((
     <CartItemDetail
       title="Mock Product Title"
-      productURLPath="/product"
-      productSlug="/product-slug"
+      productURLPath="product/"
+      productSlug="product-slug"
       attributes={attributes}
     />
   ));

--- a/package/src/components/CartItemDetail/v1/__snapshots__/CartItemDetail.test.js.snap
+++ b/package/src/components/CartItemDetail/v1/__snapshots__/CartItemDetail.test.js.snap
@@ -75,7 +75,7 @@ exports[`basic snapshot with product url path prop 1`] = `
     className="c1"
   >
     <a
-      href="/product/product-slug"
+      href="product/product-slug"
     >
       Mock Product Title
     </a>
@@ -182,7 +182,7 @@ exports[`basic snapshot with props 1`] = `
     className="c1"
   >
     <a
-      href="/product-slug"
+      href="product-slug"
     >
       Mock Product Title
     </a>
@@ -305,7 +305,7 @@ exports[`basic snapshot with quantity attribute 1`] = `
     className="c1"
   >
     <a
-      href="/product-slug"
+      href="product-slug"
     >
       Mock Product Title
     </a>
@@ -434,7 +434,7 @@ exports[`basic snapshot with vendor attribute 1`] = `
     className="c1"
   >
     <a
-      href="/product-slug"
+      href="product-slug"
     >
       Mock Product Title
     </a>

--- a/package/src/components/CartItems/v1/CartItems.js
+++ b/package/src/components/CartItems/v1/CartItems.js
@@ -56,7 +56,7 @@ class CartItems extends Component {
      */
     onRemoveItemFromCart: PropTypes.func,
     /**
-     * Product URL path to be prepended before the slug. Should start with "/"
+     * Product URL path to be prepended before the slug. Should end with with "/"
      */
     productURLPath: PropTypes.string
   };

--- a/package/src/components/CartItems/v1/CartItems.md
+++ b/package/src/components/CartItems/v1/CartItems.md
@@ -203,7 +203,7 @@ const handleChangeCartItemQuantity = (value, _id) => console.log("cart items new
 const handleRemoveItemFromCart = (_id) => console.log("cart items remove this item", _id);
 
 <CartItems
-  productURLPath="/special/path"
+  productURLPath="special/path/"
   items={items}
   onChangeCartItemQuantity={handleChangeCartItemQuantity}
   onRemoveItemFromCart={handleRemoveItemFromCart}

--- a/package/src/components/CartItems/v1/CartItems.md
+++ b/package/src/components/CartItems/v1/CartItems.md
@@ -23,7 +23,7 @@ const items = [{
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -40,7 +40,7 @@ const items = [{
   price: {
     displayAmount: "$78.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "Another Great Product",
   quantity: 1
@@ -51,7 +51,7 @@ const handleRemoveItemFromCart = (_id) => console.log("cart items remove this it
 
 <CartItems
   items={items}
-  productURLPath="/product"
+  productURLPath="product/"
   onChangeCartItemQuantity={handleChangeCartItemQuantity}
   onRemoveItemFromCart={handleRemoveItemFromCart}
 />
@@ -75,7 +75,7 @@ const items = [{
     displayAmount: "$20.00"
   },
   productVendor: "Patagonia",
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   title: "A Great Product",
   quantity: 2
 },
@@ -91,7 +91,7 @@ const items = [{
   price: {
     displayAmount: "$78.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Nike",
   title: "Another Great Product",
   quantity: 1
@@ -126,7 +126,7 @@ const items = [{
     displayAmount: "$20.00"
   },
   productVendor: "Patagonia",
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   title: "A Great Product",
   quantity: 2
 },
@@ -142,7 +142,7 @@ const items = [{
   price: {
     displayAmount: "$78.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Nike",
   title: "Another Great Product",
   quantity: 1
@@ -177,7 +177,7 @@ const items = [{
     displayAmount: "$20.00"
   },
   productVendor: "Patagonia",
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   title: "A Great Product",
   quantity: 2
 },
@@ -193,7 +193,7 @@ const items = [{
   price: {
     displayAmount: "$78.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Nike",
   title: "Another Great Product",
   quantity: 1

--- a/package/src/components/CartItems/v1/CartItems.test.js
+++ b/package/src/components/CartItems/v1/CartItems.test.js
@@ -30,7 +30,7 @@ test("basic snapshot with required props", () => {
       price: {
         displayAmount: "$20.00"
       },
-      productSlug: "/product-slug",
+      productSlug: "product-slug",
       productVendor: "Patagonia",
       title: "A Great Product",
       quantity: 2
@@ -51,7 +51,7 @@ test("basic snapshot with required props", () => {
         displayAmount: "$78.00"
       },
       productVendor: "Nike",
-      productSlug: "/product-slug",
+      productSlug: "product-slug",
       title: "Another Great Product",
       quantity: 1
     }
@@ -83,7 +83,7 @@ test("basic snapshot with required props and optional prop", () => {
       price: {
         displayAmount: "$20.00"
       },
-      productSlug: "/product-slug",
+      productSlug: "product-slug",
       productVendor: "Patagonia",
       title: "A Great Product",
       quantity: 2
@@ -104,13 +104,13 @@ test("basic snapshot with required props and optional prop", () => {
         displayAmount: "$78.00"
       },
       productVendor: "Nike",
-      productSlug: "/product-slug",
+      productSlug: "product-slug",
       title: "Another Great Product",
       quantity: 1
     }
   ];
 
-  const component = renderer.create(<CartItems items={mockItems} components={mockComponents} productURLPath="/product" />);
+  const component = renderer.create(<CartItems items={mockItems} components={mockComponents} productURLPath="product/" />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -136,7 +136,7 @@ const checkoutSummary = {
     price: {
       displayAmount: "$20.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Patagonia",
     title: "A Great Product",
     quantity: 2
@@ -153,7 +153,7 @@ const checkoutSummary = {
     price: {
       displayAmount: "$78.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Patagonia",
     title: "Another Great Product",
     quantity: 1

--- a/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.md
+++ b/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.md
@@ -26,7 +26,7 @@ const checkoutSummary = {
     price: {
       displayAmount: "$20.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Patagonia",
     title: "A Great Product",
     quantity: 2
@@ -43,7 +43,7 @@ const checkoutSummary = {
     price: {
       displayAmount: "$78.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Patagonia",
     title: "Another Great Product",
     quantity: 1
@@ -55,7 +55,7 @@ const checkoutSummary = {
   onReadyForSaveChange={isReady}
   checkoutSummary={checkoutSummary}
   stepNumber={4}
-  productURLPath="/product"
+  productURLPath="product/"
 />
 
 ```

--- a/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.test.js
+++ b/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.test.js
@@ -23,7 +23,7 @@ const checkoutSummary = {
     price: {
       displayAmount: "$20.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Patagonia",
     title: "A Great Product",
     quantity: 2
@@ -40,7 +40,7 @@ const checkoutSummary = {
     price: {
       displayAmount: "$78.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Patagonia",
     title: "Another Great Product",
     quantity: 1

--- a/package/src/components/MiniCart/v1/MiniCart.md
+++ b/package/src/components/MiniCart/v1/MiniCart.md
@@ -34,7 +34,7 @@ const items = [
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -51,13 +51,13 @@ const items = [
   price: {
     displayAmount: "$78.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "Another Great Product",
   quantity: 1
 }];
 
-<MiniCart cart={{ checkout, items }} productURLPath="/product" onCheckoutButtonClick={() => alert("Checkout!")} />
+<MiniCart cart={{ checkout, items }} productURLPath="product/" onCheckoutButtonClick={() => alert("Checkout!")} />
 ```
 
 #### Scrolling
@@ -89,7 +89,7 @@ const items = [{
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
   quantity: 2
@@ -106,7 +106,7 @@ const items = [{
   price: {
     displayAmount: "$78.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Nike",
   title: "Another Great Product",
   quantity: 1
@@ -123,7 +123,7 @@ const items = [{
   price: {
     displayAmount: "$20.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
   productVendor: "Everlane",
   title: "A Product",
   quantity: 2
@@ -140,7 +140,7 @@ const items = [{
   price: {
     displayAmount: "$150.00"
   },
-  productSlug: "/product-slug",
+  productSlug: "product-slug",
    productVendor: "Greats",
   title: "Another Product",
   quantity: 1

--- a/package/src/components/MiniCart/v1/MiniCart.test.js
+++ b/package/src/components/MiniCart/v1/MiniCart.test.js
@@ -33,7 +33,7 @@ const mockItems = [
     price: {
       displayAmount: "$20.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Patagonia",
     title: "A Great Product",
     quantity: 2
@@ -53,7 +53,7 @@ const mockItems = [
     price: {
       displayAmount: "$78.00"
     },
-    productSlug: "/product-slug",
+    productSlug: "product-slug",
     productVendor: "Nike",
     title: "Another Great Product",
     quantity: 1


### PR DESCRIPTION
Resolves #357
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## CartItem
- Adds `productURLPath` to the way image URLs are created, so that products linked from images can also have more complex url paths

## Fixes
- Changes `productSlug` to proper slug format: `slug-format` in all tests and docs

## Testing
0. CartItemDetails: Link still works w/o a slash before the slug - https://deploy-preview-349--stoic-hodgkin-c0179e.netlify.com/#!/CartItemDetail 
1. CartItem image URL works -https://deploy-preview-349--stoic-hodgkin-c0179e.netlify.com/#!/CartItem
2. FinalReviewCheckoutAction image: https://deploy-preview-349--stoic-hodgkin-c0179e.netlify.com/#!/FinalReviewCheckoutAction
3. MiniCart image: https://deploy-preview-349--stoic-hodgkin-c0179e.netlify.com/#!/MiniCart