### PR TITLE
fix: clear Select when value prop becomes null

### DIFF
--- a/package/src/components/Select/v1/Select.js
+++ b/package/src/components/Select/v1/Select.js
@@ -573,7 +573,7 @@ class Select extends Component {
       passthroughProps[prop] = this.props[prop];
     });
 
-    let optionValue;
+    let optionValue = null;
     if (value !== undefined && value !== null) {
       optionValue = reactSelectOptions.find((opt) => {
         if (opt.options) return opt.options.find((o) => o.value === value);

--- a/package/src/components/Select/v1/Select.test.js
+++ b/package/src/components/Select/v1/Select.test.js
@@ -55,3 +55,11 @@ test("alphabetize option snapshot", () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test("when value prop changes to `null`, selection is cleared", () => {
+  const wrapper = mount(<Select options={OPTIONS} value="c" />);
+  expect(wrapper.html().indexOf(">C</div>")).not.toBe(-1);
+
+  wrapper.setProps({ value: null });
+  expect(wrapper.html().indexOf(">Select...</div>")).not.toBe(-1);
+});


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

When using `Select` component, I noticed that when `value` prop was initially set and then became `null`, it was not clearing the selection.

## Testing
There is a test proving it works, but if you want to test in the UI, you can add the following to the markdown file temporarily.

```
```jsx
const options = [
  { value: 'chocolate', label: 'Chocolate' },
  { value: 'darkchocolate', label: 'Dark Chocolate' },
  { value: 'mintchip', label: 'Mint Chip' },
  { value: 'strawberry', label: 'Strawberry' },
  { value: 'vanilla', label: 'Vanilla' },
];

initialState = { value: "vanilla" };

const handleChange = () => {
  setState({ value: null })
};

<div>
<p>{state.value}</p>
<Select options={options} value={state.value} />
<Button onClick={handleChange}>Change</Button>
</div>
;```
```