### PR TITLE
feat(regioninput): add RegionInput component, use in AddressForm

### DIFF
--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -401,7 +401,6 @@ class AddressForm extends Component {
                 isReadOnly={isSaving}
                 name="region"
                 placeholder="Region"
-                value={value ? value.region : null}
               />
               <ErrorsBlock names={["region"]} />
             </Field>

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -226,7 +226,7 @@ class AddressForm extends Component {
     return options;
   }
 
-  regionOptions() {
+  get regionOptions() {
     const { locales } = this.props;
     const { activeCountry } = this.state;
     const options = [];
@@ -263,9 +263,8 @@ class AddressForm extends Component {
       addressNamePlaceholder,
       value,
       className,
-      components: { Checkbox, ErrorsBlock, Field, TextInput, Select, PhoneNumberInput },
+      components: { Checkbox, ErrorsBlock, Field, TextInput, Select, PhoneNumberInput, RegionInput },
       errors,
-      locales,
       isOnDarkBackground,
       isSaving,
       name,
@@ -397,8 +396,7 @@ class AddressForm extends Component {
             <Field name="region" label="Region" labelFor={regionInputId} isRequired>
               <RegionInput
                 id={regionInputId}
-                onChange={this.handleCountryChange}
-                options={this.regionOptions(locales)}
+                options={this.regionOptions}
                 isOnDarkBackground={isOnDarkBackground}
                 isReadOnly={isSaving}
                 name="region"

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -74,7 +74,12 @@ class AddressForm extends Component {
        * Pass either the Reaction PhoneNumberInput component or your own component that is
        * compatible with ReactoForm.
        */
-      PhoneNumberInput: CustomPropTypes.component.isRequired
+      PhoneNumberInput: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction RegionInput component or your own component that is
+       * compatible with ReactoForm.
+       */
+      RegionInput: CustomPropTypes.component.isRequired
     }).isRequired,
     /**
      * Errors array
@@ -107,7 +112,7 @@ class AddressForm extends Component {
       continent: PropTypes.string,
       capital: PropTypes.string,
       currency: PropTypes.string,
-      languges: PropTypes.string,
+      languages: PropTypes.string,
       states: PropTypes.objectOf(PropTypes.shape({ name: PropTypes.string }))
     })),
     /**
@@ -151,9 +156,9 @@ class AddressForm extends Component {
     isOnDarkBackground: false,
     isSaving: false,
     name: "address",
-    onCancel() {},
-    onChange() {},
-    onSubmit() {},
+    onCancel() { },
+    onChange() { },
+    onSubmit() { },
     shouldShowAddressNameField: false,
     shouldShowIsCommercialField: false,
     validator: getRequiredValidator(
@@ -221,7 +226,7 @@ class AddressForm extends Component {
     return options;
   }
 
-  get regionOptions() {
+  regionOptions() {
     const { locales } = this.props;
     const { activeCountry } = this.state;
     const options = [];
@@ -260,6 +265,7 @@ class AddressForm extends Component {
       className,
       components: { Checkbox, ErrorsBlock, Field, TextInput, Select, PhoneNumberInput },
       errors,
+      locales,
       isOnDarkBackground,
       isSaving,
       name,
@@ -389,26 +395,16 @@ class AddressForm extends Component {
 
           <ColHalf>
             <Field name="region" label="Region" labelFor={regionInputId} isRequired>
-              {this.regionOptions && this.regionOptions.length > 1 ? (
-                <Select
-                  id={regionInputId}
-                  alphabetize
-                  isSearchable
-                  name="region"
-                  options={this.regionOptions}
-                  placeholder="Region"
-                  isOnDarkBackground={isOnDarkBackground}
-                  isReadOnly={isSaving}
-                />
-              ) : (
-                <TextInput
-                  id={regionInputId}
-                  name="region"
-                  placeholder="Region"
-                  isOnDarkBackground={isOnDarkBackground}
-                  isReadOnly={isSaving}
-                />
-              )}
+              <RegionInput
+                id={regionInputId}
+                onChange={this.handleCountryChange}
+                options={this.regionOptions(locales)}
+                isOnDarkBackground={isOnDarkBackground}
+                isReadOnly={isSaving}
+                name="region"
+                placeholder="Region"
+                value={value ? value.region : null}
+              />
               <ErrorsBlock names={["region"]} />
             </Field>
           </ColHalf>

--- a/package/src/components/RegionInput/v1/RegionInput.js
+++ b/package/src/components/RegionInput/v1/RegionInput.js
@@ -4,7 +4,6 @@ import { withComponents } from "@reactioncommerce/components-context";
 import { CustomPropTypes } from "../../../utils";
 
 class RegionInput extends Component {
-
   static propTypes = {
     /**
      * You can provide a `className` prop that will be applied to the outermost DOM element

--- a/package/src/components/RegionInput/v1/RegionInput.js
+++ b/package/src/components/RegionInput/v1/RegionInput.js
@@ -4,7 +4,6 @@ import { withComponents } from "@reactioncommerce/components-context";
 import { CustomPropTypes } from "../../../utils";
 
 class RegionInput extends Component {
-  static isFormInput = true;
 
   static propTypes = {
     /**
@@ -32,6 +31,10 @@ class RegionInput extends Component {
        */
       Select: CustomPropTypes.component.isRequired
     }).isRequired,
+    /**
+     * Name of input
+     */
+    name: PropTypes.string.isRequired,
     /**
      * Region options to populate the form's region fields
      */
@@ -76,8 +79,4 @@ class RegionInput extends Component {
   }
 }
 
-const WrappedRegionInput = withComponents(RegionInput);
-
-WrappedRegionInput.isFormInput = true;
-
-export default WrappedRegionInput;
+export default withComponents(RegionInput);

--- a/package/src/components/RegionInput/v1/RegionInput.js
+++ b/package/src/components/RegionInput/v1/RegionInput.js
@@ -45,6 +45,7 @@ class RegionInput extends Component {
   render() {
     const {
       className,
+      components: { Select, TextInput },
       options,
       value,
       ...props
@@ -75,4 +76,8 @@ class RegionInput extends Component {
   }
 }
 
-export default withComponents(RegionInput);
+const WrappedRegionInput = withComponents(RegionInput);
+
+WrappedRegionInput.isFormInput = true;
+
+export default WrappedRegionInput;

--- a/package/src/components/RegionInput/v1/RegionInput.js
+++ b/package/src/components/RegionInput/v1/RegionInput.js
@@ -1,0 +1,78 @@
+import React, { Component, Fragment } from "react";
+import PropTypes from "prop-types";
+import { withComponents } from "@reactioncommerce/components-context";
+import { CustomPropTypes } from "../../../utils";
+
+class RegionInput extends Component {
+  static isFormInput = true;
+
+  static propTypes = {
+    /**
+     * You can provide a `className` prop that will be applied to the outermost DOM element
+     * rendered by this component. We do not recommend using this for styling purposes, but
+     * it can be useful as a selector in some situations.
+     */
+    className: PropTypes.string,
+    /**
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
+    components: PropTypes.shape({
+      /**
+       * Pass either the Reaction TextInput component or your own component that is
+       * compatible with ReactoForm.
+       */
+      TextInput: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction Select component or your own component that is
+       * compatible with ReactoForm.
+       */
+      Select: CustomPropTypes.component.isRequired
+    }).isRequired,
+    /**
+     * Region options to populate the form's region fields
+     */
+    options: PropTypes.array,
+    /**
+     * Prepopulate the input's value
+     */
+    value: PropTypes.string
+  };
+
+  render() {
+    const {
+      className,
+      options,
+      value,
+      ...props
+    } = this.props;
+
+    return (
+      <Fragment>
+        {
+          options && options.length > 1 ? (
+            <Select
+              className={className}
+              alphabetize
+              isSearchable
+              options={options}
+              value={value}
+              {...props}
+            />
+          ) : (
+            <TextInput
+              className={className}
+              value={value}
+              {...props}
+            />
+          )
+        }
+      </Fragment>
+    );
+  }
+}
+
+export default withComponents(RegionInput);

--- a/package/src/components/RegionInput/v1/RegionInput.md
+++ b/package/src/components/RegionInput/v1/RegionInput.md
@@ -1,0 +1,40 @@
+### Overview
+
+The `RegionInput` component renders either a `Select` or `TextInput`, based on the number of region options.
+
+### Usage
+
+#### Input in a form
+
+```jsx
+const locales = {
+  "NR": {
+    "name": "Country Without Regions",
+  },
+  "WR": {
+    "name": "Country With Regions",
+    "states": {
+      "AA": {
+        "name": "A State"
+      },
+      "BB": {
+        "name": "B State"
+      }
+    }
+  }
+};
+
+<AddressForm isOnDarkBackground locales={locales} />
+```
+
+#### Input with a value
+
+```jsx
+<RegionInput isOnDarkBackground isReadOnly value="California" />
+```
+
+### Theme
+
+Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
+
+| Theme Prop | Default | Description |

--- a/package/src/components/RegionInput/v1/RegionInput.md
+++ b/package/src/components/RegionInput/v1/RegionInput.md
@@ -4,7 +4,34 @@ The `RegionInput` component renders either a `Select` or `TextInput`, based on t
 
 ### Usage
 
-#### Input in a form
+Use the `RegionInput` in a form with country and region locales. In the `AddressForm` component, for example, the form's `activeCountry` state, set by the country select, will trigger the `RegionInput` to appear as a plain text input or a dropdown of regions specified in a locale object or file.
+
+Pass any related form input props, like `isReadOnly`, `placeholder`, `maxLength`, `name`, `id` and more through from the parent component into `RegionInput`. See [Select](./#!/Select) and [TextInput](./#!/TextInput) for more props.
+
+#### With a value in a TextInput
+
+```jsx
+<RegionInput isOnDarkBackground isReadOnly value="California" />
+```
+
+#### With a value in a Select
+
+```jsx
+const options = [
+  {
+    "value": "AA",
+    "label": "A State"
+  },
+  {
+    "value": "BB",
+    "label": "B State"
+  }
+];
+
+<RegionInput options={options} value="BB" />
+```
+
+#### Implemented in an AddressForm
 
 ```jsx
 const locales = {
@@ -24,17 +51,36 @@ const locales = {
   }
 };
 
-<AddressForm isOnDarkBackground locales={locales} />
-```
+class AddressExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this._addressForm;
+    this.bindForm.bind(this);
+  }
 
-#### Input with a value
+  bindForm(formEl) {
+    if (formEl) {
+      this._addressForm = formEl;
+    }
+  }
 
-```jsx
-<RegionInput isOnDarkBackground isReadOnly value="California" />
+  render() {
+    return (
+      <div>
+        <AddressForm
+          locales={locales}
+          ref={(formEl) => { this.bindForm(formEl) }}
+          onSubmit={(address) => console.log("Address submitted", address)}
+        />
+        <Button onClick={() => this._addressForm.submit()}>Submit</Button>
+      </div>
+    );
+  }
+}
+
+<AddressExample />
 ```
 
 ### Theme
 
-Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
-
-| Theme Prop | Default | Description |
+Refer to [Select](./#!/Select), [TextInput](./#!/TextInput) and [AddressForm](./#!/AddressForm) themes.

--- a/package/src/components/RegionInput/v1/RegionInput.md
+++ b/package/src/components/RegionInput/v1/RegionInput.md
@@ -11,7 +11,7 @@ Pass any related form input props, like `isReadOnly`, `placeholder`, `maxLength`
 #### With a value in a TextInput
 
 ```jsx
-<RegionInput isOnDarkBackground isReadOnly value="California" />
+<RegionInput name="region" isOnDarkBackground isReadOnly value="California" />
 ```
 
 #### With a value in a Select
@@ -28,7 +28,7 @@ const options = [
   }
 ];
 
-<RegionInput options={options} value="BB" />
+<RegionInput name="region" options={options} value="BB" />
 ```
 
 #### Implemented in an AddressForm

--- a/package/src/components/RegionInput/v1/RegionInput.test.js
+++ b/package/src/components/RegionInput/v1/RegionInput.test.js
@@ -11,9 +11,7 @@ test("basic snapshot with only the components and required props should render a
 });
 
 test("basic snapshot with other form props", () => {
-  const component = renderer.create(<RegionInput components={mockComponents} value="California" name="region" isOnDarkBackground
-    isReadOnly
-                                    />);
+  const component = renderer.create(<RegionInput components={mockComponents} value="California" name="region" isReadOnly />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/RegionInput/v1/RegionInput.test.js
+++ b/package/src/components/RegionInput/v1/RegionInput.test.js
@@ -1,16 +1,60 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import mockComponents from "../../../tests/mockComponents";
 import RegionInput from "./RegionInput";
 
-test("basic snapshot", () => {
-  const component = renderer.create(<RegionInput />);
+test("basic snapshot with only the components on props should render a TextInput", () => {
+  const component = renderer.create(<RegionInput components={mockComponents} />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-test("basic snapshot", () => {
-  const component = renderer.create(<RegionInput />);
+test("basic snapshot with other form props", () => {
+  const component = renderer.create(<RegionInput components={mockComponents} value="California" isOnDarkBackground isReadOnly />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with pre-filled value in TextInput", () => {
+  const component = renderer.create(<RegionInput components={mockComponents} value="California"/>);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with pre-filled value in Select", () => {
+  const options = [
+    {
+      value: "AA",
+      label: "A State"
+    },
+    {
+      value: "BB",
+      label: "B State"
+    }
+  ];
+
+  const component = renderer.create(<RegionInput components={mockComponents} options={options} value="BB"/>);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with options should render a Select", () => {
+  const options = [
+    {
+      value: "AA",
+      label: "A State"
+    },
+    {
+      value: "BB",
+      label: "B State"
+    }
+  ];
+
+  const component = renderer.create(<RegionInput components={mockComponents} options={options}/>);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/RegionInput/v1/RegionInput.test.js
+++ b/package/src/components/RegionInput/v1/RegionInput.test.js
@@ -3,22 +3,22 @@ import renderer from "react-test-renderer";
 import mockComponents from "../../../tests/mockComponents";
 import RegionInput from "./RegionInput";
 
-test("basic snapshot with only the components on props should render a TextInput", () => {
-  const component = renderer.create(<RegionInput components={mockComponents} />);
+test("basic snapshot with only the components and required props should render a TextInput", () => {
+  const component = renderer.create(<RegionInput name="region" components={mockComponents} />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("basic snapshot with other form props", () => {
-  const component = renderer.create(<RegionInput components={mockComponents} value="California" isOnDarkBackground isReadOnly />);
+  const component = renderer.create(<RegionInput components={mockComponents} value="California" name="region" isOnDarkBackground isReadOnly />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("basic snapshot with pre-filled value in TextInput", () => {
-  const component = renderer.create(<RegionInput components={mockComponents} value="California"/>);
+  const component = renderer.create(<RegionInput name="region" components={mockComponents} value="California"/>);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
@@ -36,7 +36,7 @@ test("basic snapshot with pre-filled value in Select", () => {
     }
   ];
 
-  const component = renderer.create(<RegionInput components={mockComponents} options={options} value="BB"/>);
+  const component = renderer.create(<RegionInput name="region" components={mockComponents} options={options} value="BB"/>);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
@@ -54,7 +54,7 @@ test("basic snapshot with options should render a Select", () => {
     }
   ];
 
-  const component = renderer.create(<RegionInput components={mockComponents} options={options}/>);
+  const component = renderer.create(<RegionInput name="region" components={mockComponents} options={options}/>);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/RegionInput/v1/RegionInput.test.js
+++ b/package/src/components/RegionInput/v1/RegionInput.test.js
@@ -1,0 +1,17 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import RegionInput from "./RegionInput";
+
+test("basic snapshot", () => {
+  const component = renderer.create(<RegionInput />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot", () => {
+  const component = renderer.create(<RegionInput />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/RegionInput/v1/RegionInput.test.js
+++ b/package/src/components/RegionInput/v1/RegionInput.test.js
@@ -11,7 +11,9 @@ test("basic snapshot with only the components and required props should render a
 });
 
 test("basic snapshot with other form props", () => {
-  const component = renderer.create(<RegionInput components={mockComponents} value="California" name="region" isOnDarkBackground isReadOnly />);
+  const component = renderer.create(<RegionInput components={mockComponents} value="California" name="region" isOnDarkBackground
+    isReadOnly
+                                    />);
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/RegionInput/v1/__snapshots__/RegionInput.test.js.snap
+++ b/package/src/components/RegionInput/v1/__snapshots__/RegionInput.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot with only the components on props should render a TextInput 1`] = `"TextInput(undefined)"`;
+
+exports[`basic snapshot with options should render a Select 1`] = `"Select(undefined)"`;
+
+exports[`basic snapshot with other form props 1`] = `"TextInput(undefined)"`;
+
+exports[`basic snapshot with pre-filled value in Select 1`] = `"Select(undefined)"`;
+
+exports[`basic snapshot with pre-filled value in TextInput 1`] = `"TextInput(undefined)"`;

--- a/package/src/components/RegionInput/v1/__snapshots__/RegionInput.test.js.snap
+++ b/package/src/components/RegionInput/v1/__snapshots__/RegionInput.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic snapshot with only the components on props should render a TextInput 1`] = `"TextInput(undefined)"`;
+exports[`basic snapshot with only the components and required props should render a TextInput 1`] = `"TextInput(undefined)"`;
 
 exports[`basic snapshot with options should render a Select 1`] = `"Select(undefined)"`;
 

--- a/package/src/components/RegionInput/v1/index.js
+++ b/package/src/components/RegionInput/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./RegionInput";

--- a/package/src/tests/mockComponents.js
+++ b/package/src/tests/mockComponents.js
@@ -60,6 +60,7 @@ function stringifyJSONCircularSafe(obj) {
   "ProgressiveImage",
   "ProfileImage",
   "QuantityInput",
+  "RegionInput",
   "Select",
   "StockWarning",
   "TextInput",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -421,6 +421,7 @@ module.exports = {
             "ErrorsBlock",
             "Field",
             "PhoneNumberInput",
+            "RegionInput",
             "QuantityInput",
             "Select",
             "SelectableItem",

--- a/styleguide/src/appComponents.js
+++ b/styleguide/src/appComponents.js
@@ -38,6 +38,7 @@ import Price from "../../package/src/components/Price/v1";
 import ProfileImage from "../../package/src/components/ProfileImage/v1";
 import ProgressiveImage from "../../package/src/components/ProgressiveImage/v1";
 import QuantityInput from "../../package/src/components/QuantityInput/v1";
+import RegionInput from "../../package/src/components/RegionInput/v1";
 import Select from "../../package/src/components/Select/v1";
 import StockWarning from "../../package/src/components/StockWarning/v1";
 import StripeForm from "../../package/src/components/StripeForm/v1";
@@ -91,6 +92,7 @@ export default {
   ProfileImage,
   ProgressiveImage,
   QuantityInput,
+  RegionInput,
   Select,
   spinner,
   StockWarning,

--- a/styleguide/src/sections/InstallingandImporting.md
+++ b/styleguide/src/sections/InstallingandImporting.md
@@ -57,6 +57,7 @@ import CheckoutActionComplete from "@reactioncommerce/components/CheckoutActionC
 import CheckoutActionIncomplete from "@reactioncommerce/components/CheckoutActionIncomplete/v1";
 import ErrorsBlock from "@reactioncommerce/components/ErrorsBlock/v1";
 import Field from "@reactioncommerce/components/Field/v1";
+import InlineAlert from "@reactioncommerce/components/InlineAlert/v1";
 import InPageMenuItem from "@reactioncommerce/components/InPageMenuItem/v1";
 import Link from "@reactioncommerce/components/Link/v1";
 import MiniCartSummary from "@reactioncommerce/components/MiniCartSummary/v1";
@@ -65,6 +66,7 @@ import Price from "@reactioncommerce/components/Price/v1";
 import ProfileImage from "@reactioncommerce/components/ProfileImage/v1";
 import ProgressiveImage from "@reactioncommerce/components/ProgressiveImage/v1";
 import QuantityInput from "@reactioncommerce/components/QuantityInput/v1";
+import RegionInput from "@reactioncommerce/components/RegionInput/v1";
 import Select from "@reactioncommerce/components/Select/v1";
 import StockWarning from "@reactioncommerce/components/StockWarning/v1";
 import StripeForm from "@reactioncommerce/components/StripeForm/v1";
@@ -103,6 +105,7 @@ export default {
   iconLock,
   iconMastercard,
   iconVisa,
+  InlineAlert,
   InPageMenuItem,
   Link,
   MiniCartSummary,
@@ -111,6 +114,7 @@ export default {
   ProfileImage,
   ProgressiveImage,
   QuantityInput,
+  RegionInput,
   Select,
   spinner,
   StockWarning,


### PR DESCRIPTION
Resolves #345 
Impact: **minor**  
Type: **feature**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## RegionInput
- Creates `RegionInput` component, pulling https://github.com/reactioncommerce/reaction-component-library/blob/97a0d91f5d03dd7262e69633960b17cd8194d997/package/src/components/AddressForm/v1/AddressForm.js#L392 out of `AddressForm` and into its own re-usable component
- Adds docs and tests for various scenarios: TextInput field, Select field, a pre-filled TextInput field, a pre-filled Select field

## AddressForm
- Refactors `AddressForm` to use `RegionInput`

## Fixes
- I corrected a spelling on a prop object value: https://github.com/reactioncommerce/reaction-component-library/pull/354/files#diff-f9fd26feeb715b8d3d2968faa3f81589L110

## Testing
1. RegionInput: https://deploy-preview-354--stoic-hodgkin-c0179e.netlify.com/#!/RegionInput
2. AddressForm: https://deploy-preview-354--stoic-hodgkin-c0179e.netlify.com/#!/AddressForm