### PR TITLE
fix(stripepaymentcheckoutaction): check for Stripe Form completion

### DIFF
--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -105,6 +105,7 @@ class StripePaymentCheckoutAction extends Component {
     activeCountry: "US",
     status: "active",
     billingAddress: "same_as_shipping",
+    isStripeFormComplete: false,
     countries: [
       { value: "US", label: "United States" },
       { value: "DE", label: "Germany" },
@@ -163,20 +164,26 @@ class StripePaymentCheckoutAction extends Component {
   }
 
   handleUseNewBillingAddress = (billingAddress) => {
+    const { isStripeFormComplete } = this.state;
     if (billingAddress === "use_different_billing_address") {
       this.setState({ billingAddress });
     } else if (billingAddress === "same_as_shipping") {
       // If a user decides to use the same address
       this.setState({ billingAddress });
       // Confirm if Stripe Form is filled out
-      // to trigger onReadyForSaveChange()
-      this.handleStripeFormIsComplete();
+      if (isStripeFormComplete) {
+        // Trigger onReadyForSaveChange()
+        this.handleStripeFormIsComplete(true);
+      }
     }
   }
 
   handleStripeFormIsComplete = (isComplete) => {
     const { onReadyForSaveChange } = this.props;
     onReadyForSaveChange(isComplete);
+    this.setState({
+      isStripeFormComplete: true
+    });
   }
 
   renderBillingAddressForm = () => {

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -163,15 +163,19 @@ class StripePaymentCheckoutAction extends Component {
   }
 
   handleUseNewBillingAddress = (billingAddress) => {
-    // Only react to value changes
-    if (typeof billingAddress === "string") {
+    if (billingAddress === "use_different_billing_address") {
       this.setState({ billingAddress });
+    } else if (billingAddress === "same_as_shipping") {
+      // If a user decides to use the same address
+      this.setState({ billingAddress });
+      // Confirm if Stripe Form is filled out
+      // to trigger onReadyForSaveChange()
+      this.handleStripeFormIsComplete();
     }
   }
 
   handleStripeFormIsComplete = (isComplete) => {
     const { onReadyForSaveChange } = this.props;
-
     onReadyForSaveChange(isComplete);
   }
 


### PR DESCRIPTION
Resolves #357
Impact: **critical**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## StripePaymentCheckoutAction
- If a user clicks **Use a different billing address**, and then clicks **Same as shipping address** with a blank address form, check to see if the `StripeForm` is complete to enable the **Save** button to be clicked, by running `this.handleStripeFormIsComplete();`
- Creates and sets `isStripeFormComplete` state

## Testing
Test https://deploy-preview-359--stoic-hodgkin-c0179e.netlify.com/#!/CheckoutActions
1. Do step 1 and 2
2. Fill out credit card
3. Click `Use a different address`
4. _then_ Click `Use same`