### PR TITLE
fix(regioninput): add isFormInput back to RegionInput

### DIFF
--- a/package/src/components/RegionInput/v1/RegionInput.js
+++ b/package/src/components/RegionInput/v1/RegionInput.js
@@ -4,6 +4,8 @@ import { withComponents } from "@reactioncommerce/components-context";
 import { CustomPropTypes } from "../../../utils";
 
 class RegionInput extends Component {
+  static isFormInput = true;
+
   static propTypes = {
     /**
      * You can provide a `className` prop that will be applied to the outermost DOM element
@@ -78,4 +80,8 @@ class RegionInput extends Component {
   }
 }
 
-export default withComponents(RegionInput);
+const WrappedRegionInput = withComponents(RegionInput);
+
+WrappedRegionInput.isFormInput = true;
+
+export default WrappedRegionInput;


### PR DESCRIPTION
## RegionInput

Hotfixing `RegionInput` with `isFormInput` and wrapping the component so that the input is compliant with Reacto-Form in its current state, and does not break the AddressForm.

