### PR TITLE
fix: 361 nnnat minicart checkout button

### DIFF
--- a/package/src/components/MiniCart/v1/MiniCart.js
+++ b/package/src/components/MiniCart/v1/MiniCart.js
@@ -35,7 +35,8 @@ const Footer = styled.div`
   border-top-color: ${applyTheme("MiniCartFooter.borderTopColor")};
   border-top-style: solid;
   border-top-width: ${applyTheme("MiniCartFooter.borderTopWidth")};
-  box-shadow: ${({ count }) => (count > 2 ? applyTheme("MiniCartFooter.boxShadow_overflow") : applyTheme("MiniCartFooter.boxShadow"))};
+  box-shadow: ${({ count }) =>
+    (count > 2 ? applyTheme("MiniCartFooter.boxShadow_overflow") : applyTheme("MiniCartFooter.boxShadow"))};
   padding-bottom: ${applyTheme("MiniCartFooter.paddingBottom")};
   padding-left: ${applyTheme("MiniCartFooter.paddingLeft")};
   padding-right: ${applyTheme("MiniCartFooter.paddingRight")};
@@ -44,8 +45,7 @@ const Footer = styled.div`
 `;
 
 const FooterMessage = styled.span`
-  ${addTypographyStyles("MiniCartFooterMessage", "captionText")}
-  display: block;
+  ${addTypographyStyles("MiniCartFooterMessage", "captionText")} display: block;
   padding-bottom: ${applyTheme("MiniCartFooterMessage.paddingBottom")};
   padding-left: ${applyTheme("MiniCartFooterMessage.paddingLeft")};
   padding-right: ${applyTheme("MiniCartFooterMessage.paddingRight")};
@@ -115,7 +115,7 @@ class MiniCart extends Component {
        * An element to show as the cart checkout button. If this isn't provided,
        * a button will be rendered using Button component.
        */
-      cartCheckoutButton: PropTypes.node,
+      CartCheckoutButton: PropTypes.any,
       /**
        * Pass either the Reaction CartItems component or your own component that
        * accepts compatible props.
@@ -132,7 +132,7 @@ class MiniCart extends Component {
      */
     onChangeCartItemQuantity: PropTypes.func,
     /**
-     * On default checkout button click. Not used if a custom button is supplied by `components.cartCheckoutButton`
+     * On default checkout button click. Not used if a custom button is supplied by `components.CartCheckoutButton`
      */
     onCheckoutButtonClick: PropTypes.func,
     /**
@@ -141,38 +141,36 @@ class MiniCart extends Component {
     onRemoveItemFromCart: PropTypes.func,
     /**
      * Product URL path to be prepended before the slug
-    */
+     */
     productURLPath: PropTypes.string
   };
 
   static defaultProps = {
-    onChangeCartItemQuantity() { },
-    onCheckoutButtonClick() { },
-    onRemoveItemFromCart() { }
+    onChangeCartItemQuantity() {},
+    onCheckoutButtonClick() {},
+    onRemoveItemFromCart() {}
   };
 
   render() {
     const {
       cart: { checkout: { summary }, items },
       className,
-      components: {
-        Button,
-        cartCheckoutButton,
-        CartItems,
-        MiniCartSummary,
-        ...components
-      },
+      components: { Button, CartCheckoutButton, CartItems, MiniCartSummary },
       onCheckoutButtonClick,
       ...props
     } = this.props;
     return (
       <Cart className={className}>
         <Items>
-          <CartItems items={items} components={components} {...props} isMiniCart />
+          <CartItems items={items} {...props} isMiniCart />
         </Items>
         <Footer count={items.length}>
-          <MiniCartSummary components={components} displaySubtotal={summary.itemTotal.displayAmount} />
-          {cartCheckoutButton || <Button actionType="important" components={components} isFullWidth onClick={onCheckoutButtonClick}>Checkout</Button>}
+          <MiniCartSummary displaySubtotal={summary.itemTotal.displayAmount} />
+          {(CartCheckoutButton && <CartCheckoutButton onClick={onCheckoutButtonClick} />) || (
+            <Button actionType="important" isFullWidth onClick={onCheckoutButtonClick}>
+              Checkout
+            </Button>
+          )}
           <FooterMessage>Shipping and tax calculated in checkout</FooterMessage>
         </Footer>
       </Cart>

--- a/package/src/components/MiniCart/v1/MiniCart.md
+++ b/package/src/components/MiniCart/v1/MiniCart.md
@@ -60,6 +60,65 @@ const items = [
 <MiniCart cart={{ checkout, items }} productURLPath="product/" onCheckoutButtonClick={() => alert("Checkout!")} />
 ```
 
+### Custom Cart Checkout Button
+Provide a custom checkout button via `props.components.CartCheckoutButton`, you can add this directly to the `MiniCart` within your app or just add your custom button to the `components-context`.
+```jsx
+const checkout = {
+  summary: {
+    itemTotal: {
+      displayAmount: "$25.00"
+    },
+    taxTotal: {
+      displayAmount: "$2.50"
+    }
+  }
+}
+
+const items = [
+{
+  _id: "123",
+  attributes: [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }],
+  compareAtPrice: {
+    displayAmount: "$45.00"
+  },
+  currentQuantity: 3,
+  imageURLs: {
+    small: "//placehold.it/150",
+    thumbnail: "//placehold.it/100"
+  },
+  isLowQuantity: true,
+  price: {
+    displayAmount: "$20.00"
+  },
+  productSlug: "product-slug",
+  productVendor: "Patagonia",
+  title: "A Great Product",
+  quantity: 2
+},
+{
+  _id: "456",
+  attributes: [{ label: "Color", value: "Black" }, { label: "Size", value: "10" }],
+  currentQuantity: 500,
+  imageURLs: {
+    small: "//placehold.it/150",
+    thumbnail: "//placehold.it/100"
+  },
+  isLowQuantity: false,
+  price: {
+    displayAmount: "$78.00"
+  },
+  productSlug: "product-slug",
+  productVendor: "Patagonia",
+  title: "Another Great Product",
+  quantity: 1
+}];
+
+const CartCheckoutButton = ({ onClick }) => (<button onClick={onClick} style={{width: "100%", padding: "10px", backgroundColor: "limegreen", font: "20px serif" }}>Custom</button>);
+
+<MiniCart components={{CartCheckoutButton}} cart={{ checkout, items }} productURLPath="product/" onCheckoutButtonClick={() => alert("Checkout!")} />
+
+```
+
 #### Scrolling
 
 ```jsx


### PR DESCRIPTION
Resolves #361 
Impact: **major**  
Type: **bugfix|docs**

## Component
The `MiniCart` was not passing the `CartCheckoutButton` a click handler. The `MiniCart` and `CartCheckoutButton` pre-date the component-context and this bug was probably caused during that update. Now that this issue is fixed a custom `CartCheckoutButton` could be added directly to the components-context.

## Breaking changes
N/A

## Testing
1. Review the new `MiniCart` docs section "Custom Cart Checkout Button".
2. Verify the `alert` fires when the custom button is clicked.
