### PR TITLE
fix(inlinealerts): #363 empty alerts should not be displayed

### DIFF
--- a/package/src/components/AddressBook/v1/AddressBook.md
+++ b/package/src/components/AddressBook/v1/AddressBook.md
@@ -77,7 +77,7 @@ const props = {
 <AddressBook {...props} />
 ```
 
-#### Example implamentation
+#### Example implementation
 Simple `AddressBook` example with two saved addresses.
 ```jsx
 const salvos =  {

--- a/package/src/components/InlineAlert/v1/InlineAlert.js
+++ b/package/src/components/InlineAlert/v1/InlineAlert.js
@@ -47,7 +47,9 @@ const StyledDiv = styled.div`
           border-color: ${applyTheme("InlineAlert.borderColor_warning")};
         `;
       default:
-        return "";
+        return css`
+          display: none;
+        `;
     }
   }};
   `;
@@ -117,8 +119,8 @@ class InlineAlert extends Component {
   };
 
   static defaultProps = {
-    actionType: "information",
-    message: "Alert",
+    actionType: "",
+    message: "",
     isAutoClosing: false,
     isClosed: false,
     isDismissable: false

--- a/package/src/components/InlineAlert/v1/InlineAlert.js
+++ b/package/src/components/InlineAlert/v1/InlineAlert.js
@@ -75,6 +75,7 @@ class InlineAlert extends Component {
   static propTypes = {
     /**
      * The type of alert: Error, Information, Success or Warning
+     * An empty alertType will not render an alert
      */
     alertType: PropTypes.oneOf(["error", "information", "success", "warning"]),
     /**

--- a/package/src/components/InlineAlert/v1/InlineAlert.md
+++ b/package/src/components/InlineAlert/v1/InlineAlert.md
@@ -31,7 +31,9 @@ Alert language should be polite, clear and concise. Alert language can also incl
 
 Inline alerts should guide the user into taking corrective action if necessary. If the alert relates to a form, form field validation should be used in conjunction with the alert.
 
-User should be able to dismiss inline alerts when appropriate. Information and success alerts can close automaticallly after 10 seconds. Error alerts should be persistent, and close only when action is resolved.
+Users should be able to dismiss inline alerts when appropriate. Information and success alerts can close automaticallly after 10 seconds. Error alerts should be persistent, and close only when action is resolved.
+
+An empty `<InlineAlert/>` without an `alertType`, or a blank `alertType`, will not be rendered.
 
 ### Alert Types
 
@@ -109,6 +111,18 @@ const iconComponents = {
 <InlineAlert isAutoClosing alertType="information" message="This will close in 10 seconds."/>
 ```
 
+#### No props
+
+- An empty `<InlineAlert/>`, specifically, an alert without a specified `alertType`, will not be rendered:
+
+```jsx
+<InlineAlert alertType="" message="Message" title="Title"/>
+```
+
+```jsx
+<InlineAlert />
+```
+
 ### Theme
 
 Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
@@ -143,5 +157,5 @@ Assume that any theme prop that does not begin with "rui" is within `rui_compone
 
 #### Typography
 
-- The message  uses `bodyText` style with `rui_components.InlineAlert` override
+- The message uses `bodyText` style with `rui_components.InlineAlert` override
 - The title uses `bodyTextSemiBold` style with `rui_components.InlineAlert` override

--- a/package/src/components/InlineAlert/v1/InlineAlert.test.js
+++ b/package/src/components/InlineAlert/v1/InlineAlert.test.js
@@ -3,7 +3,14 @@ import renderer from "react-test-renderer";
 import mockComponents from "../../../tests/mockComponents";
 import InlineAlert from "./InlineAlert";
 
-test("basic snapshot with only required props", () => {
+test("basic snapshot no props", () => {
+  const component = renderer.create(<InlineAlert/>);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("basic snapshot with some props", () => {
   const component = renderer.create(<InlineAlert alertType="warning" message="Card ending in 0000 is expiring soon." />);
 
   const tree = component.toJSON();

--- a/package/src/components/InlineAlert/v1/__snapshots__/InlineAlert.test.js.snap
+++ b/package/src/components/InlineAlert/v1/__snapshots__/InlineAlert.test.js.snap
@@ -244,7 +244,45 @@ exports[`basic information snapshot 1`] = `
 </div>
 `;
 
-exports[`basic snapshot with only required props 1`] = `
+exports[`basic snapshot no props 1`] = `
+.c0 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 2px;
+  padding-bottom: 15px;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 15px;
+  position: relative;
+  white-space: pre-wrap;
+  overflow: hidden;
+  max-height: 3000vh;
+  opacity: 1;
+  -webkit-transition: border 0s cubic-bezier(0.785,0.135,0.15,0.86) 250ms,max-height 0s cubic-bezier(0.785,0.135,0.15,0.86) 250ms,padding 0s cubic-bezier(0.785,0.135,0.15,0.86) 250ms,opacity 250ms cubic-bezier(0.785,0.135,0.15,0.86);
+  transition: border 0s cubic-bezier(0.785,0.135,0.15,0.86) 250ms,max-height 0s cubic-bezier(0.785,0.135,0.15,0.86) 250ms,padding 0s cubic-bezier(0.785,0.135,0.15,0.86) 250ms,opacity 250ms cubic-bezier(0.785,0.135,0.15,0.86);
+  display: none;
+}
+
+<div
+  className="c0"
+>
+  
+</div>
+`;
+
+exports[`basic snapshot with some props 1`] = `
 .c0 {
   -webkit-font-smoothing: antialiased;
   color: #3c3c3c;

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.md
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.md
@@ -11,6 +11,7 @@ const isReady = (ready) => true;
   status="incomplete"
   onReadyForSaveChange={isReady}
   stepNumber={3}
+  alert={{}}
 />
 
 ```


### PR DESCRIPTION
Resolves #363 
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## InlineAlert
- Change `defaultProps` from `alertType: information` and `message: Alert` to empty strings
- An empty `alertType` will change the CSS to `display: none`
- Test: Add empty alert test

## Screenshots
<img width="1049" alt="screen shot 2018-11-09 at 12 15 31 pm" src="https://user-images.githubusercontent.com/3673236/48286025-2e7c1800-e419-11e8-8313-79412aa439c5.png">

## Testing
1. Add `alert={{}}` to any of the 3 CheckoutActions with Alerts (Shipping, Fulfillment, Address): https://deploy-preview-364--stoic-hodgkin-c0179e.netlify.com/#!/StripePaymentCheckoutAction
2. InlineAlert docs: https://deploy-preview-364--stoic-hodgkin-c0179e.netlify.com/#!/InlineAlert

