### PR TITLE
fix(addressreview): xform validated address when selected

### DIFF
--- a/package/src/components/AddressReview/v1/AddressReview.md
+++ b/package/src/components/AddressReview/v1/AddressReview.md
@@ -19,10 +19,8 @@ const addressSuggestion = {
   address2: "",
   country: "US",
   city: "Belle Chasse",
-  fullName: "Salvos Seafood",
   postal: "70037",
-  region: "LA",
-  phone: "(504) 393-7303"
+  region: "LA"
 };
 
 const props = { addressEntered, addressSuggestion };
@@ -49,10 +47,8 @@ const addressSuggestion = {
   address2: "",
   country: "US",
   city: "Belle Chasse",
-  fullName: "Salvos Seafood",
   postal: "70037",
-  region: "LA",
-  phone: "(504) 393-7303"
+  region: "LA"
 };
 
 const props = { addressEntered, addressSuggestion, value: "entered" };
@@ -79,10 +75,8 @@ const addressSuggestion = {
   address2: "",
   country: "US",
   city: "Belle Chasse",
-  fullName: "Salvos Seafood",
   postal: "70037",
-  region: "LA",
-  phone: "(504) 393-7303"
+  region: "LA"
 };
 
 class AddressExample extends React.Component {


### PR DESCRIPTION
Resolves N/A
Impact: **critical**  
Type: **bugfix**

## Component
`AddressReview` component was built expecting that validation result address object would match the Reaction GQL `Address` type. This is not the case for several address properties (i.e., `fullName` & `phone`) on validation results. I've added a simple transform method that will copy those missing properties over to any suggested address that gets selected.

## Breaking changes
N/A

## Testing
1. Visit the [AddressReview docs](https://deploy-preview-365--stoic-hodgkin-c0179e.netlify.com/#!/AddressReview) and test the implementation example.
2. Select the "Suggested Address" and click submit.
3. Verify that the `fullName`, `phone` & `isCommercial` properties have been copied over to the selected address.