### PR TITLE
fix: nnnnat drop-in address validation

### DIFF
--- a/package/src/components/AddressCapture/v1/AddressCapture.js
+++ b/package/src/components/AddressCapture/v1/AddressCapture.js
@@ -5,15 +5,42 @@ import { CustomPropTypes } from "../../../utils";
 
 class AddressCapture extends Component {
   static propTypes = {
+    /**
+     * AddressForm component props
+     */
     addressFormProps: PropTypes.shape({
+      /**
+       * Place holder for Address Name field.
+       */
       addressNamePlaceholder: PropTypes.string,
+      /**
+       * Should the AddressForm show the "Address Names" field.
+       */
       shouldShowAddressNameField: PropTypes.bool,
+      /**
+       * Should the AddressForm show the "Is Commercial Address" field.
+       */
       shouldShowIsCommercialField: PropTypes.bool,
+      /**
+       * Address object to be edited
+       */
       value: CustomPropTypes.address
     }),
+    /**
+     * AddressReview component props
+     */
     addressReviewProps: PropTypes.shape({
+      /**
+       * Address entered
+       */
       addressEntered: CustomPropTypes.address,
+      /**
+       * Address validations address suggestion
+       */
       addressSuggestion: CustomPropTypes.address,
+      /**
+       * The selected address option
+       */
       value: PropTypes.string
     }),
     /**
@@ -41,9 +68,21 @@ class AddressCapture extends Component {
        */
       AddressReview: CustomPropTypes.component.isRequired
     }).isRequired,
+    /**
+     * Is data being saved
+     */
     isSaving: PropTypes.bool,
+    /**
+     * Form name
+     */
     name: PropTypes.string,
+    /**
+     * Address validation event callback.
+     */
     onAddressValidation: PropTypes.func,
+    /**
+     * Form submit event callback
+     */
     onSubmit: PropTypes.func
   };
 
@@ -59,18 +98,48 @@ class AddressCapture extends Component {
 
   /**
    *
+   * @method hasAddressSuggestion
+   * @summary returns true if we have a suggested address from a address validation service
+   * @return {Boolean} - true if address suggestion on props
+   */
+  get hasAddressSuggestion() {
+    const { addressReviewProps: { addressSuggestion } } = this.props;
+    return !!addressSuggestion;
+  }
+
+  /**
+   *
+   * @method formRef
+   * @summary binds the active form element to the `_form` property
+   * @param {Object} form - React ref element
+   * @return {undefined}
+   */
+  formRef = (form) => {
+    this._form = form;
+  };
+
+  /**
+   *
    * @name submit
    * @summary Instance method that submits the form, this allows a parent component access to the Form submit event.
-   * @return {Undefined} - Nothing
+   * @return {undefined}
    */
   submit = () => {
     this._form.submit();
   };
 
+  /**
+   *
+   * @method handleSubmit
+   * @summary validate or submit the entered address object.
+   * @param {Object} address - submited address object
+   * @return {undefined}
+   */
   handleSubmit = async (address) => {
     const { onAddressValidation, onSubmit } = this.props;
     if (onAddressValidation && !address.isValid) {
       await onAddressValidation(address);
+      if (!this.hasAddressSuggestion) await onSubmit(address);
     } else {
       await onSubmit(address);
     }
@@ -78,35 +147,19 @@ class AddressCapture extends Component {
 
   renderForm() {
     const { addressFormProps, components: { AddressForm }, isSaving } = this.props;
-    return (
-      <AddressForm
-        {...addressFormProps}
-        ref={(el) => {
-          this._form = el;
-        }}
-        isSaving={isSaving}
-        onSubmit={this.handleSubmit}
-      />
-    );
+    return <AddressForm {...addressFormProps} ref={this.formRef} isSaving={isSaving} onSubmit={this.handleSubmit} />;
   }
 
   renderReview() {
     const { addressReviewProps, components: { AddressReview }, isSaving } = this.props;
     return (
-      <AddressReview
-        {...addressReviewProps}
-        ref={(el) => {
-          this._form = el;
-        }}
-        isSaving={isSaving}
-        onSubmit={this.handleSubmit}
-      />
+      <AddressReview {...addressReviewProps} ref={this.formRef} isSaving={isSaving} onSubmit={this.handleSubmit} />
     );
   }
 
   render() {
-    const { addressReviewProps: { addressSuggestion }, className } = this.props;
-    return <div className={className}>{addressSuggestion ? this.renderReview() : this.renderForm()}</div>;
+    const { className } = this.props;
+    return <div className={className}>{this.hasAddressSuggestion ? this.renderReview() : this.renderForm()}</div>;
   }
 }
 

--- a/package/src/components/AddressCapture/v1/AddressCapture.js
+++ b/package/src/components/AddressCapture/v1/AddressCapture.js
@@ -1,0 +1,113 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { withComponents } from "@reactioncommerce/components-context";
+import { CustomPropTypes } from "../../../utils";
+
+class AddressCapture extends Component {
+  static propTypes = {
+    addressFormProps: PropTypes.shape({
+      addressNamePlaceholder: PropTypes.string,
+      shouldShowAddressNameField: PropTypes.bool,
+      shouldShowIsCommercialField: PropTypes.bool,
+      value: CustomPropTypes.address
+    }),
+    addressReviewProps: PropTypes.shape({
+      addressEntered: CustomPropTypes.address,
+      addressSuggestion: CustomPropTypes.address,
+      value: PropTypes.string
+    }),
+    /**
+     * You can provide a `className` prop that will be applied to the outermost DOM element
+     * rendered by this component. We do not recommend using this for styling purposes, but
+     * it can be useful as a selector in some situations.
+     */
+    className: PropTypes.string,
+    /**
+     * If you've set up a components context using
+     * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
+     * (recommended), then this prop will come from there automatically. If you have not
+     * set up a components context or you want to override one of the components in a
+     * single spot, you can pass in the components prop directly.
+     */
+    components: PropTypes.shape({
+      /**
+       * Pass either the Reaction AddressForm component or your own component that is
+       * compatible with the AddressForm spec.
+       */
+      AddressForm: CustomPropTypes.component.isRequired,
+      /**
+       * Pass either the Reaction AddressReview component or your own component that is
+       * compatible with AddressReview spec.
+       */
+      AddressReview: CustomPropTypes.component.isRequired
+    }).isRequired,
+    isSaving: PropTypes.bool,
+    name: PropTypes.string,
+    onAddressValidation: PropTypes.func,
+    onSubmit: PropTypes.func
+  };
+
+  static defaultProps = {
+    addressFormProps: {},
+    addressReviewProps: {
+      addressSuggestion: null
+    },
+    isSaving: false
+  };
+
+  _form = null;
+
+  /**
+   *
+   * @name submit
+   * @summary Instance method that submits the form, this allows a parent component access to the Form submit event.
+   * @return {Undefined} - Nothing
+   */
+  submit = () => {
+    this._form.submit();
+  };
+
+  handleSubmit = async (address) => {
+    const { onAddressValidation, onSubmit } = this.props;
+    if (onAddressValidation && !address.isValid) {
+      await onAddressValidation(address);
+    } else {
+      await onSubmit(address);
+    }
+  };
+
+  renderForm() {
+    const { addressFormProps, components: { AddressForm }, isSaving } = this.props;
+    return (
+      <AddressForm
+        {...addressFormProps}
+        ref={(el) => {
+          this._form = el;
+        }}
+        isSaving={isSaving}
+        onSubmit={this.handleSubmit}
+      />
+    );
+  }
+
+  renderReview() {
+    const { addressReviewProps, components: { AddressReview }, isSaving } = this.props;
+    return (
+      <AddressReview
+        {...addressReviewProps}
+        ref={(el) => {
+          this._form = el;
+        }}
+        isSaving={isSaving}
+        onSubmit={this.handleSubmit}
+      />
+    );
+  }
+
+  render() {
+    const { addressReviewProps: { addressSuggestion }, className } = this.props;
+    return <div className={className}>{addressSuggestion ? this.renderReview() : this.renderForm()}</div>;
+  }
+}
+
+export default withComponents(AddressCapture);

--- a/package/src/components/AddressCapture/v1/AddressCapture.js
+++ b/package/src/components/AddressCapture/v1/AddressCapture.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import { withComponents } from "@reactioncommerce/components-context";
 import { CustomPropTypes } from "../../../utils";
@@ -13,6 +13,10 @@ class AddressCapture extends Component {
        * Place holder for Address Name field.
        */
       addressNamePlaceholder: PropTypes.string,
+      /**
+       * OnChange event callback
+       */
+      onChange: PropTypes.func,
       /**
        * Should the AddressForm show the "Address Names" field.
        */
@@ -151,9 +155,12 @@ class AddressCapture extends Component {
   }
 
   renderReview() {
-    const { addressReviewProps, components: { AddressReview }, isSaving } = this.props;
+    const { addressReviewProps, components: { AddressReview, Button }, isSaving } = this.props;
     return (
-      <AddressReview {...addressReviewProps} ref={this.formRef} isSaving={isSaving} onSubmit={this.handleSubmit} />
+      <Fragment>
+        <AddressReview {...addressReviewProps} ref={this.formRef} isSaving={isSaving} onSubmit={this.handleSubmit} />
+        <Button isTextOnly>Edit entered address</Button>
+      </Fragment>
     );
   }
 

--- a/package/src/components/AddressCapture/v1/AddressCapture.md
+++ b/package/src/components/AddressCapture/v1/AddressCapture.md
@@ -1,0 +1,141 @@
+### Overview
+
+### Usage
+
+#### Add an address
+```jsx
+initialState = { isProcessing: false, savedAddress: null };
+let _form = null;
+
+const handleSubmit = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true });
+  setTimeout(async () => {
+    console.log("Address saved", value);
+    setState({ isProcessing: false, savedAddress: value });
+    resolve(value)
+  }, 2000);
+});
+
+const props = {
+  addressFormProps: {
+    shouldShowIsCommercialField: true,
+    value: state.savedAddress
+  },
+  name: "example",
+  onSubmit: handleSubmit
+};
+
+state.savedAddress ? <Address address={state.savedAddress} /> : <div>
+  <AddressCapture {...props} ref={(formEl) => { _form = formEl; }} />
+  <Button onClick={() => { _form.submit() }} isWaiting={state.isProcessing}>Capture</Button>
+</div>
+```
+
+#### Edit an address
+```jsx
+initialState = { 
+  isProcessing: false,
+  updatedAddress: null,
+  savedAddress: {
+    address1: "2110 Main Street",
+    address2: "Suite 207",
+    country: "US",
+    city: "Santa Monica",
+    fullName: "Reaction Commerce, Inc.",
+    postal: "90405",
+    region: "CA",
+    phone: "123-123-1234",
+    isCommercial: true
+  } 
+};
+let _form = null;
+
+const handleSubmit = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true });
+  setTimeout(async () => {
+    console.log("Address saved", value);
+    setState({ isProcessing: false, updatedAddress: value });
+    resolve(value)
+  }, 2000);
+});
+
+const props = {
+  addressFormProps: {
+    shouldShowIsCommercialField: true,
+    value: state.updatedAddress || state.savedAddress
+  },
+  name: "example",
+  onSubmit: handleSubmit
+};
+
+console.log("whats the saved address", state.savedAddress);
+
+state.updatedAddress ? <Address address={state.updatedAddress} /> : <div>
+  <AddressCapture {...props} ref={(formEl) => { _form = formEl; }} />
+  <Button onClick={() => { _form.submit() }} isWaiting={state.isProcessing}>Edit</Button>
+</div>
+```
+
+#### Validate an address
+```jsx
+initialState = { isProcessing: false, savedAddress: null, submittedAddress: null, validationResults: null };
+let _form = null;
+
+const handleSubmit = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true });
+  setTimeout(async () => {
+    console.log("Address saved", value);
+    setState({ isProcessing: false, savedAddress: value });
+    resolve(value)
+  }, 2000);
+});
+
+const handleAddressValidation = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true, submittedAddress: value });
+  setTimeout(async () => {
+    console.log("Address validated", value);
+    const validationResults = {
+      suggestedAddresses: [{
+        ...value,
+        address1: "Corrected " + value.address1,
+        postal: "90210",
+        isValid: true
+      }],
+      validationErrors: [{
+        summary: "Address Not Found",
+        details: "The address as submitted could not be found. Please check for excessive abbreviations in " +
+        "the street address line or in the City name.",
+        source: "USPS",
+        type: "error" 
+      }]
+    };
+    setState({ isProcessing: false, validationResults });
+    resolve(value);
+  }, 2000);
+});
+
+const props = {
+  addressFormProps: {
+    shouldShowIsCommercialField: true,
+    value: state.submittedAddress
+  },
+  addressReviewProps: {
+    addressEntered: state.submittedAddress,
+    addressSuggestion: state.validationResults && state.validationResults.suggestedAddresses[0] || null
+  },
+  name: "example",
+  onSubmit: handleSubmit,
+  onAddressValidation: handleAddressValidation
+};
+
+state.savedAddress ? <Address address={state.savedAddress} /> : <div>
+  <AddressCapture {...props} ref={(formEl) => { _form = formEl; }} />
+  <Button onClick={() => { _form.submit() }} isWaiting={state.isProcessing}>{state.validationResults ? "Capture" : "Validate"}</Button>
+</div>
+```
+
+### Theme
+
+Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
+
+| Theme Prop | Default | Description |

--- a/package/src/components/AddressCapture/v1/AddressCapture.md
+++ b/package/src/components/AddressCapture/v1/AddressCapture.md
@@ -3,7 +3,46 @@ The `AddressCapture` is a wrapper component that provides a simple API to orches
 
 ### Usage
 
-#### Add an address
+**Default Address Form**
+```jsx
+<AddressCapture name="example" />
+```
+
+**Address Review**
+```jsx
+const props = {
+  addressReviewProps: {
+    addressEntered: {
+      address1: "2111 Main Street",
+      address2: "Suite 207",
+      country: "US",
+      city: "Santa Monica",
+      fullName: "Reaction Commerce, Inc.",
+      postal: "90305",
+      region: "CA",
+      phone: "123-123-1234",
+      isCommercial: true
+    },
+    addressSuggestion: {
+      address1: "2110 Main Street",
+      address2: "Suite 207",
+      country: "US",
+      city: "Santa Monica",
+      postal: "90405",
+      region: "CA"
+    }
+  },
+  name: "example"
+};
+
+<AddressCapture {...props} />
+```
+
+
+
+### Implementation Example
+
+#### Add Address
 A naive exmaple to demonstrate a basic address add UX flow. 
 ```jsx
 initialState = { isProcessing: false, savedAddress: null };
@@ -33,7 +72,7 @@ state.savedAddress ? <Address address={state.savedAddress} /> : <div>
 </div>
 ```
 
-#### Edit an address
+#### Edit Address
 A naive exmaple to demonstrate a basic address edit UX flow. 
 ```jsx
 initialState = { 
@@ -78,8 +117,10 @@ state.updatedAddress ? <Address address={state.updatedAddress} /> : <div>
 </div>
 ```
 
-#### Validate an address
-A naive exmaple to demonstrate a basic address validation UX flow. Address postal codes that start with "1" will pass validation, all others will fail.
+#### Validate Address
+A naive exmaple to demonstrate a basic address validation UX flow.
+
+*Address postal codes that start with "1" will pass validation, all others will fail.*
 ```jsx
 initialState = { isProcessing: false, savedAddress: null, submittedAddress: null, validationResults: null };
 let _form = null;

--- a/package/src/components/AddressCapture/v1/AddressCapture.md
+++ b/package/src/components/AddressCapture/v1/AddressCapture.md
@@ -1,8 +1,10 @@
 ### Overview
+The `AddressCapture` is a wrapper component that provides a simple API to orchestrate an address validation UX flow using the `AddressForm` and `AddressReview` components.
 
 ### Usage
 
 #### Add an address
+A naive exmaple to demonstrate a basic address add UX flow. 
 ```jsx
 initialState = { isProcessing: false, savedAddress: null };
 let _form = null;
@@ -32,6 +34,7 @@ state.savedAddress ? <Address address={state.savedAddress} /> : <div>
 ```
 
 #### Edit an address
+A naive exmaple to demonstrate a basic address edit UX flow. 
 ```jsx
 initialState = { 
   isProcessing: false,
@@ -68,7 +71,6 @@ const props = {
   onSubmit: handleSubmit
 };
 
-console.log("whats the saved address", state.savedAddress);
 
 state.updatedAddress ? <Address address={state.updatedAddress} /> : <div>
   <AddressCapture {...props} ref={(formEl) => { _form = formEl; }} />
@@ -77,6 +79,7 @@ state.updatedAddress ? <Address address={state.updatedAddress} /> : <div>
 ```
 
 #### Validate an address
+A naive exmaple to demonstrate a basic address validation UX flow. Address postal codes that start with "1" will pass validation, all others will fail.
 ```jsx
 initialState = { isProcessing: false, savedAddress: null, submittedAddress: null, validationResults: null };
 let _form = null;
@@ -95,18 +98,11 @@ const handleAddressValidation = (value) => new Promise((resolve, reject) => {
   setTimeout(async () => {
     console.log("Address validated", value);
     const validationResults = {
-      suggestedAddresses: [{
+      suggestedAddresses: value.postal[0] === "1" ? [] : [{
         ...value,
         address1: "Corrected " + value.address1,
         postal: "90210",
         isValid: true
-      }],
-      validationErrors: [{
-        summary: "Address Not Found",
-        details: "The address as submitted could not be found. Please check for excessive abbreviations in " +
-        "the street address line or in the City name.",
-        source: "USPS",
-        type: "error" 
       }]
     };
     setState({ isProcessing: false, validationResults });

--- a/package/src/components/AddressCapture/v1/AddressCapture.md
+++ b/package/src/components/AddressCapture/v1/AddressCapture.md
@@ -43,7 +43,7 @@ const props = {
 ### Implementation Example
 
 #### Add Address
-A naive exmaple to demonstrate a basic address add UX flow. 
+A naive example to demonstrate a basic address add UX flow. 
 ```jsx
 initialState = { isProcessing: false, savedAddress: null };
 let _form = null;
@@ -73,7 +73,7 @@ state.savedAddress ? <Address address={state.savedAddress} /> : <div>
 ```
 
 #### Edit Address
-A naive exmaple to demonstrate a basic address edit UX flow. 
+A naive example to demonstrate a basic address edit UX flow. 
 ```jsx
 initialState = { 
   isProcessing: false,
@@ -118,7 +118,7 @@ state.updatedAddress ? <Address address={state.updatedAddress} /> : <div>
 ```
 
 #### Validate Address
-A naive exmaple to demonstrate a basic address validation UX flow.
+A naive example to demonstrate a basic address validation UX flow.
 
 *Address postal codes that start with "1" will pass validation, all others will fail.*
 ```jsx
@@ -170,9 +170,3 @@ state.savedAddress ? <Address address={state.savedAddress} /> : <div>
   <Button onClick={() => { _form.submit() }} isWaiting={state.isProcessing}>{state.validationResults ? "Capture" : "Validate"}</Button>
 </div>
 ```
-
-### Theme
-
-Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
-
-| Theme Prop | Default | Description |

--- a/package/src/components/AddressCapture/v1/AddressCapture.test.js
+++ b/package/src/components/AddressCapture/v1/AddressCapture.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import mockComponents from "../../../tests/mockComponents";
+import AddressCapture from "./AddressCapture";
+
+test("basic snapshot", () => {
+  const component = renderer.create(<AddressCapture components={mockComponents} />);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/package/src/components/AddressCapture/v1/__snapshots__/AddressCapture.test.js.snap
+++ b/package/src/components/AddressCapture/v1/__snapshots__/AddressCapture.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic snapshot 1`] = `
+<div
+  className={undefined}
+>
+  AddressForm(undefined)
+</div>
+`;

--- a/package/src/components/AddressCapture/v1/index.js
+++ b/package/src/components/AddressCapture/v1/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AddressCapture";

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -156,20 +156,12 @@ class AddressForm extends Component {
     isOnDarkBackground: false,
     isSaving: false,
     name: "address",
-    onCancel() { },
-    onChange() { },
-    onSubmit() { },
+    onCancel() {},
+    onChange() {},
+    onSubmit() {},
     shouldShowAddressNameField: false,
     shouldShowIsCommercialField: false,
-    validator: getRequiredValidator(
-      "country",
-      "fullName",
-      "address1",
-      "city",
-      "phone",
-      "postal",
-      "region"
-    ),
+    validator: getRequiredValidator("country", "fullName", "address1", "city", "phone", "postal", "region"),
     value: {
       addressName: "",
       address1: "",
@@ -250,6 +242,15 @@ class AddressForm extends Component {
     onCancel();
   };
 
+  handleSubmit = async (value) => {
+    const { onAddressValidation, onSubmit } = this.props;
+    if (onAddressValidation) {
+      await onAddressValidation(value);
+    } else {
+      await onSubmit(value);
+    }
+  };
+
   getValue = () => this._form.getValue();
 
   submit = () => {
@@ -286,14 +287,15 @@ class AddressForm extends Component {
     const isCommercialInputId = `isCommercial_${this.uniqueInstanceIdentifier}`;
 
     return (
-      <Form className={className}
+      <Form
+        className={className}
         ref={(formEl) => {
           this._form = formEl;
         }}
         errors={errors}
         name={name}
         onChange={onChange}
-        onSubmit={this.props.onSubmit}
+        onSubmit={this.handleSubmit}
         validator={validator}
         revalidateOn="changed"
         value={value}
@@ -352,7 +354,6 @@ class AddressForm extends Component {
               <ErrorsBlock names={["fullName"]} />
             </Field>
           </ColFull>
-
 
           <ColFull>
             <Field name="address1" label="Address" labelFor={address1InputId} isRequired>

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -84,18 +84,16 @@ class AddressForm extends Component {
     /**
      * Errors array
      */
-    errors: PropTypes.arrayOf(
-      PropTypes.shape({
-        /**
+    errors: PropTypes.arrayOf(PropTypes.shape({
+      /**
          * Error message
          */
-        message: PropTypes.string.isRequired,
-        /**
+      message: PropTypes.string.isRequired,
+      /**
          * Error name
          */
-        name: PropTypes.string.isRequired
-      })
-    ),
+      name: PropTypes.string.isRequired
+    })),
     /**
      * Enable when using the form on a dark background, disabled by default
      */
@@ -107,18 +105,16 @@ class AddressForm extends Component {
     /**
      * Locale options to populate the forms country and region fields
      */
-    locales: PropTypes.objectOf(
-      PropTypes.shape({
-        name: PropTypes.string,
-        native: PropTypes.string,
-        phone: PropTypes.string,
-        continent: PropTypes.string,
-        capital: PropTypes.string,
-        currency: PropTypes.string,
-        languages: PropTypes.string,
-        states: PropTypes.objectOf(PropTypes.shape({ name: PropTypes.string }))
-      })
-    ),
+    locales: PropTypes.objectOf(PropTypes.shape({
+      name: PropTypes.string,
+      native: PropTypes.string,
+      phone: PropTypes.string,
+      continent: PropTypes.string,
+      capital: PropTypes.string,
+      currency: PropTypes.string,
+      languages: PropTypes.string,
+      states: PropTypes.objectOf(PropTypes.shape({ name: PropTypes.string }))
+    })),
     /**
      * Form name
      */

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -242,15 +242,6 @@ class AddressForm extends Component {
     onCancel();
   };
 
-  handleSubmit = async (value) => {
-    const { onAddressValidation, onSubmit } = this.props;
-    if (onAddressValidation && !value.isValid) {
-      await onAddressValidation(value);
-    } else {
-      await onSubmit(value);
-    }
-  };
-
   getValue = () => this._form.getValue();
 
   submit = () => {
@@ -259,7 +250,7 @@ class AddressForm extends Component {
 
   validate = () => this._form.validate();
 
-  renderForm() {
+  render() {
     const {
       addressNamePlaceholder,
       value,
@@ -295,7 +286,7 @@ class AddressForm extends Component {
         errors={errors}
         name={name}
         onChange={onChange}
-        onSubmit={this.handleSubmit}
+        onSubmit={this.props.onSubmit}
         validator={validator}
         revalidateOn="changed"
         value={value}
@@ -448,27 +439,6 @@ class AddressForm extends Component {
         </Grid>
       </Form>
     );
-  }
-
-  renderReview() {
-    const { addressValidationResults, components: { AddressReview }, name } = this.props;
-    return (
-      <AddressReview
-        ref={(formEl) => {
-          this._form = formEl;
-        }}
-        name={name}
-        onSubmit={this.handleSubmit}
-        addressEntered={addressValidationResults.submittedAddress}
-        addressSuggestion={addressValidationResults.suggestedAddresses[0]}
-      />
-    );
-  }
-
-  render() {
-    const { addressValidationResults } = this.props;
-    const { suggestedAddresses } = addressValidationResults || [];
-    return suggestedAddresses && suggestedAddresses.length ? this.renderReview() : this.renderForm();
   }
 }
 

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -46,7 +46,7 @@ class AddressForm extends Component {
      */
     components: PropTypes.shape({
       /**
-       * Pass either the Reaction Field component or your own component that is
+       * Pass either the Reaction Checkbox component or your own component that is
        * compatible with ReactoForm.
        */
       Checkbox: CustomPropTypes.component.isRequired,

--- a/package/src/components/AddressForm/v1/AddressForm.js
+++ b/package/src/components/AddressForm/v1/AddressForm.js
@@ -84,16 +84,18 @@ class AddressForm extends Component {
     /**
      * Errors array
      */
-    errors: PropTypes.arrayOf(PropTypes.shape({
-      /**
+    errors: PropTypes.arrayOf(
+      PropTypes.shape({
+        /**
          * Error message
          */
-      message: PropTypes.string.isRequired,
-      /**
+        message: PropTypes.string.isRequired,
+        /**
          * Error name
          */
-      name: PropTypes.string.isRequired
-    })),
+        name: PropTypes.string.isRequired
+      })
+    ),
     /**
      * Enable when using the form on a dark background, disabled by default
      */
@@ -105,16 +107,18 @@ class AddressForm extends Component {
     /**
      * Locale options to populate the forms country and region fields
      */
-    locales: PropTypes.objectOf(PropTypes.shape({
-      name: PropTypes.string,
-      native: PropTypes.string,
-      phone: PropTypes.string,
-      continent: PropTypes.string,
-      capital: PropTypes.string,
-      currency: PropTypes.string,
-      languages: PropTypes.string,
-      states: PropTypes.objectOf(PropTypes.shape({ name: PropTypes.string }))
-    })),
+    locales: PropTypes.objectOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        native: PropTypes.string,
+        phone: PropTypes.string,
+        continent: PropTypes.string,
+        capital: PropTypes.string,
+        currency: PropTypes.string,
+        languages: PropTypes.string,
+        states: PropTypes.objectOf(PropTypes.shape({ name: PropTypes.string }))
+      })
+    ),
     /**
      * Form name
      */
@@ -244,7 +248,7 @@ class AddressForm extends Component {
 
   handleSubmit = async (value) => {
     const { onAddressValidation, onSubmit } = this.props;
-    if (onAddressValidation) {
+    if (onAddressValidation && !value.isValid) {
       await onAddressValidation(value);
     } else {
       await onSubmit(value);
@@ -259,7 +263,7 @@ class AddressForm extends Component {
 
   validate = () => this._form.validate();
 
-  render() {
+  renderForm() {
     const {
       addressNamePlaceholder,
       value,
@@ -448,6 +452,27 @@ class AddressForm extends Component {
         </Grid>
       </Form>
     );
+  }
+
+  renderReview() {
+    const { addressValidationResults, components: { AddressReview }, name } = this.props;
+    return (
+      <AddressReview
+        ref={(formEl) => {
+          this._form = formEl;
+        }}
+        name={name}
+        onSubmit={this.handleSubmit}
+        addressEntered={addressValidationResults.submittedAddress}
+        addressSuggestion={addressValidationResults.suggestedAddresses[0]}
+      />
+    );
+  }
+
+  render() {
+    const { addressValidationResults } = this.props;
+    const { suggestedAddresses } = addressValidationResults || [];
+    return suggestedAddresses && suggestedAddresses.length ? this.renderReview() : this.renderForm();
   }
 }
 

--- a/package/src/components/AddressForm/v1/AddressForm.md
+++ b/package/src/components/AddressForm/v1/AddressForm.md
@@ -272,68 +272,6 @@ const handleSubmit = (value) => new Promise((resolve, reject) => {
 </div>
 ```
 
-#### With Address Validation Implementation Example
-A naive example to demonstrate an address validation UX flow.
-```jsx
-initState = { 
-  isProcessing: false,
-  submittedAddress: null,
-  suggestedAddresses: [],
-  validationErrors: []
-};
-const withLocales = require("../../../../../styleguide/src/components/withLocales").default;
-const AddressFormWithLocales = withLocales(AddressForm);
-let _form = null;
-
-const handleAddressValidation = (value) => new Promise((resolve, reject) => {
-  setState({ isProcessing: true, submittedAddress: value });
-  setTimeout(async () => {
-    console.log("Address validated", value);
-    const validationResults = {
-      suggestedAddresses: [{
-        ...value,
-        address1: "Corrected " + value.address1,
-        isValid: true
-      }],
-      validationErrors: [{
-        summary: "Address Not Found",
-        details: "The address as submitted could not be found. Please check for excessive abbreviations in " +
-        "the street address line or in the City name.",
-        source: "USPS",
-        type: "error" 
-      }]
-    };
-    setState({ isProcessing: false, ...validationResults });
-    resolve(value);
-  }, 2000);
-});
-
-const handleSubmit = (value) => new Promise((resolve, reject) => {
-  setState({ isProcessing: true, submittedAddress: value });
-  setTimeout(async () => {
-    console.log("Address saved", value);
-    setState({ isProcessing: false });
-    resolve(value)
-  }, 2000);
-});
-
-const addressValidationResults = { 
-  submittedAddress: state.submittedAddress, 
-  suggestedAddresses: state.suggestedAddresses,
-  validationErrors: state.validationErrors
-};
-
-<div>
-  <AddressFormWithLocales 
-    addressValidationResults={addressValidationResults}
-    onAddressValidation={handleAddressValidation}
-    onSubmit={handleSubmit}
-    ref={(formEl) => { _form = formEl; }}
-  />
-  <Button onClick={() => { _form.submit(); }} isWaiting={state.isProcessing} >Submit</Button>
-</div>
-```
-
 ### Theme
 
 Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).

--- a/package/src/components/AddressForm/v1/AddressForm.md
+++ b/package/src/components/AddressForm/v1/AddressForm.md
@@ -292,7 +292,8 @@ const handleAddressValidation = (value) => new Promise((resolve, reject) => {
     const validationResults = {
       suggestedAddresses: [{
         ...value,
-        address1: "Corrected " + value.address1
+        address1: "Corrected " + value.address1,
+        isValid: true
       }],
       validationErrors: [{
         summary: "Address Not Found",

--- a/package/src/components/AddressForm/v1/AddressForm.md
+++ b/package/src/components/AddressForm/v1/AddressForm.md
@@ -251,37 +251,86 @@ Some `fulfillmentMethods` will charge a different shipping rate if shipping to a
 
 #### Address Form Implementation Example
 Simple `AddressForm` implementation example. Bind to the form element via a `ref` method that can be used by any `Button` to trigger `submit` & `validate` form methods.
-
 ```jsx
+initState = { isProcessing: false };
 const withLocales = require("../../../../../styleguide/src/components/withLocales").default;
 const AddressFormWithLocales = withLocales(AddressForm);
-class AddressExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this._addressForm;
-    this.bindForm.bind(this);
-  }
+let _form = null;
 
-  bindForm(formEl) {
-    if (formEl) {
-      this._addressForm = formEl;
-    }
-  }
+const handleSubmit = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true });
+  setTimeout(async () => {
+    console.log("Address saved", value);
+    setState({ isProcessing: false });
+    resolve(value)
+  }, 2000);
+});
 
-  render() {
-    return (
-      <div>
-        <AddressFormWithLocales
-          ref={(formEl) => { this.bindForm(formEl) }}
-          onSubmit={(address) => console.log("Address submitted", address)}
-        />
-        <Button onClick={() => this._addressForm.submit()}>Submit</Button>
-      </div>
-    );
-  }
-}
+<div>
+  <AddressFormWithLocales ref={(formEl) => { _form = formEl; }} onSubmit={handleSubmit} />
+  <Button onClick={() => { _form.submit(); }} isWaiting={state.isProcessing} >Submit</Button>
+</div>
+```
 
-<AddressExample />
+#### With Address Validation Implementation Example
+A naive example to demonstrate an address validation UX flow.
+```jsx
+initState = { 
+  isProcessing: false,
+  submittedAddress: null,
+  suggestedAddresses: [],
+  validationErrors: []
+};
+const withLocales = require("../../../../../styleguide/src/components/withLocales").default;
+const AddressFormWithLocales = withLocales(AddressForm);
+let _form = null;
+
+const handleAddressValidation = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true, submittedAddress: value });
+  setTimeout(async () => {
+    console.log("Address validated", value);
+    const validationResults = {
+      suggestedAddresses: [{
+        ...value,
+        address1: "Corrected " + value.address1
+      }],
+      validationErrors: [{
+        summary: "Address Not Found",
+        details: "The address as submitted could not be found. Please check for excessive abbreviations in " +
+        "the street address line or in the City name.",
+        source: "USPS",
+        type: "error" 
+      }]
+    };
+    setState({ isProcessing: false, ...validationResults });
+    resolve(value);
+  }, 2000);
+});
+
+const handleSubmit = (value) => new Promise((resolve, reject) => {
+  setState({ isProcessing: true, submittedAddress: value });
+  setTimeout(async () => {
+    console.log("Address saved", value);
+    setState({ isProcessing: false });
+    resolve(value)
+  }, 2000);
+});
+
+const addressValidationResults = { 
+  submittedAddress: state.submittedAddress, 
+  suggestedAddresses: state.suggestedAddresses,
+  validationErrors: state.validationErrors
+};
+
+<div>
+  <AddressFormWithLocales 
+    addressValidationResults={addressValidationResults}
+    onAddressValidation={handleAddressValidation}
+    onSubmit={handleSubmit}
+    ref={(formEl) => { _form = formEl; }}
+  />
+  <Button onClick={() => { _form.submit(); }} isWaiting={state.isProcessing} >Submit</Button>
+</div>
 ```
 
 ### Theme

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -64,28 +64,6 @@ const actions = [
 ```
 
 ```jsx
-const addressEntered = {
-  address1: "7742 Hwy 25",
-  address2: "",
-  country: "US",
-  city: "Belle Chasse",
-  fullName: "Salvos Seafood",
-  postal: "70047",
-  region: "LA",
-  phone: "(504) 393-7303"
-};
-
-const addressSuggestion = {
-  address1: "7742 Hwy 23",
-  address2: "",
-  country: "US",
-  city: "Belle Chasse",
-  fullName: "Salvos Seafood",
-  postal: "70037",
-  region: "LA",
-  phone: "(504) 393-7303"
-};
-
 const fulfillmentGroups = [{
   _id: 1,
   type: "shipping",
@@ -250,8 +228,13 @@ class CheckoutActionsExample extends React.Component {
             
             return {
               addressValidationResults: {
-                submittedAddress: addressEntered,
-                suggestedAddresses: [addressSuggestion],
+                submittedAddress: data,
+                  suggestedAddresses: data.postal[0] === "1" ? [] : [{
+                  ...data,
+                  address1: "Corrected " + data.address1,
+                  postal: "90210",
+                  isValid: true
+                }],
                 validationErrors: []
               },
               actionAlerts,
@@ -359,7 +342,7 @@ class CheckoutActionsExample extends React.Component {
         props:  {
           addressValidationResults,
           fulfillmentGroup: checkout.fulfillmentGroups[0],
-          validation: this.validateShippingAddress,
+          onAddressValidation: this.validateShippingAddress,
           alert: actionAlerts["1"]
         }
       },

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -36,15 +36,10 @@ class ShippingAddressCheckoutAction extends Component {
      */
     components: PropTypes.shape({
       /**
-       * Pass either the Reaction AddressForm component or your own component that
+       * Pass either the Reaction AddressCapture component or your own component that
        * accepts compatible props.
        */
-      AddressForm: CustomPropTypes.component.isRequired,
-      /**
-       * Pass either the Reaction AddressReview component or your own component that
-       * accepts compatible props.
-       */
-      AddressReview: CustomPropTypes.component.isRequired,
+      AddressCapture: CustomPropTypes.component.isRequired,
       /**
        * Pass either the Reaction InlineAlert component or your own component that
        * accepts compatible props.
@@ -116,11 +111,7 @@ class ShippingAddressCheckoutAction extends Component {
 
   get hasValidationResults() {
     const { addressValidationResults } = this.props;
-    return !!(
-      addressValidationResults &&
-      addressValidationResults.suggestedAddresses.length &&
-      addressValidationResults.submittedAddress
-    );
+    return !!(addressValidationResults && addressValidationResults.suggestedAddresses.length);
   }
 
   get getSubmittedAddress() {
@@ -165,60 +156,9 @@ class ShippingAddressCheckoutAction extends Component {
     onReadyForSaveChange(true);
   };
 
-  handleSubmit = async (value) => {
-    const { onSubmit, onAddressValidation } = this.props;
-    if (onAddressValidation && this.inEntry) {
-      await onAddressValidation(value);
-    } else {
-      await onSubmit(value);
-    }
-  };
-
   handleChange = (values) => {
     if (this.isFormFilled(values)) this.ready();
   };
-
-  renderAddressReview() {
-    const {
-      addressValidationResults: { submittedAddress, suggestedAddresses },
-      components: { AddressReview, Button }
-    } = this.props;
-    return (
-      <Fragment>
-        <AddressReview
-          ref={(formEl) => {
-            this._form = formEl;
-          }}
-          addressEntered={submittedAddress}
-          addressSuggestion={suggestedAddresses[0]}
-          onSubmit={this.handleSubmit}
-        />
-        <Button
-          isTextOnly
-          onClick={() => {
-            this.toggleStatus = EDIT;
-          }}
-        >
-          Edit entered address
-        </Button>
-      </Fragment>
-    );
-  }
-
-  renderAddressForm() {
-    const { components: { AddressForm }, isSaving } = this.props;
-    return (
-      <AddressForm
-        ref={(formEl) => {
-          this._form = formEl;
-        }}
-        isSaving={isSaving}
-        onChange={this.handleChange}
-        onSubmit={this.handleSubmit}
-        value={this.inEdit ? this.getSubmittedAddress : this.getShippingAddress}
-      />
-    );
-  }
 
   renderAddressCapture() {
     const {

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -259,7 +259,12 @@ const handleValidation = (value) => new Promise((resolve, reject) => {
     setState({
       addressValidationResults: {
         submittedAddress: value,
-        suggestedAddresses: [salvos],
+        suggestedAddresses:  value.postal[0] === "1" ? [] : [{
+          ...value,
+          address1: "Corrected " + value.address1,
+          postal: "90210",
+          isValid: true
+        }],
         validationErrors: [{
          summary: "Address Not Found",
          details: "The address as submitted could not be found. Please check for excessive abbreviations in the street address line or in the City name.",

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -159,7 +159,8 @@ action.renderComplete(capturedData);
 ```
 
 ### Implementation Examples
-A naive exmaple to demonstrate a basic shipping address checkout action UX flow. 
+A naive exmaple to demonstrate a basic shipping address checkout action UX flow.
+
 **Basic set shipping address**
 ```jsx
 initState = {
@@ -208,6 +209,7 @@ const props = {
 ```
 
 **With simple address validation**
+
 A naive example to demonstrate a validation shipping address checkout action UX flow. 
 ```jsx
 initState = {
@@ -232,7 +234,8 @@ const salvos = {
   fullName: "Salvos Seafood",
   postal: "70037",
   region: "LA",
-  phone: "(504) 393-7303"
+  phone: "(504) 393-7303",
+  isValid: true
 };
 
 const handleSubmit = (value) => new Promise((resolve, reject) => {
@@ -258,8 +261,10 @@ const handleValidation = (value) => new Promise((resolve, reject) => {
         submittedAddress: value,
         suggestedAddresses: [salvos],
         validationErrors: [{
-          details: "Sorry but we believe you meant to enter the address of Salvos Seafood",
-          type: "warning"
+         summary: "Address Not Found",
+         details: "The address as submitted could not be found. Please check for excessive abbreviations in the street address line or in the City name.",
+         source: "USPS",
+         type: "error"
         }]
       },
       isProcessing: false
@@ -273,9 +278,9 @@ const props = {
   fulfillmentGroup: state.fulfillmentGroup,
   label: "Shipping Address",
   stepNumber: 1,
+  onAddressValidation: handleValidation,
   onSubmit: handleSubmit,
-  onReadyForSaveChange() { setState({ isReady: true }); },
-  validation: handleValidation
+  onReadyForSaveChange() { setState({ isReady: true }); }
 };
 
 <div>

--- a/package/src/components/ShippingAddressCheckoutAction/v1/__snapshots__/ShippingAddressCheckoutAction.test.js.snap
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/__snapshots__/ShippingAddressCheckoutAction.test.js.snap
@@ -25,7 +25,7 @@ Array [
     Shipping Address
   </h3>,
   "",
-  "AddressForm(undefined)",
+  "AddressCapture(undefined)",
 ]
 `;
 
@@ -54,6 +54,6 @@ Array [
     Shipping Address
   </h3>,
   "",
-  "AddressForm(undefined)",
+  "AddressCapture(undefined)",
 ]
 `;

--- a/package/src/tests/mockComponents.js
+++ b/package/src/tests/mockComponents.js
@@ -36,6 +36,7 @@ function stringifyJSONCircularSafe(obj) {
   "Accordion",
   "AccordionFormList",
   "AddressBook",
+  "AddressCapture",
   "AddressForm",
   "AddressReview",
   "AddressSelect",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -448,7 +448,6 @@ module.exports = {
       sections: [
         generateSection({
           componentNames: [
-            "AddressCapture",
             "ShopLogo"
           ],
           content: "styleguide/src/sections/General.md",
@@ -496,6 +495,7 @@ module.exports = {
         }),
         generateSection({
           componentNames: [
+            "AddressCapture",
             "AddressForm",
             "AddressReview",
             "GuestForm",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -448,6 +448,7 @@ module.exports = {
       sections: [
         generateSection({
           componentNames: [
+            "AddressCapture",
             "ShopLogo"
           ],
           content: "styleguide/src/sections/General.md",

--- a/styleguide/src/appComponents.js
+++ b/styleguide/src/appComponents.js
@@ -14,6 +14,7 @@ import Accordion from "../../package/src/components/Accordion/v1";
 import AccordionFormList from "../../package/src/components/AccordionFormList/v1";
 import Address from "../../package/src/components/Address/v1";
 import AddressBook from "../../package/src/components/AddressBook/v1";
+import AddressCapture from "../../package/src/components/AddressCapture/v1";
 import AddressForm from "../../package/src/components/AddressForm/v1";
 import AddressReview from "../../package/src/components/AddressReview/v1";
 import BadgeOverlay from "../../package/src/components/BadgeOverlay/v1";
@@ -59,6 +60,7 @@ export default {
   AccordionFormList,
   Address,
   AddressBook,
+  AddressCapture,
   AddressForm: AddressFormWithLocales,
   AddressReview,
   BadgeOverlay,


### PR DESCRIPTION
Resolves N/A
Impact: **major**  
Type: **bugfix|refactor**

## Issue
Currently, the `AddressForm` & `AddressReview` are sibling components leaving the responsibility of switching UI to a parent when an `address` has been validated. This causes a situation where we have to implement at least 3 parent components to control this flow.

## Solution
~~To make the validation UI more portable move the UI switching logic of the address validation flow to the `AddressForm` component.~~

Created a wrapper component that orchestrates an address validation UX flow using the `AddressForm` and `AddressReview` components.

## Breaking changes
N/A

## Testing
1. Visit [AddressCapture docs](https://deploy-preview-366--stoic-hodgkin-c0179e.netlify.com/#!/AddressCapture) and test the example implementations.
2. Test the simple example with the console open to see the submitted/edited addresses.
3. Test the "Address Validation" example to see the address validation flow.
4. Verify you can edit a submitted address during the "Review" step.
