### PR TITLE
feat: add surcharge to Cart Summary

### DIFF
--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -48,6 +48,10 @@ const Discount = styled.span`
   ${addTypographyStyles("CartSummaryDiscount", "bodyTextBold")}
 `;
 
+const Surcharge = styled.span`
+  ${addTypographyStyles("CartSummarySurcharge", "bodyTextBold")}
+`;
+
 const Total = styled.span`
   ${addTypographyStyles("CartSummaryTotal", "bodyTextBold")}
 `;
@@ -72,6 +76,10 @@ class CartSummary extends Component {
      * Subtotal amount
      */
     displaySubtotal: PropTypes.string.isRequired,
+    /**
+     * Surcharge amount
+     */
+    displaySurcharge: PropTypes.string,
     /**
      * Calculated tax amount
      */
@@ -123,12 +131,26 @@ class CartSummary extends Component {
     );
   }
 
+  renderSurcharge() {
+    const { displaySurcharge, isDense } = this.props;
+
+    return (
+      <tr>
+        <Td isDense={isDense}>Surcharge applied</Td>
+        <TdValue isDense={isDense}>
+          <Surcharge>{displaySurcharge}</Surcharge>
+        </TdValue>
+      </tr>
+    );
+  }
+
   render() {
     const {
       className,
       displayDiscount,
       displayShipping,
       displaySubtotal,
+      displaySurcharge,
       displayTax,
       displayTotal,
       isDense,
@@ -139,6 +161,7 @@ class CartSummary extends Component {
     const tax = displayTax || "-";
     const header = !isDense && this.renderHeader();
     const discount = displayDiscount && this.renderDiscount();
+    const surcharge = displaySurcharge && this.renderSurcharge();
 
     return (
       <Table className={className} isDense={isDense}>
@@ -153,6 +176,7 @@ class CartSummary extends Component {
             <TdValue isDense={isDense}>{shipping}</TdValue>
           </tr>
           {discount}
+          {surcharge}
           <tr>
             <Td isDense={isDense}>Tax</Td>
             <TdValue isDense={isDense}>{tax}</TdValue>

--- a/package/src/components/CartSummary/v1/CartSummary.js
+++ b/package/src/components/CartSummary/v1/CartSummary.js
@@ -49,7 +49,7 @@ const Discount = styled.span`
 `;
 
 const Surcharge = styled.span`
-  ${addTypographyStyles("CartSummarySurcharge", "bodyTextBold")}
+  ${addTypographyStyles("CartSummarySurcharge", "bodyText")}
 `;
 
 const Total = styled.span`

--- a/package/src/components/CartSummary/v1/CartSummary.md
+++ b/package/src/components/CartSummary/v1/CartSummary.md
@@ -52,6 +52,19 @@ The CartSummary displays item quantity, subtotal, shipping, tax and total. The c
 />
 ```
 
+#### Display add surcharges
+
+```jsx
+<CartSummary
+  displaySurcharge="$9.99"
+  displayShipping="$5.25"
+  displaySubtotal="$275.77"
+  displayTotal="$298.63"
+  itemsQuantity={3}
+  displayTax="$7.62"
+/>
+```
+
 #### Dense layout
 
 ```jsx

--- a/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.js
+++ b/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.js
@@ -53,6 +53,10 @@ class FinalReviewCheckoutAction extends Component {
        */
       displaySubtotal: PropTypes.string.isRequired,
       /**
+       * Surcharges added to this cart
+       */
+      displaySurcharge: PropTypes.string,
+      /**
        * Calculated tax amount
        */
       displayTax: PropTypes.string,
@@ -134,6 +138,7 @@ class FinalReviewCheckoutAction extends Component {
         displayDiscount,
         displayShipping,
         displaySubtotal,
+        displaySurcharge,
         displayTax,
         displayTotal,
         items
@@ -166,6 +171,7 @@ class FinalReviewCheckoutAction extends Component {
               displayDiscount={displayDiscount}
               displayShipping={displayShipping}
               displaySubtotal={displaySubtotal}
+              displaySurcharge={displaySurcharge}
               displayTax={displayTax}
               displayTotal={displayTotal}
             />

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -279,6 +279,12 @@ const rui_components = {
       lineHeight: 1
     }
   },
+  CartSummarySurcharge: {
+    typography: {
+      color: colors.red300,
+      lineHeight: 1
+    }
+  },
   CartSummaryTotal: {
     typography: {
       color: colors.coolGrey500,

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -281,7 +281,7 @@ const rui_components = {
   },
   CartSummarySurcharge: {
     typography: {
-      color: colors.red300,
+      color: colors.coolGrey500,
       lineHeight: 1
     }
   },


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Component
CartSummary existing component

## Screenshots
![cartsummary_ _reaction_design_system](https://user-images.githubusercontent.com/4482263/48658201-9c64a880-e9f2-11e8-9597-c36c38d84263.png)

## Breaking changes
None

## Testing
1. See that surcharges are visible, when applicable, in CartSummary component