### PR TITLE
feat(#369): CartItem - Display Subtotal

### DIFF
--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -377,11 +377,13 @@ class CartItem extends Component {
             displayCompareAtPrice={displayCompareAtPrice}
             hasPriceBottom={isMiniCart}
           />
-          {displaySubtotal && 
+          { quantity != 1 ?
             <ItemContentSubtotal isMiniCart={isMiniCart}>
               <ItemContentSubtotalTitle>Total ({quantity}):</ItemContentSubtotalTitle>
               <ItemContentSubtotalDisplay>{displaySubtotal}</ItemContentSubtotalDisplay>
             </ItemContentSubtotal>
+            :
+            null
           }
         </ItemContentPrice>        
       </Item>

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -80,22 +80,28 @@ const ItemContentQuantityInput = styled.div`
 `;
 
 const ItemContentPrice = styled.div`
-  bottom: 0;
-  flex: 0 1 auto;
-  position: absolute;
+  position: ${(props) => (props.isMiniCart ? "absolute" : "initial")};
+  bottom: ${applyTheme("CartItem.paddingBottom")};
   right: 0;
-
+  text-align: right;
+  @media (max-width: 768px) {
+    position: absolute;
+  }
   @media (min-width: 768px) {
     margin-left: 1.5rem;
-    position: ${({ isMiniCart }) => (isMiniCart ? "absolute" : "relative")};
   }
 `;
 
 const ItemContentSubtotal = styled.div`
-  position: absolute;
-  bottom: 16px;
+  position: ${(props) => (props.isMiniCart ? "initial" : "absolute")};
+  margin-top: ${(props) => (props.isMiniCart ? applyTheme("CartItem.subtotalDisplaySpacingAbove")(props) : "0")};
+  bottom: ${applyTheme("CartItem.paddingBottom")};
   right: 0;
   text-align: right;
+  @media (max-width: 768px) {
+    position: initial;
+    margin-top: ${applyTheme("CartItem.subtotalDisplaySpacingAbove")};
+  }
 `;
 
 const ItemContentSubtotalTitle = styled.div`
@@ -372,7 +378,7 @@ class CartItem extends Component {
             hasPriceBottom={isMiniCart}
           />
           {displaySubtotal && 
-            <ItemContentSubtotal>
+            <ItemContentSubtotal isMiniCart={isMiniCart}>
               <ItemContentSubtotalTitle>Total ({quantity}):</ItemContentSubtotalTitle>
               <ItemContentSubtotalDisplay>{displaySubtotal}</ItemContentSubtotalDisplay>
             </ItemContentSubtotal>

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -377,7 +377,7 @@ class CartItem extends Component {
             displayCompareAtPrice={displayCompareAtPrice}
             hasPriceBottom={isMiniCart}
           />
-          { quantity != 1 ?
+          { quantity !== 1 ?
             <ItemContentSubtotal isMiniCart={isMiniCart}>
               <ItemContentSubtotalTitle>Total ({quantity}):</ItemContentSubtotalTitle>
               <ItemContentSubtotalDisplay>{displaySubtotal}</ItemContentSubtotalDisplay>

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -5,6 +5,7 @@ import { withComponents } from "@reactioncommerce/components-context";
 import { addTypographyStyles, applyTheme, CustomPropTypes } from "../../../utils";
 
 const Item = styled.div`
+  position: relative;
   align-items: flex-start;
   border-bottom-color: ${applyTheme("CartItem.borderBottomColor")};
   border-bottom-style: solid;
@@ -88,6 +89,22 @@ const ItemContentPrice = styled.div`
     margin-left: 1.5rem;
     position: ${({ isMiniCart }) => (isMiniCart ? "absolute" : "relative")};
   }
+`;
+
+const ItemContentSubtotal = styled.div`
+  position: absolute;
+  bottom: 16px;
+  right: 0;
+  text-align: right;
+`;
+
+const ItemContentSubtotalTitle = styled.div`
+  ${addTypographyStyles("ItemContentSubtotalTitle", "labelText")};
+  white-space: pre;
+`;
+
+const ItemContentSubtotalDisplay = styled.div`
+  ${addTypographyStyles("ItemContentSubtotalDisplay", "bodyTextSemiBold")};
 `;
 
 const ItemRemoveButton = styled.button`
@@ -219,6 +236,12 @@ class CartItem extends Component {
       /**
        * Chosen items title
        */
+      subtotal: PropTypes.shape({
+        /**
+         * The display subtotal
+         */
+        displayAmount: PropTypes.string,
+      }),
       title: PropTypes.string,
       /**
        * Quantity of chosen item in cart
@@ -293,10 +316,12 @@ class CartItem extends Component {
         title,
         quantity,
         isLowQuantity,
-        price: { displayAmount: displayPrice }
+        price: { displayAmount: displayPrice },
+        subtotal
       }
     } = this.props;
 
+    const { displayAmount: displaySubtotal } = subtotal || {};
     const { displayAmount: displayCompareAtPrice } = compareAtPrice || {};
 
     const {
@@ -339,15 +364,20 @@ class CartItem extends Component {
 
             {!isReadOnly && <ItemRemoveButton onClick={this.handleRemoveItemFromCart}>Remove</ItemRemoveButton>}
           </ItemContentDetail>
-
-          <ItemContentPrice isMiniCart={isMiniCart}>
-            <Price
-              displayPrice={displayPrice}
-              displayCompareAtPrice={displayCompareAtPrice}
-              hasPriceBottom={isMiniCart}
-            />
-          </ItemContentPrice>
         </ItemContent>
+        <ItemContentPrice isMiniCart={isMiniCart}>
+          <Price
+            displayPrice={displayPrice}
+            displayCompareAtPrice={displayCompareAtPrice}
+            hasPriceBottom={isMiniCart}
+          />
+          {displaySubtotal && 
+            <ItemContentSubtotal>
+              <ItemContentSubtotalTitle>Total ({quantity}):</ItemContentSubtotalTitle>
+              <ItemContentSubtotalDisplay>{displaySubtotal}</ItemContentSubtotalDisplay>
+            </ItemContentSubtotal>
+          }
+        </ItemContentPrice>        
       </Item>
     );
   }

--- a/package/src/components/CartItem/v1/CartItem.md
+++ b/package/src/components/CartItem/v1/CartItem.md
@@ -26,11 +26,49 @@ const item = {
   },
   productSlug: "product-slug",
   productVendor: "Patagonia",
+  subtotal: {
+    displayAmount: "$40.00",
+  },
   title: "A Great Product",
   quantity: 2
 };
 
 <CartItem
+  item={item}
+  onChangeCartItemQuantity={(value, _id) => console.log("cart item quantity changed to", value, "for item", _id)}
+  onRemoveItemFromCart={() => console.log("Item removed from cart")}
+/>
+```
+
+#### Default: isMiniCart
+
+```jsx
+const item = {
+  _id: "123",
+  attributes: [{ label: "Color", value: "Red" }, { label: "Size", value: "Medium" }],
+  compareAtPrice: {
+    displayAmount: "$45.00"
+  },
+  currentQuantity: 3,
+  imageURLs: {
+    small: "//placehold.it/150",
+    thumbnail: "//placehold.it/100"
+  },
+  isLowQuantity: true,
+  price: {
+    displayAmount: "$20.00"
+  },
+  productSlug: "product-slug",
+  productVendor: "Patagonia",
+  subtotal: {
+    displayAmount: "$40.00",
+  },
+  title: "A Great Product",
+  quantity: 2
+};
+
+<CartItem
+  isMiniCart
   item={item}
   onChangeCartItemQuantity={(value, _id) => console.log("cart item quantity changed to", value, "for item", _id)}
   onRemoveItemFromCart={() => console.log("Item removed from cart")}

--- a/package/src/components/CartItem/v1/CartItem.test.js
+++ b/package/src/components/CartItem/v1/CartItem.test.js
@@ -21,6 +21,9 @@ const mockItem = {
   },
   productSlug: "product-slug",
   productVendor: "Patagonia",
+  subtotal: {
+    displayAmount: "$40.00",
+  },
   title: "A Great Product",
   quantity: 2
 };

--- a/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
+++ b/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
@@ -93,12 +93,10 @@ exports[`basic snapshot with empty props 1`] = `
 }
 
 .c7 {
-  bottom: 0;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  position: absolute;
+  position: initial;
+  bottom: 16px;
   right: 0;
+  text-align: right;
 }
 
 .c6 {
@@ -156,10 +154,15 @@ exports[`basic snapshot with empty props 1`] = `
   }
 }
 
+@media (max-width:768px) {
+  .c7 {
+    position: absolute;
+  }
+}
+
 @media (min-width:768px) {
   .c7 {
     margin-left: 1.5rem;
-    position: relative;
   }
 }
 
@@ -289,16 +292,15 @@ exports[`basic snapshot with isReadOnly prop 1`] = `
 }
 
 .c5 {
-  bottom: 0;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  position: absolute;
+  position: initial;
+  bottom: 16px;
   right: 0;
+  text-align: right;
 }
 
 .c6 {
   position: absolute;
+  margin-top: 0;
   bottom: 16px;
   right: 0;
   text-align: right;
@@ -343,10 +345,22 @@ exports[`basic snapshot with isReadOnly prop 1`] = `
   }
 }
 
+@media (max-width:768px) {
+  .c5 {
+    position: absolute;
+  }
+}
+
 @media (min-width:768px) {
   .c5 {
     margin-left: 1.5rem;
-    position: relative;
+  }
+}
+
+@media (max-width:768px) {
+  .c6 {
+    position: initial;
+    margin-top: 10px;
   }
 }
 
@@ -500,16 +514,15 @@ exports[`basic snapshot with productURLPath prop 1`] = `
 }
 
 .c5 {
-  bottom: 0;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  position: absolute;
+  position: initial;
+  bottom: 16px;
   right: 0;
+  text-align: right;
 }
 
 .c6 {
   position: absolute;
+  margin-top: 0;
   bottom: 16px;
   right: 0;
   text-align: right;
@@ -554,10 +567,22 @@ exports[`basic snapshot with productURLPath prop 1`] = `
   }
 }
 
+@media (max-width:768px) {
+  .c5 {
+    position: absolute;
+  }
+}
+
 @media (min-width:768px) {
   .c5 {
     margin-left: 1.5rem;
-    position: relative;
+  }
+}
+
+@media (max-width:768px) {
+  .c6 {
+    position: initial;
+    margin-top: 10px;
   }
 }
 
@@ -718,16 +743,15 @@ exports[`basic snapshot with props 1`] = `
 }
 
 .c7 {
-  bottom: 0;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  position: absolute;
+  position: initial;
+  bottom: 16px;
   right: 0;
+  text-align: right;
 }
 
 .c8 {
   position: absolute;
+  margin-top: 0;
   bottom: 16px;
   right: 0;
   text-align: right;
@@ -819,10 +843,22 @@ exports[`basic snapshot with props 1`] = `
   }
 }
 
+@media (max-width:768px) {
+  .c7 {
+    position: absolute;
+  }
+}
+
 @media (min-width:768px) {
   .c7 {
     margin-left: 1.5rem;
-    position: relative;
+  }
+}
+
+@media (max-width:768px) {
+  .c8 {
+    position: initial;
+    margin-top: 10px;
   }
 }
 

--- a/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
+++ b/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`basic snapshot with empty props 1`] = `
 .c0 {
+  position: relative;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -193,17 +194,18 @@ exports[`basic snapshot with empty props 1`] = `
         Remove
       </button>
     </div>
-    <div
-      className="c7"
-    >
-      Price(undefined)
-    </div>
+  </div>
+  <div
+    className="c7"
+  >
+    Price(undefined)
   </div>
 </div>
 `;
 
 exports[`basic snapshot with isReadOnly prop 1`] = `
 .c0 {
+  position: relative;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -293,6 +295,44 @@ exports[`basic snapshot with isReadOnly prop 1`] = `
   flex: 0 1 auto;
   position: absolute;
   right: 0;
+}
+
+.c6 {
+  position: absolute;
+  bottom: 16px;
+  right: 0;
+  text-align: right;
+}
+
+.c7 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  white-space: pre;
+}
+
+.c8 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 600;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
 }
 
 @media (min-width:992px) {
@@ -349,10 +389,26 @@ exports[`basic snapshot with isReadOnly prop 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="c5"
+  >
+    Price(undefined)
     <div
-      className="c5"
+      className="c6"
     >
-      Price(undefined)
+      <div
+        className="c7"
+      >
+        Total (
+        2
+        ):
+      </div>
+      <div
+        className="c8"
+      >
+        $40.00
+      </div>
     </div>
   </div>
 </div>
@@ -360,6 +416,7 @@ exports[`basic snapshot with isReadOnly prop 1`] = `
 
 exports[`basic snapshot with productURLPath prop 1`] = `
 .c0 {
+  position: relative;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -449,6 +506,44 @@ exports[`basic snapshot with productURLPath prop 1`] = `
   flex: 0 1 auto;
   position: absolute;
   right: 0;
+}
+
+.c6 {
+  position: absolute;
+  bottom: 16px;
+  right: 0;
+  text-align: right;
+}
+
+.c7 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  white-space: pre;
+}
+
+.c8 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 600;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
 }
 
 @media (min-width:992px) {
@@ -505,10 +600,26 @@ exports[`basic snapshot with productURLPath prop 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="c5"
+  >
+    Price(undefined)
     <div
-      className="c5"
+      className="c6"
     >
-      Price(undefined)
+      <div
+        className="c7"
+      >
+        Total (
+        2
+        ):
+      </div>
+      <div
+        className="c8"
+      >
+        $40.00
+      </div>
     </div>
   </div>
 </div>
@@ -516,6 +627,7 @@ exports[`basic snapshot with productURLPath prop 1`] = `
 
 exports[`basic snapshot with props 1`] = `
 .c0 {
+  position: relative;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -612,6 +724,44 @@ exports[`basic snapshot with props 1`] = `
   flex: 0 1 auto;
   position: absolute;
   right: 0;
+}
+
+.c8 {
+  position: absolute;
+  bottom: 16px;
+  right: 0;
+  text-align: right;
+}
+
+.c9 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  white-space: pre;
+}
+
+.c10 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 600;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
 }
 
 .c6 {
@@ -726,10 +876,26 @@ exports[`basic snapshot with props 1`] = `
         Remove
       </button>
     </div>
+  </div>
+  <div
+    className="c7"
+  >
+    Price(undefined)
     <div
-      className="c7"
+      className="c8"
     >
-      Price(undefined)
+      <div
+        className="c9"
+      >
+        Total (
+        2
+        ):
+      </div>
+      <div
+        className="c10"
+      >
+        $40.00
+      </div>
     </div>
   </div>
 </div>

--- a/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
+++ b/package/src/components/CartItem/v1/__snapshots__/CartItem.test.js.snap
@@ -99,6 +99,45 @@ exports[`basic snapshot with empty props 1`] = `
   text-align: right;
 }
 
+.c8 {
+  position: absolute;
+  margin-top: 0;
+  bottom: 16px;
+  right: 0;
+  text-align: right;
+}
+
+.c9 {
+  -webkit-font-smoothing: antialiased;
+  color: #505558;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 400;
+  -webkit-letter-spacing: .02em;
+  -moz-letter-spacing: .02em;
+  -ms-letter-spacing: .02em;
+  letter-spacing: .02em;
+  line-height: 1.25;
+  white-space: pre;
+}
+
+.c10 {
+  -webkit-font-smoothing: antialiased;
+  color: #3c3c3c;
+  font-family: 'Source Sans Pro','Helvetica Neue',Helvetica,sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-stretch: normal;
+  font-weight: 600;
+  -webkit-letter-spacing: .03em;
+  -moz-letter-spacing: .03em;
+  -ms-letter-spacing: .03em;
+  letter-spacing: .03em;
+  line-height: 1.5;
+}
+
 .c6 {
   -webkit-font-smoothing: antialiased;
   color: #505558;
@@ -166,6 +205,13 @@ exports[`basic snapshot with empty props 1`] = `
   }
 }
 
+@media (max-width:768px) {
+  .c8 {
+    position: initial;
+    margin-top: 10px;
+  }
+}
+
 <div
   className="c0"
 >
@@ -202,6 +248,19 @@ exports[`basic snapshot with empty props 1`] = `
     className="c7"
   >
     Price(undefined)
+    <div
+      className="c8"
+    >
+      <div
+        className="c9"
+      >
+        Total (
+        ):
+      </div>
+      <div
+        className="c10"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/package/src/components/CartItems/v1/CartItems.md
+++ b/package/src/components/CartItems/v1/CartItems.md
@@ -26,7 +26,10 @@ const items = [{
   productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "A Great Product",
-  quantity: 2
+  quantity: 2,
+  subtotal: {
+    displayAmount: "$40.00",
+  }
 },
 {
   _id: "456",
@@ -43,7 +46,10 @@ const items = [{
   productSlug: "product-slug",
   productVendor: "Patagonia",
   title: "Another Great Product",
-  quantity: 1
+  quantity: 1,
+  subtotal: {
+    displayAmount: "$40.00",
+  }
 }];
 
 const handleChangeCartItemQuantity = (value, _id) => console.log("cart items new quantity", value, "for item", _id);
@@ -77,7 +83,10 @@ const items = [{
   productVendor: "Patagonia",
   productSlug: "product-slug",
   title: "A Great Product",
-  quantity: 2
+  quantity: 2,
+  subtotal: {
+    displayAmount: "$40.00",
+  }
 },
 {
   _id: "456",
@@ -94,7 +103,10 @@ const items = [{
   productSlug: "product-slug",
   productVendor: "Nike",
   title: "Another Great Product",
-  quantity: 1
+  quantity: 1,
+  subtotal: {
+    displayAmount: "$40.00",
+  }
 }];
 
 const handleChangeCartItemQuantity = (value, _id) => console.log("cart items new quantity", value, "for item", _id);

--- a/package/src/components/CartItems/v1/CartItems.md
+++ b/package/src/components/CartItems/v1/CartItems.md
@@ -106,7 +106,7 @@ const items = [{
   title: "Another Great Product",
   quantity: 1,
   subtotal: {
-    displayAmount: "$40.00",
+    displayAmount: "$78.00",
   }
 }];
 

--- a/package/src/components/CartItems/v1/CartItems.md
+++ b/package/src/components/CartItems/v1/CartItems.md
@@ -64,6 +64,7 @@ const handleRemoveItemFromCart = (_id) => console.log("cart items remove this it
 ```
 
 #### In Mini Cart
+
 ```jsx
 const items = [{
   _id: "123",

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -236,6 +236,7 @@ const rui_components = {
     paddingLeft: 0,
     paddingRight: 0,
     paddingTop: padding.sixteen,
+    subtotalDisplaySpacingAbove: padding.ten,
     quantityInputSpacingAbove: padding.twelve,
     quantityInputSpacingBelow: padding.eight,
     removeButtonColor_focus: colors.coolGrey,


### PR DESCRIPTION
Resolves #369 
Impact: **minor**  
Type: **feature**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## CartItem, CartItems, MiniCart
- When an item has a quantity of more than one, display the subtotal cost of all of the items.
- This applies to Cart and MiniCart.

## Testing
1. Test CartItems in regular mode and MiniCart mode
2. Test CartItems in desktop and mobile mode