### PR TITLE
fix: 374 nnnnat address validaiton bugs

### DIFF
--- a/package/src/components/Address/v1/Address.js
+++ b/package/src/components/Address/v1/Address.js
@@ -81,9 +81,9 @@ class Address extends Component {
       case "country":
         addressElement = addressProp;
         break;
-      case "region":
-        addressElement = <Fragment>{addressProp} </Fragment>;
-        break;
+      // case "region":
+      //   addressElement = <Fragment>{addressProp} </Fragment>;
+      //   break;
       default:
         addressElement = (
           <Fragment>

--- a/package/src/components/Address/v1/__snapshots__/Address.test.js.snap
+++ b/package/src/components/Address/v1/__snapshots__/Address.test.js.snap
@@ -86,6 +86,7 @@ exports[`basic snapshot with invalid address properties prop 1`] = `
   , 
   LA
    
+  <br />
   70037
    
   <br />
@@ -149,6 +150,7 @@ exports[`basic snapshot with required props 1`] = `
   , 
   LA
    
+  <br />
   70037
    
   <br />

--- a/package/src/components/AddressCapture/v1/AddressCapture.js
+++ b/package/src/components/AddressCapture/v1/AddressCapture.js
@@ -19,6 +19,21 @@ class AddressCapture extends Component {
        */
       addressNamePlaceholder: PropTypes.string,
       /**
+       * Errors array
+       */
+      errors: PropTypes.arrayOf(
+        PropTypes.shape({
+          /**
+           * Error message
+           */
+          message: PropTypes.string.isRequired,
+          /**
+           * Error name
+           */
+          name: PropTypes.string.isRequired
+        })
+      ),
+      /**
        * OnChange event callback
        */
       onChange: PropTypes.func,
@@ -47,6 +62,10 @@ class AddressCapture extends Component {
        * Address validations address suggestion
        */
       addressSuggestion: CustomPropTypes.address,
+      /**
+       * Address validation error object
+       */
+      validationError: PropTypes.object,
       /**
        * The selected address option
        */
@@ -125,6 +144,17 @@ class AddressCapture extends Component {
   get hasAddressSuggestion() {
     const { addressReviewProps: { addressSuggestion } } = this.props;
     return !!addressSuggestion;
+  }
+
+  /**
+   *
+   * @method hasValidationError
+   * @summary returns true if we have any validation errors from a address validation service
+   * @return {Boolean} - true if validation errors on props
+   */
+  get hasValidationError() {
+    const { addressReviewProps: { validationError } } = this.props;
+    return !!validationError;
   }
 
   /**
@@ -235,7 +265,7 @@ class AddressCapture extends Component {
     const { onAddressValidation, onSubmit } = this.props;
     if (onAddressValidation && !address.isValid) {
       await onAddressValidation(address);
-      if (!this.hasAddressSuggestion) await onSubmit(address);
+      if (!this.hasAddressSuggestion && !this.hasValidationError) await onSubmit(address);
     } else {
       await onSubmit(address);
     }

--- a/package/src/components/AddressCapture/v1/AddressCapture.js
+++ b/package/src/components/AddressCapture/v1/AddressCapture.js
@@ -21,18 +21,16 @@ class AddressCapture extends Component {
       /**
        * Errors array
        */
-      errors: PropTypes.arrayOf(
-        PropTypes.shape({
-          /**
+      errors: PropTypes.arrayOf(PropTypes.shape({
+        /**
            * Error message
            */
-          message: PropTypes.string.isRequired,
-          /**
+        message: PropTypes.string.isRequired,
+        /**
            * Error name
            */
-          name: PropTypes.string.isRequired
-        })
-      ),
+        name: PropTypes.string.isRequired
+      })),
       /**
        * OnChange event callback
        */

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -225,7 +225,7 @@ class CheckoutActionsExample extends React.Component {
             actionAlerts["1"] = {
               alertType: "warning",
               title: "The address you entered may be incorrect or incomplete.",
-              message: "Please review our suggestion below, and choose which version you’d like to use. Possible errors are shown in red."
+              message: "Please review your entered address below. Possible errors are shown in red."
             };
             
             return {

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -237,7 +237,7 @@ class CheckoutActionsExample extends React.Component {
                   postal: "90210",
                   isValid: true
                 }],
-                validationErrors: value.postal[1] === "1" ? [] : [actionAlerts]
+                validationErrors: data.postal[1] === "1" ? [] : [actionAlerts]
               },
               actionAlerts,
               checkout

--- a/package/src/components/CheckoutActions/v1/CheckoutActions.md
+++ b/package/src/components/CheckoutActions/v1/CheckoutActions.md
@@ -63,6 +63,8 @@ const actions = [
 
 ```
 
+*Address postal codes that start with "11" will pass validation, all others will fail.*
+*Address postal codes that start with "10" will fail validation with 0 suggested addresses.*
 ```jsx
 const fulfillmentGroups = [{
   _id: 1,
@@ -235,7 +237,7 @@ class CheckoutActionsExample extends React.Component {
                   postal: "90210",
                   isValid: true
                 }],
-                validationErrors: []
+                validationErrors: value.postal[1] === "1" ? [] : [actionAlerts]
               },
               actionAlerts,
               checkout

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -222,7 +222,7 @@ class ShippingAddressCheckoutAction extends Component {
         <Title>
           {stepNumber}. {label}
         </Title>
-        {alert ? <InlineAlert alertType="warning" {...alert} /> : ""}
+        {alert ? <InlineAlert {...alert} /> : ""}
         {this.renderAddressCapture()}
       </Fragment>
     );

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -111,7 +111,7 @@ class ShippingAddressCheckoutAction extends Component {
 
   get hasValidationResults() {
     const { addressValidationResults } = this.props;
-    return !!(addressValidationResults && addressValidationResults.suggestedAddresses.length);
+    return !!(addressValidationResults && addressValidationResults.validationErrors.length);
   }
 
   get getSubmittedAddress() {

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -16,6 +16,14 @@ const Address = styled.address`
 const ENTRY = "entry";
 const EDIT = "edit";
 const REVIEW = "review";
+const FORM_ERRORS = [
+  { message: "", name: "country" },
+  { message: "", name: "fullName" },
+  { message: "", name: "address1" },
+  { message: "", name: "city" },
+  { message: "", name: "region" },
+  { message: "", name: "postal" }
+];
 
 class ShippingAddressCheckoutAction extends Component {
   static propTypes = {
@@ -90,7 +98,8 @@ class ShippingAddressCheckoutAction extends Component {
   };
 
   state = {
-    status: !this.hasShippingAddressOnCart && this.hasValidationResults ? REVIEW : ENTRY
+    status: !this.hasShippingAddressOnCart && this.hasValidationResults ? REVIEW : ENTRY,
+    formErrors: this.hasValidationResults ? FORM_ERRORS : []
   };
 
   componentDidMount() {
@@ -99,7 +108,10 @@ class ShippingAddressCheckoutAction extends Component {
 
   componentDidUpdate({ addressValidationResults: prevValidationResults }) {
     const { addressValidationResults } = this.props;
-    if (!isEqual(prevValidationResults, addressValidationResults) && this.inEntry) this.toggleStatus = REVIEW;
+    if (!isEqual(prevValidationResults, addressValidationResults) && this.hasValidationResults) {
+      this.setFormErrors = FORM_ERRORS;
+      this.toggleStatus = EDIT;
+    }
   }
 
   _form = null;
@@ -145,6 +157,10 @@ class ShippingAddressCheckoutAction extends Component {
     this.setState({ status });
   }
 
+  set setFormErrors(formErrors) {
+    this.setState({ formErrors });
+  }
+
   isFormFilled = (values) => Object.keys(values).every((key) => (key === "address2" ? true : values[key] !== null));
 
   submit = () => {
@@ -157,6 +173,8 @@ class ShippingAddressCheckoutAction extends Component {
   };
 
   handleChange = (values) => {
+    const { formErrors } = this.state;
+    if (formErrors.length) this.setFormErrors = [];
     if (this.isFormFilled(values)) this.ready();
   };
 
@@ -168,20 +186,25 @@ class ShippingAddressCheckoutAction extends Component {
       onSubmit,
       onAddressValidation
     } = this.props;
+    const { formErrors } = this.state;
+
     const captureProps = {
       addressFormProps: {
         onChange: this.handleChange,
         shouldShowIsCommercialField: true,
-        value: this.inEdit ? this.getSubmittedAddress : this.getShippingAddress
+        value: this.inEdit ? this.getSubmittedAddress : this.getShippingAddress,
+        errors: formErrors
       },
       addressReviewProps: {
         addressEntered: this.getSubmittedAddress,
-        addressSuggestion: this.hasValidationResults ? addressValidationResults.suggestedAddresses[0] : null
+        addressSuggestion: this.hasValidationResults ? addressValidationResults.suggestedAddresses[0] : null,
+        validationError: this.hasValidationResults ? addressValidationResults.validationErrors[0] : null
       },
       isSaving,
       onAddressValidation,
       onSubmit
     };
+
     return (
       <AddressCapture
         ref={(formEl) => {

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.md
@@ -210,7 +210,9 @@ const props = {
 
 **With simple address validation**
 
-A naive example to demonstrate a validation shipping address checkout action UX flow. 
+A naive example to demonstrate a validation shipping address checkout action UX flow
+*Address postal codes that start with "11" will pass validation, all others will fail.*
+*Address postal codes that start with "10" will fail validation with 0 suggested addresses.*
 ```jsx
 initState = {
   addressValidationResults: null,
@@ -265,7 +267,7 @@ const handleValidation = (value) => new Promise((resolve, reject) => {
           postal: "90210",
           isValid: true
         }],
-        validationErrors: [{
+        validationErrors: value.postal[1] === "1" ? [] : [{
          summary: "Address Not Found",
          details: "The address as submitted could not be found. Please check for excessive abbreviations in the street address line or in the City name.",
          source: "USPS",


### PR DESCRIPTION
Resolves #374 #373 
Impact: **major**  
Type: **bugfix**

## Component
AddressCapture component would allow the submission of invalid addresses in some cases.
Address component postal code would cause a weird line break with long addresses.

## Screenshots
@cassytaylor part of the issue was we could have an invalid address with 0 suggested address. If that is the case I'm applying error state to the AddressForm and showing the validation error message above in an InlineAlert.
![screen shot 2018-11-28 at 4 56 58 pm](https://user-images.githubusercontent.com/1135948/49188029-f2a8e400-f32e-11e8-9dac-e8cd57ab95de.png)


## Breaking changes
N/A

## Testing
1. Visit the [CheckoutActions docs]() and enter a shipping address with a postal code of "10111".
2. The action shoudl encounter a validation error without and suggestions. The form should show field errror state and an InlineAlert should appear.
3. Visit the [Address docs]() and verify the postal code is on a new line.