### PR TITLE
chore: refactor Docker node_modules linking

### DIFF
--- a/.reaction/yarnrc-docker.template
+++ b/.reaction/yarnrc-docker.template
@@ -11,5 +11,4 @@ yarn-offline-mirror-pruning true
 
 --install.cache-folder /home/node/.cache/yarn
 --install.ignore-scripts true
---install.modules-folder /usr/local/src/node_modules
 --install.prefer-offline true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
       - $HOME/.cache/yarn-offline-mirror:/home/node/.cache/yarn-offline-mirror
       - web-yarn:/home/node/.cache/yarn
       - .:/usr/local/src/reaction-app # link everything from the root folder on the host machine into the container
-      - empty_node_modules:/usr/local/src/reaction-app/node_modules # except do not link the host node_modules in because it will override the container node_modules
-      - node_modules:/usr/local/src/node_modules # persist the node_modules that is used, which is up one folder level in the container
+      - node_modules:/usr/local/src/reaction-app/node_modules # except do not link the host /node_modules in because it will override the container node_modules
+      - package_node_modules:/usr/local/src/reaction-app/package/node_modules # except do not link the host /package/node_modules in because it will override the container node_modules
 
 volumes:
   web-yarn:
-  empty_node_modules:
   node_modules:
+  package_node_modules:


### PR DESCRIPTION
Resolves #378
Impact: **minor**  
Type: **chore**

This fixes the issue described in #378. The problem is that in this repo we install from two different `package.json` files (one for the style guide and one for the NPM package) and both use the custom Yarn config, which specifies a custom `--install.modules-folder`. So essentially one `yarn install` would install everything in that folder in the container and then the next `yarn install` would overwrite everything in that folder.

I briefly tried having two different `node_modules` folders, both up one level in the directory tree. However, Node will not find the files unless the folder is exactly named `node_modules`.

But in reality, there is no reason to move `node_modules` up a level in the first place. Given that linked volumes in `docker-compose.yml` take precedence over the generic project directory link, we can keep both `node_modules` in there normal spot and simply map the in-container folders to volumes. So this is what I've done.

## Testing
Assuming you are having the problem described in the issue, run `docker-compose up -d --build` after pulling this and it should start up without problems. If not, `docker volume rm` all volumes that begin with `reaction-component-library_web` and then try again.

Also verify that you can successfully build the Docker image for production and run it.