### PR TITLE
Update components context

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "suiteName": "jest-tests"
   },
   "dependencies": {
-    "@reactioncommerce/components-context": "1.0.0",
+    "@reactioncommerce/components-context": "^1.1.0",
     "babel-polyfill": "^6.26.0",
     "prop-types": "15.6.2",
     "react": "16.4.2",

--- a/package/src/components/AddressCapture/v1/AddressCapture.js
+++ b/package/src/components/AddressCapture/v1/AddressCapture.js
@@ -134,7 +134,6 @@ class AddressCapture extends Component {
   _form = null;
 
   /**
-   *
    * @method hasAddressSuggestion
    * @summary returns true if we have a suggested address from a address validation service
    * @return {Boolean} - true if address suggestion on props
@@ -145,7 +144,6 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method hasValidationError
    * @summary returns true if we have any validation errors from a address validation service
    * @return {Boolean} - true if validation errors on props
@@ -156,7 +154,6 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method addressEntered
    * @summary getter that returns the entered address
    * @return {Object} addressEntered -  Address object
@@ -167,7 +164,6 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method addressSuggestion
    * @summary getter that returns the suggested address
    * @return {Object} addressSuggestion -  Address object
@@ -178,7 +174,6 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method addressProvided
    * @summary getter that returns the provided address form value
    * @return {Object} addressProvided -  Address object
@@ -189,10 +184,9 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method inEntry
    * @summary getter that returns true if in entry mode
-   * @return {Boolean}
+   * @return {Boolean} True if currently in entry status
    */
   get inEntry() {
     const { status } = this.state;
@@ -200,10 +194,9 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method inEdit
    * @summary getter that returns true if in edit mode
-   * @return {Boolean}
+   * @return {Boolean} True if currently in edit status
    */
   get inEdit() {
     const { status } = this.state;
@@ -211,10 +204,9 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method inReview
    * @summary getter that returns true if in review mode
-   * @return {Boolean}
+   * @return {Boolean} True if currently in review status
    */
   get inReview() {
     const { status } = this.state;
@@ -222,9 +214,9 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method toggleStatus
    * @summary setter that toggles the Component's status.
+   * @param {String} status The new status
    * @return {undefined}
    */
   set toggleStatus(status) {
@@ -232,7 +224,6 @@ class AddressCapture extends Component {
   }
 
   /**
-   *
    * @method formRef
    * @summary binds the active form element to the `_form` property
    * @param {Object} form - React ref element
@@ -243,8 +234,7 @@ class AddressCapture extends Component {
   };
 
   /**
-   *
-   * @name submit
+   * @method submit
    * @summary Instance method that submits the form, this allows a parent component access to the Form submit event.
    * @return {undefined}
    */
@@ -253,10 +243,9 @@ class AddressCapture extends Component {
   };
 
   /**
-   *
    * @method handleSubmit
    * @summary validate or submit the entered address object.
-   * @param {Object} address - submited address object
+   * @param {Object} address - submitted address object
    * @return {undefined}
    */
   handleSubmit = async (address) => {

--- a/package/src/components/AddressReview/v1/AddressReview.test.js
+++ b/package/src/components/AddressReview/v1/AddressReview.test.js
@@ -27,25 +27,29 @@ const mockAddressSuggestion = {
 };
 
 test("basic snapshot with only required props", () => {
-  const component = renderer.create(<AddressReview
-    addressEntered={mockAddressEntered}
-    addressSuggestion={mockAddressSuggestion}
-    components={mockComponents}
-  />);
+  const component = renderer.create((
+    <AddressReview
+      addressEntered={mockAddressEntered}
+      addressSuggestion={mockAddressSuggestion}
+      components={mockComponents}
+    />
+  ));
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 test("basic snapshot with all props", () => {
-  const component = renderer.create(<AddressReview
-    addressEntered={mockAddressEntered}
-    addressSuggestion={mockAddressSuggestion}
-    components={mockComponents}
-    value="entered"
-    warningTitle="Warning"
-    warningMessage="Something is wrong"
-  />);
+  const component = renderer.create((
+    <AddressReview
+      addressEntered={mockAddressEntered}
+      addressSuggestion={mockAddressSuggestion}
+      components={mockComponents}
+      value="entered"
+      warningTitle="Warning"
+      warningMessage="Something is wrong"
+    />
+  ));
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/package/src/components/ErrorsBlock/v1/ErrorsBlock.js
+++ b/package/src/components/ErrorsBlock/v1/ErrorsBlock.js
@@ -98,8 +98,4 @@ class ErrorsBlock extends Component {
   }
 }
 
-const WrappedErrorsBlock = withComponents(ErrorsBlock);
-
-WrappedErrorsBlock.isFormErrors = true;
-
-export default WrappedErrorsBlock;
+export default withComponents(ErrorsBlock);

--- a/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.js
+++ b/package/src/components/FinalReviewCheckoutAction/v1/FinalReviewCheckoutAction.js
@@ -35,6 +35,9 @@ const Items = styled.div`
 `;
 
 class FinalReviewCheckoutAction extends Component {
+  // Checkout review is the final step so it has no complete state
+  static renderComplete = () => null;
+
   static propTypes = {
     /**
      * Cart data
@@ -182,10 +185,4 @@ class FinalReviewCheckoutAction extends Component {
   }
 }
 
-const WrappedFinalReviewCheckoutAction = withComponents(FinalReviewCheckoutAction);
-
-// Checkout review is the final step so it has no complete state
-// eslint-disable-next-line
-WrappedFinalReviewCheckoutAction.renderComplete = () => null
-
-export default WrappedFinalReviewCheckoutAction;
+export default withComponents(FinalReviewCheckoutAction);

--- a/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
+++ b/package/src/components/FulfillmentOptionsCheckoutAction/v1/FulfillmentOptionsCheckoutAction.js
@@ -30,6 +30,14 @@ const FulfillmentOptionShape = PropTypes.shape({
 });
 
 class FulfillmentOptionsCheckoutAction extends Component {
+  static renderComplete({ fulfillmentGroup: { selectedFulfillmentOption } }) {
+    return (
+      <FulfillmentOption>
+        {selectedFulfillmentOption.fulfillmentMethod.displayName} • {selectedFulfillmentOption.price.displayAmount}
+      </FulfillmentOption>
+    );
+  }
+
   static propTypes = {
     /**
      * Alert object provides alert into to InlineAlert.
@@ -183,13 +191,4 @@ class FulfillmentOptionsCheckoutAction extends Component {
   }
 }
 
-const WrappedFullfillmentOptionsCheckoutAction = withComponents(FulfillmentOptionsCheckoutAction);
-
-// eslint-disable-next-line
-WrappedFullfillmentOptionsCheckoutAction.renderComplete = ({ fulfillmentGroup: { selectedFulfillmentOption } }) => (
-  <FulfillmentOption>
-    {selectedFulfillmentOption.fulfillmentMethod.displayName} • {selectedFulfillmentOption.price.displayAmount}
-  </FulfillmentOption>
-);
-
-export default WrappedFullfillmentOptionsCheckoutAction;
+export default withComponents(FulfillmentOptionsCheckoutAction);

--- a/package/src/components/InlineAlert/v1/InlineAlert.js
+++ b/package/src/components/InlineAlert/v1/InlineAlert.js
@@ -175,6 +175,5 @@ class InlineAlert extends Component {
     );
   }
 }
-const WrappedInlineAlert = withComponents(InlineAlert);
 
-export default WrappedInlineAlert;
+export default withComponents(InlineAlert);

--- a/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
+++ b/package/src/components/PhoneNumberInput/v1/PhoneNumberInput.js
@@ -479,8 +479,4 @@ class PhoneNumberInput extends Component {
   }
 }
 
-const WrappedPhoneNumberInput = withComponents(PhoneNumberInput);
-
-WrappedPhoneNumberInput.isFormInput = true;
-
-export default WrappedPhoneNumberInput;
+export default withComponents(PhoneNumberInput);

--- a/package/src/components/RegionInput/v1/RegionInput.js
+++ b/package/src/components/RegionInput/v1/RegionInput.js
@@ -80,8 +80,4 @@ class RegionInput extends Component {
   }
 }
 
-const WrappedRegionInput = withComponents(RegionInput);
-
-WrappedRegionInput.isFormInput = true;
-
-export default WrappedRegionInput;
+export default withComponents(RegionInput);

--- a/package/src/components/SelectableList/v1/SelectableList.js
+++ b/package/src/components/SelectableList/v1/SelectableList.js
@@ -359,8 +359,4 @@ class SelectableList extends Component {
   }
 }
 
-const WrappedSelectableList = withComponents(SelectableList);
-
-WrappedSelectableList.isFormInput = true;
-
-export default WrappedSelectableList;
+export default withComponents(SelectableList);

--- a/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
+++ b/package/src/components/ShippingAddressCheckoutAction/v1/ShippingAddressCheckoutAction.js
@@ -26,6 +26,24 @@ const FORM_ERRORS = [
 ];
 
 class ShippingAddressCheckoutAction extends Component {
+  static renderComplete({ fulfillmentGroup: { data: { shippingAddress } } }) {
+    return (
+      <Address>
+        {shippingAddress.fullName}
+        <br />
+        {shippingAddress.address1}
+        <br />
+        {shippingAddress.address2 !== null && shippingAddress.address2 !== "" ? (
+          <span>
+            {shippingAddress.address2} <br />
+          </span>
+        ) : null}
+        {shippingAddress.city}, {shippingAddress.region} {shippingAddress.postal} <br />
+        {shippingAddress.country}
+      </Address>
+    );
+  }
+
   static propTypes = {
     /**
      * Address validation results object
@@ -229,23 +247,4 @@ class ShippingAddressCheckoutAction extends Component {
   }
 }
 
-const WrappedShippingAddressCheckoutAction = withComponents(ShippingAddressCheckoutAction);
-
-// eslint-disable-next-line
-WrappedShippingAddressCheckoutAction.renderComplete = ({ fulfillmentGroup: { data: { shippingAddress } } }) => (
-  <Address>
-    {shippingAddress.fullName}
-    <br />
-    {shippingAddress.address1}
-    <br />
-    {shippingAddress.address2 !== null && shippingAddress.address2 !== "" ? (
-      <span>
-        {shippingAddress.address2} <br />
-      </span>
-    ) : null}
-    {shippingAddress.city}, {shippingAddress.region} {shippingAddress.postal} <br />
-    {shippingAddress.country}
-  </Address>
-);
-
-export default WrappedShippingAddressCheckoutAction;
+export default withComponents(ShippingAddressCheckoutAction);

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -35,6 +35,14 @@ const billingAddressOptions = [{
 }];
 
 class StripePaymentCheckoutAction extends Component {
+  static renderComplete({ payment: { data: { displayName } } }) {
+    return (
+      <div>
+        {displayName}
+      </div>
+    );
+  }
+
   static propTypes = {
     /**
      * Alert object provides alert into to InlineAlert.
@@ -249,13 +257,4 @@ class StripePaymentCheckoutAction extends Component {
   }
 }
 
-const WrappedStripePaymentCheckoutAction = withComponents(StripePaymentCheckoutAction);
-
-// eslint-disable-next-line
-WrappedStripePaymentCheckoutAction.renderComplete = ({ payment: { data: { billingAddress, displayName } }}) => (
-  <div>
-    {displayName}
-  </div>
-);
-
-export default WrappedStripePaymentCheckoutAction;
+export default withComponents(StripePaymentCheckoutAction);

--- a/package/src/components/TextInput/v1/TextInput.js
+++ b/package/src/components/TextInput/v1/TextInput.js
@@ -592,8 +592,4 @@ class TextInput extends Component {
   }
 }
 
-const WrappedTextInput = withComponents(TextInput);
-
-WrappedTextInput.isFormInput = true;
-
-export default WrappedTextInput;
+export default withComponents(TextInput);

--- a/package/src/svg/iconPlus.js
+++ b/package/src/svg/iconPlus.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from "react";
 import styled from "styled-components";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,9 +238,12 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
-"@reactioncommerce/components-context@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.0.0.tgz#587764cf0d1b0312c786b8e4657379de02e13845"
+"@reactioncommerce/components-context@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.1.0.tgz#d50ab030423f5c2802f7342c30589493b1d9ed73"
+  integrity sha512-WhMplFH1z6FMC6zVsPTMIpGGdkNnQ2mFO+TZZee+zhwdiPtLVHAtuhEwBCCuaIA3OjCS4qThf8r6Eg2an8AjsQ==
+  dependencies:
+    hoist-non-react-statics "^3.2.0"
 
 "@reactioncommerce/eslint-config@^1.0.1":
   version "1.0.1"
@@ -4841,6 +4844,13 @@ hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
+hoist-non-react-statics@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -8397,7 +8407,7 @@ react-is@^16.3.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
 
-react-is@^16.6.1, react-is@^16.6.3:
+react-is@^16.3.2, react-is@^16.6.1, react-is@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
 


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Changes
Previously `withComponents` HOC did not hoist non-React `static` props, so we had code at the bottom of many component files hoisting or setting statics. This pulls in the latest `components-context` package release, which has a fixed `withComponents`. I've removed the workaround code.

## Breaking changes
None

## Testing
Make sure that affected components, mainly forms and CheckoutAction steps still seem to work properly.