### PR TITLE
chore: Adopt Developer Certificate of Origin in documentation.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [Running and Developing Locally](./developing.md)
 - [Repo Structure](./repo-structure.md)
 - [Style Guide Development](./style-guide-development.md)
+- [Contributing](./contributing.md)
 
 ### Editor Extensions
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 We're thrilled that you want to contribute to the Reaction Component Library!
 
-Before submitting your first contribution, please consult the [official guide on contributing to the Reaction code base] first. The sections below are currently specific to the Reaction Component Library and should be considered in addition to the official guide.
+Before submitting your first contribution, please consult the [official guide on contributing to the Reaction code base](https://docs.reactioncommerce.com/docs/contributing-to-reaction) first. The sections below are currently specific to the Reaction Component Library and should be considered in addition to the official guide.
 
 # Signing your Commits
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,42 @@
+# Contributing
+
+# Signing your Commits
+
+Contributing to the Reaction Component Library requires signing your work by way of signed Git commits.
+
+The Reaction Component Library uses the Apache 2.0 license to allow our community and customers to use it in whichever way they please. It also helps foster open contributions.
+
+As a contributor, we want to make sure that you understand your rights as the copyright holder. We also want to make sure that contributions done on behalf of companies (i.e. by their employees) are submitted with the acknowledgement that the contributor (employee) isn't the copyright holder (employer).
+
+The Reaction Components Library is using a Developer Certificate of Origin (DCO), by way of signed commits, to help contributors acknowledge that they're aware of their rights, and that they have the authority to submit their contributions either on their or on their employer's behalf.
+
+The DCO signoff is attached to every single commit, thereby stating that the committer agrees to the DCO as shown below or on <https://developercertificate.org/>.
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the
+    best of my knowledge, is covered under an appropriate open
+    source license and I have the right under that license to   
+    submit that work with modifications, whether created in whole
+    or in part by me, under the same open source license (unless
+    I am permitted to submit under a different license), as
+    Indicated in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including
+    all personal information I submit with it, including my
+    sign-off) is maintained indefinitely and may be redistributed
+    consistent with this project or the open source license(s)
+    involved.
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,9 @@
 # Contributing
 
+We're thrilled that you want to contribute to the Reaction Component Library!
+
+Before submitting your first contribution, please consult the [official guide on contributing to the Reaction code base] first. The sections below are currently specific to the Reaction Component Library and should be considered in addition to the official guide.
+
 # Signing your Commits
 
 Contributing to the Reaction Component Library requires signing your work by way of signed Git commits.
@@ -9,6 +13,12 @@ The Reaction Component Library uses the Apache 2.0 license to allow our communit
 As a contributor, we want to make sure that you understand your rights as the copyright holder. We also want to make sure that contributions done on behalf of companies (i.e. by their employees) are submitted with the acknowledgement that the contributor (employee) isn't the copyright holder (employer).
 
 The Reaction Components Library is using a Developer Certificate of Origin (DCO), by way of signed commits, to help contributors acknowledge that they're aware of their rights, and that they have the authority to submit their contributions either on their or on their employer's behalf.
+
+To sign off on the DCO for your commits, use the command `git commit -s` which adds a line to every commit that looks like this:
+
+`Signed-Off-By: Jane Doe <jane@example.com>`
+
+We do ask that you use your full name and a valid email address in this process.
 
 The DCO signoff is attached to every single commit, thereby stating that the committer agrees to the DCO as shown below or on <https://developercertificate.org/>.
 


### PR DESCRIPTION
Signed-off-by: Mathias Meyer <meyer@paperplanes.de>

We're adopting the Developer Certificate of Origin process to document contributions and acknowledgement of the Apache 2.0 license (introduced in #377).

The goals of this change are:
- Ensuring explicit sign-off on community contributions, especially from corporate clients and their employees, to ensure contributions were made with the understanding of a) the license and b) the contributor's authority to provide the patch to Reaction as an open source project.
- Keeping legal overhead to a minimum, e.g. by avoiding complex legal language and a signing process. We want to encourage people to contribute, not put them off with legalese they may need to discuss with their lawyer before contributing.
- We want to keep the steps involved as simple as possible.

This implements the final decision record on the DCO as of 2018-12-19.