### PR TITLE
fix/chore: component context dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "suiteName": "jest-tests"
   },
   "dependencies": {
-    "@reactioncommerce/components-context": "^1.1.0",
+    "@reactioncommerce/components-context": "^1.2.0",
     "babel-polyfill": "^6.26.0",
     "prop-types": "15.6.2",
     "react": "16.4.2",

--- a/package/package.json
+++ b/package/package.json
@@ -76,7 +76,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@reactioncommerce/components-context": "^1.0.0",
+    "@reactioncommerce/components-context": "^1.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "react-container-query": "^0.11.0",

--- a/styleguide/src/sections/InstallingandImporting.md
+++ b/styleguide/src/sections/InstallingandImporting.md
@@ -1,13 +1,13 @@
 #### Install
 
 ```bash
-npm install --save react@16.4.2 prop-types@15.6.2 styled-components@3.3.3 reacto-form@0.0.2 @reactioncommerce/components-context@1.0.0 @reactioncommerce/components
+npm install --save react@16.4.2 prop-types@15.6.2 styled-components@3.3.3 reacto-form@0.0.2 @reactioncommerce/components-context@1.2.0 @reactioncommerce/components
 ```
 
 or
 
 ```bash
-yarn add react@16.4.2 prop-types@15.6.2 styled-components@3.3.3 reacto-form@0.0.2 @reactioncommerce/components-context@1.0.0 @reactioncommerce/components
+yarn add react@16.4.2 prop-types@15.6.2 styled-components@3.3.3 reacto-form@0.0.2 @reactioncommerce/components-context@1.2.0 @reactioncommerce/components
 ```
 
 Note that the minimum required React version is 16.4.1 because this package uses newer APIs like `createContext` and `forwardRef`. The `react`, `prop-types`, `@reactioncommerce/components-context`, `reacto-form`, and `styled-components` packages are peer dependencies, which means that you must install the proper versions in your app. They are not included with this package.

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,10 +238,9 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
-"@reactioncommerce/components-context@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.1.0.tgz#d50ab030423f5c2802f7342c30589493b1d9ed73"
-  integrity sha512-WhMplFH1z6FMC6zVsPTMIpGGdkNnQ2mFO+TZZee+zhwdiPtLVHAtuhEwBCCuaIA3OjCS4qThf8r6Eg2an8AjsQ==
+"@reactioncommerce/components-context@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@reactioncommerce/components-context/-/components-context-1.2.0.tgz#4874a08268272cfacc9f2b6a166f36f42f0a3444"
   dependencies:
     hoist-non-react-statics "^3.2.0"
 
@@ -4847,7 +4846,6 @@ hoist-non-react-statics@^2.5.0:
 hoist-non-react-statics@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
-  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
   dependencies:
     react-is "^16.3.2"
 


### PR DESCRIPTION
Impact: **minor**  
Type: **chore**

## Component

The `components-context` dependencies are out of date. This caused an issue in reaction core with the latest component library installed with v1.0.0 of components-context broke `reacto` form validation and submitting.

## Breaking changes

none.

## Testing

ensure the form fields are working and submitting properly. The best example of this is the final example on the AddressBook component page.
