### PR TITLE
docs: how to test component library locally

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -378,6 +378,10 @@ module.exports = {
         {
           name: "Understanding Component References",
           content: "styleguide/src/sections/ComponentsContext.md"
+        },
+        {
+          name: "Developing Locally Inside Another Project",
+          content: "styleguide/src/sections/LocalDevelopment.md"
         }
       ]
     },

--- a/styleguide/src/sections/LocalDevelopment.md
+++ b/styleguide/src/sections/LocalDevelopment.md
@@ -2,7 +2,7 @@ If you'd like to see your changes locally inside of another project, such as the
 
 - `cd` into your local version of the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library), and run the following commands:
 
-```js
+```diff
 yarn install
 cd package
 yarn install

--- a/styleguide/src/sections/LocalDevelopment.md
+++ b/styleguide/src/sections/LocalDevelopment.md
@@ -1,14 +1,15 @@
 If you'd like to see your changes locally inside of another project, such as the [Reaction Operator UI](https://github.com/reactioncommerce/reaction) or the [Reaction Storefront](https://github.com/reactioncommerce/reaction-next-starterkit), it's possible to link your local version of this Component Library using the following steps:
 
-1. `cd` into your local version of the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library), and run the following commands:
-```
+- `cd` into your local version of the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library), and run the following commands:
+
+```js
 yarn install
-cd package`
+cd package
 yarn install
 yarn run build
 ```
 
-Next, `cd` into the local version of the repository you'd like to use the local `Component Library` inside. Add the following line to the `volumes:` portion of the `docker-compose.yml` file:
+- Next, `cd` into the local version of the repository you'd like to use the local `Component Library` inside. Add the following line to the `volumes:` portion of the `docker-compose.yml` file:
 
 Inside `Reaction Storefront`:
 
@@ -33,4 +34,6 @@ volumes:
 + - /{Path-to-your-local-repo}/reaction-component-library/package/dist:/usr/local/src/node_modules/@reactioncommerce/components
 ```
 
-Next, run `docker-compose up -d` like normal to access the app in your browser and test it. Be sure to remove and not commit the added line from `docker-compose.yml` when you are done testing.
+- Next, run `docker-compose up -d` like normal to access the app in your browser and test it.
+
+**Be sure to remove and not commit the added line from `docker-compose.yml` when you are done testing.**

--- a/styleguide/src/sections/LocalDevelopment.md
+++ b/styleguide/src/sections/LocalDevelopment.md
@@ -1,0 +1,36 @@
+If you'd like to see your changes locally inside of another project, such as the [Reaction Operator UI](https://github.com/reactioncommerce/reaction) or the [Reaction Storefront](https://github.com/reactioncommerce/reaction-next-starterkit), it's possible to link your local version of this Component Library using the following steps:
+
+1. `cd` into your local version of the [Reaction Component Library](https://github.com/reactioncommerce/reaction-component-library), and run the following commands:
+```
+yarn install
+cd package`
+yarn install
+yarn run build
+```
+
+Next, `cd` into the local version of the repository you'd like to use the local `Component Library` inside. Add the following line to the `volumes:` portion of the `docker-compose.yml` file:
+
+Inside `Reaction Storefront`:
+
+```diff
+volumes:
+  - $HOME/.cache/yarn-offline-mirror:/home/node/.cache/yarn-offline-mirror
+  - web-yarn:/home/node/.cache/yarn
+  - .:/usr/local/src/reaction-app
+  - empty_node_modules:/usr/local/src/reaction-app/node_modules # do not link node_modules in, and persist it between dc up runs
+  - node_modules:/usr/local/src/node_modules
++ - /{Path-to-your-local-repo}/reaction-component-library/package/dist:/usr/local/src/reaction-app/node_modules/@reactioncommerce/components
+```
+
+Inside `Reaction Operator UI`:
+```diff
+volumes:
+  - $HOME/.cache/yarn-offline-mirror:/home/node/.cache/yarn-offline-mirror
+  - web-yarn:/home/node/.cache/yarn
+  - .:/usr/local/src/reaction-app
+  - empty_node_modules:/usr/local/src/reaction-app/node_modules # do not link node_modules in, and persist it between dc up runs
+  - node_modules:/usr/local/src/node_modules
++ - /{Path-to-your-local-repo}/reaction-component-library/package/dist:/usr/local/src/node_modules/@reactioncommerce/components
+```
+
+Next, run `docker-compose up -d` like normal to access the app in your browser and test it. Be sure to remove and not commit the added line from `docker-compose.yml` when you are done testing.


### PR DESCRIPTION
Impact: **minor**  
Type: **docs**

Adding instructions on how to use a local version of the component library inside storefront and the operator UI. Instructions taken, and slightly modified per repo, from here: https://github.com/reactioncommerce/reaction-component-library/pull/395