### PR TITLE
Add height theme prop to ShopLogo

### DIFF
--- a/package/src/components/ShopLogo/v1/ShopLogo.js
+++ b/package/src/components/ShopLogo/v1/ShopLogo.js
@@ -30,7 +30,7 @@ export default class ShopLogo extends Component {
   }
 
   render() {
-    const { className, height, shopLogoUrl, shopName } = this.props;
+    const { className, shopLogoUrl, shopName } = this.props;
 
     return (
       <Container className={className}>

--- a/package/src/components/ShopLogo/v1/ShopLogo.js
+++ b/package/src/components/ShopLogo/v1/ShopLogo.js
@@ -36,7 +36,7 @@ export default class ShopLogo extends Component {
       <Container className={className}>
         {
           shopLogoUrl ? (
-            <img src={shopLogoUrl} alt={shopName} />
+            <Logo src={shopLogoUrl} alt={shopName} />
           ) : (
             shopName
           )

--- a/package/src/components/ShopLogo/v1/ShopLogo.js
+++ b/package/src/components/ShopLogo/v1/ShopLogo.js
@@ -1,10 +1,14 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { addTypographyStyles } from "../../../utils";
+import { addTypographyStyles, applyTheme } from "../../../utils";
 
 const Container = styled.div`
   ${addTypographyStyles("ShopLogo", "titleTextBold")}
+`;
+
+const Logo = styled.img`
+  height: ${applyTheme("ShopLogo.height")};
 `;
 
 export default class ShopLogo extends Component {
@@ -26,7 +30,7 @@ export default class ShopLogo extends Component {
   }
 
   render() {
-    const { className, shopLogoUrl, shopName } = this.props;
+    const { className, height, shopLogoUrl, shopName } = this.props;
 
     return (
       <Container className={className}>

--- a/package/src/components/ShopLogo/v1/ShopLogo.md
+++ b/package/src/components/ShopLogo/v1/ShopLogo.md
@@ -17,8 +17,13 @@ Renders a shop's logo if a logo URL is provided, otherwise, it will render the s
 
 ### Theme
 
-See [Theming Components](./#!/Theming%20Components).
+Assume that any theme prop that does not begin with "rui" is within `rui_components`. See [Theming Components](./#!/Theming%20Components).
+
+| Theme Prop                                         | Default | Description                                                                             |
+| -------------------------------------------------- | ------- | --------------------------------------------------------------------------------------- |
+| `ShopLogo.height` | `auto` | The height of `ShopLogo`'s `img` tag, when providing a logo URL |
 
 #### Typography
 
 - The text rendered when there is not a logo uses `titleTextBold` style with `rui_components.ShopLogo` override
+

--- a/package/src/components/ShopLogo/v1/__snapshots__/ShopLogo.test.js.snap
+++ b/package/src/components/ShopLogo/v1/__snapshots__/ShopLogo.test.js.snap
@@ -16,11 +16,16 @@ exports[`basic snapshot 1`] = `
   line-height: 1.25;
 }
 
+.c1 {
+  height: auto;
+}
+
 <div
   className="c0"
 >
   <img
     alt="Reaction"
+    className="c1"
     src="//placehold.it/60"
   />
 </div>

--- a/package/src/theme/defaultComponentTheme.js
+++ b/package/src/theme/defaultComponentTheme.js
@@ -675,6 +675,9 @@ const rui_components = {
     borderTopLeftRadius: 0,
     borderTopRightRadius: standardBorderRadius
   },
+  ShopLogo: {
+    height: "auto"
+  },
   StockWarning: {
     typography: {
       color: colors.red


### PR DESCRIPTION
Resolves #403
Impact: **minor**  
Type: **feature**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
There was no way to set `ShopLogo`'s `img` height through theming, which is a bit of a pain when using vector images as they appear huge by default.

## Screenshots
Here's a test with `
<img width="1680" alt="screen shot 2019-03-03 at 19 36 26" src="https://user-images.githubusercontent.com/45489203/53697551-bed8d100-3deb-11e9-88d6-27e315cb3673.png">
<img width="1680" alt="screen shot 2019-03-03 at 19 36 43" src="https://user-images.githubusercontent.com/45489203/53697553-c1d3c180-3deb-11e9-8682-b2317e5098aa.png">


## Breaking changes
None.

## Testing
1. Change the value of `ShopLogo.height` in `src/theme/defaultComponentTheme.js`.
2. See that the the placeholder image is now at your desired height on `http://localhost:4040/#!/ShopLogo`.