### PR TITLE
fix: trigger onChange when new address is received

### DIFF
--- a/package/src/components/AddressChoice/v1/AddressChoice.js
+++ b/package/src/components/AddressChoice/v1/AddressChoice.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import isEqual from "lodash.isequal";
 import { withComponents } from "@reactioncommerce/components-context";
 import { addressToString, CustomPropTypes } from "../../../utils";
 
@@ -67,6 +68,13 @@ class AddressChoice extends Component {
     }
 
     this.state = { selectedOption };
+  }
+
+  componentDidUpdate({ addresses }) {
+    const { selectedOption } = this.state;
+    if (selectedOption === "0" && !isEqual(addresses[0], this.props.addresses[0])) {
+      this.handleChangeSelection(selectedOption);
+    }
   }
 
   handleChangeAddress = (address) => {


### PR DESCRIPTION
Resolves #405
Impact: **major**  
Type: **bugfix|**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
`AddressChoice`

## Breaking changes
None

## Testing
1. In `CheckoutActions`, enter shipping address and select shipping method.
2. When payment form is rendered, check the `state` of `PaymentsCheckoutAction`, the billing address should be the same as the shipping address.
3. Change a field in Shipping address and save it. Check that the `state` of `PaymentsCheckoutAction` has been updated.