### PR TITLE
fix(selectableitem): remove cascading div styling

### DIFF
--- a/package/src/components/SelectableItem/v1/SelectableItem.js
+++ b/package/src/components/SelectableItem/v1/SelectableItem.js
@@ -75,7 +75,8 @@ const StyledInput = styled.input`
 const StyledDetail = styled.div`
   ${addTypographyStyles("SelectableItemDetail", "bodyText")}
   align-items: center;
-  display: flex;
+  display: ${(props) => (props.isStacked ? "block" : "flex")};
+  height: auto;
   justify-content: ${(props) => (props.isStacked ? "flex-start" : "center")};
   margin-left: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingToLabel")(props) : "0")};
   margin-top: ${(props) => (props.isStacked ? applyTheme("SelectableList.stackedSpacingBelowLabel")(props) : "0")};

--- a/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
+++ b/package/src/components/SelectableItem/v1/__snapshots__/SelectableItem.test.js.snap
@@ -118,6 +118,7 @@ exports[`basic snapshot with empty props 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  height: auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/package/src/components/SelectableList/v1/SelectableList.js
+++ b/package/src/components/SelectableList/v1/SelectableList.js
@@ -109,11 +109,6 @@ const HorizontalWrapper = styled.div`
   &:last-of-type {
     padding-left: ${applyTheme("SelectableList.horizontalLastItemPaddingLeft")};
   }
-
-  div {
-    display: block;
-    height: auto;
-  }
 `;
 
 class SelectableList extends Component {


### PR DESCRIPTION
Signed-off-by: Machiko Yasuda <machiko@reactioncommerce.com>

Impact: **minor**  
Type: **bugfix|refactor**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## SelectableItem / SelectableList in Horizontal mode
- Moved CSS styles from `SelectableList` down to the child, `SelectableItem` so that the styles only apply to the `detail` element, and not any other `div` that is in `SelectableList`.

## Screenshots
- Should look the same

## Test cases
1. Test that `isHorizontal` lists look and work the same way: https://deploy-preview-407--stoic-hodgkin-c0179e.netlify.com/#!/AddressReview
2. Test this branch on projects that use the Component Library

## Test instructions for an app that uses Component Library
1. Change `package.json` to: ` "@reactioncommerce/components": "reactioncommerce/reaction-component-library#236-machikoyasuda-fix-horizwrap",`
2. `docker-compose up --build`
3. Open the app and find somewhere where a horizontal SelectableList is used - often in AddressReview