### PR TITLE
fix: babel transform mjs files

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -77,5 +77,5 @@ ignore:
   'npm:mem:20180117':
     - libnpx > yargs > os-locale > mem:
         reason: No update available
-        expires: '2019-03-31T21:10:49.245Z'
+        expires: '2019-05-04T20:58:36.166Z'
 patch: {}

--- a/babel.config.js
+++ b/babel.config.js
@@ -44,9 +44,14 @@ module.exports = function (api) {
           browsers: [
             "last 2 versions",
             "ie 11"
-          ],
-          // "browsers" target is ignored when "esmodules" is true
-          esmodules
+          ]
+          // Note: If we eventually drop IE11 supports, it should be safe
+          // to go back to passing `esmodules: true` here. But for now,
+          // we want the mjs files to be transformed to be IE11 compatible
+          // EXCEPT for `import`. This allows Webpack 4 to tree shake this
+          // package but yet still remain compatible with IE11 without
+          // further transformation by the app using this package.
+          // esmodules
         },
         // https://babeljs.io/docs/en/babel-preset-env#usebuiltins-usage-experimental
         useBuiltIns: "usage"


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Changes
Changed Babel config.

Previously, when building the `mjs` ES module files, they were being transformed to target only modern browsers that support ES modules. We intended to keep IE11 support in those files, so this was wrong. For example, the built `mjs` files still contained arrow functions, which IE11 doesn't understand.

Now, the `mjs` files are still ES module files that Webpack can tree shake, but all code within them except for the `import` and `export` lines are transpiled the same way as for `js` files. For example, arrow functions become regular functions and thus are understood by IE11.

## Testing
Run `yarn build` command in the `/package` directory and look at the `.mjs` files created in `dist`. They should have all of the Babel transformations such as converting arrow functions to standard functions.