### PR TITLE
fix styleguidist configuration so that everything gets its own page

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -382,7 +382,8 @@ module.exports = {
           name: "Developing Locally Inside Another Project",
           content: "styleguide/src/sections/LocalDevelopment.md"
         }
-      ]
+      ],
+      sectionDepth:2
     },
     {
       name: "Style",
@@ -395,7 +396,8 @@ module.exports = {
           name: "Typography",
           content: "styleguide/src/sections/Typography.md"
         }
-      ]
+      ],
+      sectionDepth:2
     },
     {
       name: "Base Components",
@@ -444,7 +446,8 @@ module.exports = {
           content: "styleguide/src/sections/Menus.md",
           name: "Menus"
         })
-      ]
+      ],
+      sectionDepth:2
     },
     {
       name: "Storefront Components",
@@ -522,7 +525,8 @@ module.exports = {
           content: "styleguide/src/sections/Product.md",
           name: "Product"
         })
-      ]
+      ],
+      sectionDepth:2
     }
   ],
   require: ["@babel/polyfill", path.join(__dirname, "styleguide/src/styles.css")],

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -383,7 +383,7 @@ module.exports = {
           content: "styleguide/src/sections/LocalDevelopment.md"
         }
       ],
-      sectionDepth:2
+      sectionDepth: 2
     },
     {
       name: "Style",
@@ -397,7 +397,7 @@ module.exports = {
           content: "styleguide/src/sections/Typography.md"
         }
       ],
-      sectionDepth:2
+      sectionDepth: 2
     },
     {
       name: "Base Components",
@@ -447,7 +447,7 @@ module.exports = {
           name: "Menus"
         })
       ],
-      sectionDepth:2
+      sectionDepth: 2
     },
     {
       name: "Storefront Components",
@@ -526,7 +526,7 @@ module.exports = {
           name: "Product"
         })
       ],
-      sectionDepth:2
+      sectionDepth: 2
     }
   ],
   require: ["@babel/polyfill", path.join(__dirname, "styleguide/src/styles.css")],


### PR DESCRIPTION
Signed-off-by: Christopher Shepherd <christopher@reactioncommerce.com>
Closes: https://github.com/reactioncommerce/reaction-component-library/issues/422
Impact: **minor**  
Type: **bugfix**

<!-- 📦🚀 This project is deployed with [semantic-release](https://github.com/semantic-release/semantic-release) -->

<!-- Any PR with commits that start with `feat:` or `fix:` will trigger new major or minor release respectively -->

## Component
No components or dependencies changed, just updated styleguidist.config.js so that every topic gets its own page instead of rendering the whole style guide on one huge slow page
