### PR TITLE
fix: remove core-js deps from published build

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
+version: v1.12.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:hoek:20180212':
@@ -77,5 +77,5 @@ ignore:
   'npm:mem:20180117':
     - libnpx > yargs > os-locale > mem:
         reason: No update available
-        expires: '2019-08-15T22:17:20.703Z'
+        expires: '2019-09-19T20:03:04.825Z'
 patch: {}

--- a/babel.config.js
+++ b/babel.config.js
@@ -54,7 +54,7 @@ module.exports = function (api) {
           // esmodules
         },
         // https://babeljs.io/docs/en/babel-preset-env#usebuiltins-usage-experimental
-        useBuiltIns: "usage"
+        useBuiltIns: "entry"
       }
     ],
     "@babel/preset-react"


### PR DESCRIPTION
Resolves #432 
Impact: **minor**  
Type: **bugfix**

## Issue
The published package files have imports of "core-js" package paths, which are different between v2 and v3 of core-js. This creates an unnecessary requirement that the app using this package must use either v2 or v3, depending on what was used to publish this package.

## Solution
Changes the Babel config so that these imports are not added to the built files. This means that there is now an expectation that the app using this package will have polyfilled all runtime APIs that this package needs. We may want to document the exact ones, but for now we should tell apps to load everything by doing this before all other code:

```js
import 'core-js/stable';
import 'regenerator-runtime/runtime';
```

Or if using Babel, use `useBuiltIns: 'entry'` in Babel config to do this automatically.

## Breaking changes
No

## Testing
`cd package && yarn build`, then search for "core-js" in the `dist` folder and verify nothing is found