### PR TITLE
feat: added  label overrides on AccountProfileInfo

### DIFF
--- a/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
+++ b/package/src/components/AccountProfileInfo/v1/AccountProfileInfo.js
@@ -55,6 +55,10 @@ class AccountProfileInfo extends Component {
       ProfileImage: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
     }),
     /**
+     * The text for the "Edit Account" text, if it is shown.
+     */
+    editAccountButtonText: PropTypes.string,
+    /**
      * Function to pass to button onClick
      */
     onClickEdit: PropTypes.func,
@@ -75,6 +79,7 @@ class AccountProfileInfo extends Component {
   };
 
   static defaultProps = {
+    editAccountButtonText: "Edit Account",
     shouldShowEditButton: false
   };
 
@@ -104,11 +109,11 @@ class AccountProfileInfo extends Component {
   }
 
   viewerProfileEditLink = () => {
-    const { components: { Button }, onClickEdit, shouldShowEditButton } = this.props;
+    const { components: { Button }, onClickEdit, shouldShowEditButton, editAccountButtonText } = this.props;
 
     if (shouldShowEditButton) {
       return (
-        <Button isShortHeight isTextOnly isTextOnlyNoPadding onClick={onClickEdit}>Edit Account</Button>
+        <Button isShortHeight isTextOnly isTextOnlyNoPadding onClick={onClickEdit}>{editAccountButtonText}</Button>
       );
     }
     return null;


### PR DESCRIPTION
Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
AccountProfileInfo now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `editAccountButtonText` or to `<AccountProfileInfo />` 
2. Add the value `"test"` to editAccountButtonText
3. Button should display "test" when test is given as a value to the prop. When the prop `editAccountButtonText` is not added, it should default to the values given in default props
