### PR TITLE
feat: added text overrides on CartItem

### DIFF
--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -271,13 +271,9 @@ class CartItem extends Component {
      */
     removeText: PropTypes.string,
     /**
-     * The text for the "Remove" button text.
-     */
-    removeText: PropTypes.string,
-    /**
      * The text for the "Total" title text.
      */
-    totalText: PropTypes.string,
+    totalText: PropTypes.string
   };
 
   static defaultProps = {

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -338,8 +338,9 @@ class CartItem extends Component {
         isLowQuantity,
         price: { displayAmount: displayPrice },
         subtotal,
-        removeText
-      }
+      },
+      removeText,
+      totalText
     } = this.props;
 
     const { displayAmount: displaySubtotal } = subtotal || {};

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -333,7 +333,7 @@ class CartItem extends Component {
         quantity,
         isLowQuantity,
         price: { displayAmount: displayPrice },
-        subtotal,
+        subtotal
       },
       removeText,
       totalText

--- a/package/src/components/CartItem/v1/CartItem.js
+++ b/package/src/components/CartItem/v1/CartItem.js
@@ -265,14 +265,28 @@ class CartItem extends Component {
     /**
      * Product URL path to be prepended before the slug
      */
-    productURLPath: PropTypes.string
+    productURLPath: PropTypes.string,
+    /**
+     * Text to display inside the remove button
+     */
+    removeText: PropTypes.string,
+    /**
+     * The text for the "Remove" button text.
+     */
+    removeText: PropTypes.string,
+    /**
+     * The text for the "Total" title text.
+     */
+    totalText: PropTypes.string,
   };
 
   static defaultProps = {
     isMiniCart: false,
     isReadOnly: false,
     onChangeCartItemQuantity() { },
-    onRemoveItemFromCart() { }
+    onRemoveItemFromCart() { },
+    removeText: "Remove",
+    totalText: "Total"
   };
 
   state = {
@@ -323,7 +337,8 @@ class CartItem extends Component {
         quantity,
         isLowQuantity,
         price: { displayAmount: displayPrice },
-        subtotal
+        subtotal,
+        removeText
       }
     } = this.props;
 
@@ -368,7 +383,7 @@ class CartItem extends Component {
               }
             </ItemContentDetailInner>
 
-            {!isReadOnly && <ItemRemoveButton onClick={this.handleRemoveItemFromCart}>Remove</ItemRemoveButton>}
+            {!isReadOnly && <ItemRemoveButton onClick={this.handleRemoveItemFromCart}>{removeText}</ItemRemoveButton>}
           </ItemContentDetail>
         </ItemContent>
         <ItemContentPrice isMiniCart={isMiniCart}>
@@ -379,7 +394,7 @@ class CartItem extends Component {
           />
           { quantity !== 1 ?
             <ItemContentSubtotal isMiniCart={isMiniCart}>
-              <ItemContentSubtotalTitle>Total ({quantity}):</ItemContentSubtotalTitle>
+              <ItemContentSubtotalTitle>{totalText} ({quantity}):</ItemContentSubtotalTitle>
               <ItemContentSubtotalDisplay>{displaySubtotal}</ItemContentSubtotalDisplay>
             </ItemContentSubtotal>
             :


### PR DESCRIPTION
Part of: #409
Impact: minor
Type: feature

Component
CartItem now has overrides when i18next will be implemented (see #409)

Breaking changes
No breaking chances, all added fields are optional

Testing
Add a new prop `messageText` or `totalText` to `<CartItem />`
Add the value "test" to either `messageText` or `totalText`
Button or title should display "test" when test is given as a value to the prop. When the prop `messageText` or `totalText` is not added, it should default to the values given in default props