### PR TITLE
feat: added text override on CheckoutActionComplete

### DIFF
--- a/package/src/components/CheckoutActionComplete/v1/CheckoutActionComplete.js
+++ b/package/src/components/CheckoutActionComplete/v1/CheckoutActionComplete.js
@@ -54,6 +54,10 @@ const ActionButton = styled.div`
 class CheckoutActionComplete extends Component {
   static propTypes = {
     /**
+     * The text for the "Change" button text.
+     */
+    changeButtonText: PropTypes.string,
+    /**
      * You can provide a `className` prop that will be applied to the outermost DOM element
      * rendered by this component. We do not recommend using this for styling purposes, but
      * it can be useful as a selector in some situations.
@@ -91,10 +95,14 @@ class CheckoutActionComplete extends Component {
     stepNumber: PropTypes.number
   };
 
+  static defaultProps = {
+    changeButtonText: "Change"
+  }
+
   handleOnChange = () => this.props.onClickChangeButton();
 
   render() {
-    const { className, components: { Button }, content, label, stepNumber } = this.props;
+    const { className, components: { Button }, content, label, stepNumber, changeButtonText } = this.props;
 
     const step = stepNumber ? <Fragment>{stepNumber}.&nbsp;</Fragment> : null;
 
@@ -107,7 +115,7 @@ class CheckoutActionComplete extends Component {
           {content}
         </ActionDetail>
         <ActionButton>
-          <Button actionType="important" onClick={this.handleOnChange} isShortHeight isTextOnly>Change</Button>
+          <Button actionType="important" onClick={this.handleOnChange} isShortHeight isTextOnly>{changeButtonText}</Button>
         </ActionButton>
       </ActionContainer>
     );


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
CheckoutActionComplete now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `changeButtonText` to `<CheckoutActionComplete />` 
2. Add the value `"test"` to `changeButtonText`
3. Button should display "test" when test is given as a value to the prop. When the prop `changeButtonText` is not added, it should default to the values given in default props
