### PR TITLE
feat: added text overrides on CheckoutEmailAddress

### DIFF
--- a/package/src/components/CheckoutEmailAddress/v1/CheckoutEmailAddress.js
+++ b/package/src/components/CheckoutEmailAddress/v1/CheckoutEmailAddress.js
@@ -36,14 +36,22 @@ class CheckoutEmailAddress extends Component {
      */
     className: PropTypes.string,
     emailAddress: PropTypes.string.isRequired,
-    isAccountEmail: PropTypes.bool.isRequired
+    isAccountEmail: PropTypes.bool.isRequired,
+    /**
+     * The text for the "Signed in as" label text.
+     */
+    signedInText: PropTypes.string,
   };
 
+  static defaultProps = {
+    signedInText: "Signed in as"
+  }
+
   renderAccountEmail = () => {
-    const { isAccountEmail } = this.props;
+    const { isAccountEmail, signedInText } = this.props;
 
     if (isAccountEmail) {
-      return "Signed in as";
+      return signedInText;
     }
 
     return null;


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
CheckoutEmailAddress now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `signedInText` to `<CheckoutEmailAddress />` 
2. Add the value `"test"` to `signedInText`
3. Button should display "test" when test is given as a value to the prop. When the prop `signedInText` is not added, it should default to the values given in default props

## Added props:
```
signedInText: PropTypes.string,
```
