### PR TITLE
feat: added text overrides on GuestForm

### DIFF
--- a/package/src/components/GuestForm/v1/GuestForm.js
+++ b/package/src/components/GuestForm/v1/GuestForm.js
@@ -62,6 +62,14 @@ class GuestForm extends Component {
       TextInput: CustomPropTypes.component.isRequired
     }).isRequired,
     /**
+     * The text for the "Email address" label text.
+     */
+    emailLabelText: PropTypes.string,
+    /**
+     * The text for the "Email address" placeholder text.
+     */
+    emailPlaceholderText: PropTypes.string,
+    /**
      * Errors array
      */
     errors: PropTypes.arrayOf(PropTypes.shape({
@@ -112,7 +120,9 @@ class GuestForm extends Component {
     validator: getRequiredValidator("email"),
     value: {
       email: ""
-    }
+    },
+    emailLabelText: "Email address",
+    emailPlaceholderText: "Email address"
   };
 
   _form = null;
@@ -132,6 +142,8 @@ class GuestForm extends Component {
       buttonText,
       className,
       components: { Button, ErrorsBlock, Field, TextInput },
+      emailLabelText,
+      emailPlaceholderText,
       errors,
       helpText,
       isSaving,
@@ -153,8 +165,8 @@ class GuestForm extends Component {
         validator={validator}
         value={value}
       >
-        <Field name="email" label="Email Address" isRequired helpText={helpText}>
-          <TextInput id={emailInputId} isReadOnly={isSaving} name="email" placeholder="Email address"
+        <Field name="email" label={emailLabelText} isRequired helpText={helpText}>
+          <TextInput id={emailInputId} isReadOnly={isSaving} name="email" placeholder={emailPlaceholderText}
             type="email"
           />
           <ErrorsBlock names={["email"]} />


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
GuestForm now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `emailLabelText` to `<GuestForm />` 
2. Add the value `"test"` to `emailLabelText`
3. Button should display "test" when test is given as a value to the prop. When the prop `emailLabelText` is not added, it should default to the values given in default props

## Added props:
```
emailLabelText: PropTypes.string,
emailPlaceholderText: PropTypes.string
```
