### PR TITLE
feat: added text overrides on MiniCart

### DIFF
--- a/package/src/components/MiniCart/v1/MiniCart.js
+++ b/package/src/components/MiniCart/v1/MiniCart.js
@@ -167,7 +167,7 @@ class MiniCart extends Component {
       className,
       checkoutButtonText,
       components: { Button, CartCheckoutButton, CartItems, MiniCartSummary },
-      footerMessageText.
+      footerMessageText,
       onCheckoutButtonClick,
       ...props
     } = this.props;

--- a/package/src/components/MiniCart/v1/MiniCart.js
+++ b/package/src/components/MiniCart/v1/MiniCart.js
@@ -93,6 +93,10 @@ class MiniCart extends Component {
       items: PropTypes.arrayOf(PropTypes.object).isRequired
     }),
     /**
+     * The text for the "Checkout" button text.
+     */
+    checkoutButtonText: PropTypes.string,
+    /**
      * You can provide a `className` prop that will be applied to the outermost DOM element
      * rendered by this component. We do not recommend using this for styling purposes, but
      * it can be useful as a selector in some situations.
@@ -128,6 +132,10 @@ class MiniCart extends Component {
       MiniCartSummary: CustomPropTypes.component.isRequired
     }),
     /**
+     * The text for the "Shipping and tax calculated in checkout" message text.
+     */
+    footerMessageText: PropTypes.string,
+    /**
      * On cart item quantity change handler
      */
     onChangeCartItemQuantity: PropTypes.func,
@@ -148,14 +156,18 @@ class MiniCart extends Component {
   static defaultProps = {
     onChangeCartItemQuantity() {},
     onCheckoutButtonClick() {},
-    onRemoveItemFromCart() {}
+    onRemoveItemFromCart() {},
+    checkoutButtonText: "Checkout",
+    footerMessageText: "Shipping and tax calculated in checkout"
   };
 
   render() {
     const {
       cart: { checkout: { summary }, items },
       className,
+      checkoutButtonText,
       components: { Button, CartCheckoutButton, CartItems, MiniCartSummary },
+      footerMessageText.
       onCheckoutButtonClick,
       ...props
     } = this.props;
@@ -168,10 +180,10 @@ class MiniCart extends Component {
           <MiniCartSummary displaySubtotal={summary.itemTotal.displayAmount} />
           {(CartCheckoutButton && <CartCheckoutButton onClick={onCheckoutButtonClick} />) || (
             <Button actionType="important" isFullWidth onClick={onCheckoutButtonClick}>
-              Checkout
+              {checkoutButtonText}
             </Button>
           )}
-          <FooterMessage>Shipping and tax calculated in checkout</FooterMessage>
+          <FooterMessage>{footerMessageText}</FooterMessage>
         </Footer>
       </Cart>
     );


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
MiniCart now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `checkoutButtonText` to `<MiniCart />` 
2. Add the value `"test"` to `checkoutButtonText`
3. Button should display "test" when test is given as a value to the prop. When the prop `checkoutButtonText` is not added, it should default to the values given in default props

## Added props:
```
checkoutButtonText: PropTypes.string,
footerMessageText: PropTypes.string
```
