### PR TITLE
feat: added text overrides on MiniCartSummary

### DIFF
--- a/package/src/components/MiniCartSummary/v1/MiniCartSummary.js
+++ b/package/src/components/MiniCartSummary/v1/MiniCartSummary.js
@@ -44,29 +44,42 @@ class MiniCartSummary extends Component {
     /**
      * The computed taxes for items in the cart.
      */
-    displayTax: PropTypes.string
+    displayTax: PropTypes.string,
+    /**
+     * The text for the "Tax" label text.
+     */
+    taxLabelText: PropTypes.string,
+    /**
+     * The text for the "Subtotal" label text.
+     */
+    subtotalLabelText: PropTypes.string,
   };
 
+  static defaultProps = {
+    taxLabelText: "Tax",
+    subtotalLabelText: "Subtotal",
+  }
+
   renderTax = () => {
-    const { displayTax } = this.props;
+    const { displayTax, taxLabelText } = this.props;
 
     return (
       <tr>
-        <Td>Tax</Td>
+        <Td>{taxLabelText}</Td>
         <TdValue>{displayTax}</TdValue>
       </tr>
     );
   };
 
   render() {
-    const { className, displaySubtotal, displayTax } = this.props;
+    const { className, displaySubtotal, displayTax, subtotalLabelText } = this.props;
     const taxes = displayTax && this.renderTax();
 
     return (
       <Table className={className}>
         <tbody>
           <tr>
-            <Td>Subtotal</Td>
+            <Td>{subtotalLabelText}</Td>
             <TdValue>{displaySubtotal}</TdValue>
           </tr>
           {taxes}


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
MiniCartSummary now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `subtotalLabelText` to `<MiniCartSummary />` 
2. Add the value `"test"` to `subtotalLabelText`
3. Button should display "test" when test is given as a value to the prop. When the prop `subtotalLabelText` is not added, it should default to the values given in default props

## Added props:
```
taxLabelText: PropTypes.string,
subtotalLabelText: PropTypes.string
```
