### PR TITLE
feat: added text overrides on PaymentsCheckoutAction

### DIFF
--- a/package/src/components/PaymentsCheckoutAction/v1/PaymentsCheckoutAction.js
+++ b/package/src/components/PaymentsCheckoutAction/v1/PaymentsCheckoutAction.js
@@ -37,6 +37,10 @@ class PaymentsCheckoutAction extends Component {
      */
     alert: CustomPropTypes.alert,
     /**
+     * The text for the "Billing Address" title text.
+     */
+    billingAddressTitleText: PropTypes.string,
+    /**
      * You can provide a `className` prop that will be applied to the outermost DOM element
      * rendered by this component. We do not recommend using this for styling purposes, but
      * it can be useful as a selector in some situations.
@@ -120,7 +124,8 @@ class PaymentsCheckoutAction extends Component {
   static defaultProps = {
     onReadyForSaveChange() {},
     onReset() {},
-    onSubmit() {}
+    onSubmit() {},
+    billingAddressTitleText: "Billing Address"
   };
 
   constructor(props) {
@@ -212,11 +217,11 @@ class PaymentsCheckoutAction extends Component {
   };
 
   renderBillingAddressForm() {
-    const { addresses, components: { AddressChoice }, isSaving } = this.props;
+    const { addresses, components: { AddressChoice }, isSaving, billingAddressTitleText } = this.props;
 
     return (
       <Fragment>
-        <Title>Billing Address</Title>
+        <Title>{billingAddressTitleText}</Title>
         <AddressChoice addresses={addresses} isReadOnly={isSaving} onChange={this.handleAddressChange} />
       </Fragment>
     );


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
PaymentsCheckoutAction now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `billingAddressTitleText` to `<PaymentsCheckoutAction />` 
2. Add the value `"test"` to `billingAddressTitleText`
3. Button should display "test" when test is given as a value to the prop. When the prop `billingAddressTitleText` is not added, it should default to the values given in default props

## Added props:
```
billingAddressTitleText: PropTypes.string,
```
