### PR TITLE
feat: added text overrides on StripePaymentCheckoutAction

### DIFF
--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -49,6 +49,10 @@ class StripePaymentCheckoutAction extends Component {
      */
     alert: CustomPropTypes.alert,
     /**
+     * The text for the "Billing Address" label text.
+     */
+    billingAddressTitleText: PropTypes.string,
+    /**
      * If you've set up a components context using
      * [@reactioncommerce/components-context](https://github.com/reactioncommerce/components-context)
      * (recommended), then this prop will come from there automatically. If you have not
@@ -100,13 +104,19 @@ class StripePaymentCheckoutAction extends Component {
      */
     onSubmit: PropTypes.func,
     /**
+     * The text for the "Your Information is private and secure." caption text.
+     */
+    secureCaptionText: PropTypes.string,
+    /**
      * Checkout process step number
      */
     stepNumber: PropTypes.number.isRequired
   };
 
   static defaultProps = {
-    onReadyForSaveChange() { }
+    billingAddressTitleText: "Billing Address"
+    onReadyForSaveChange() { },
+    secureCaptionText: "Your Information is private and secure.",
   };
 
   state = {
@@ -225,9 +235,11 @@ class StripePaymentCheckoutAction extends Component {
   render() {
     const {
       alert,
+      billingAddressTitleText,
       components: { iconLock, InlineAlert, SelectableList, StripeForm },
       label,
-      stepNumber
+      stepNumber,
+      secureCaptionText
     } = this.props;
 
     const { billingAddress } = this.state;
@@ -243,9 +255,9 @@ class StripePaymentCheckoutAction extends Component {
           stripeRef={(stripe) => { this._stripe = stripe; }}
         />
         <SecureCaption>
-          <IconLockSpan>{iconLock}</IconLockSpan> <Span>Your Information is private and secure.</Span>
+          <IconLockSpan>{iconLock}</IconLockSpan> <Span>{secureCaptionText}</Span>
         </SecureCaption>
-        <Title>Billing Address</Title>
+        <Title>{billingAddressTitleText}</Title>
         <SelectableList
           onChanging={this.handleUseNewBillingAddress}
           options={billingAddressOptions}

--- a/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
+++ b/package/src/components/StripePaymentCheckoutAction/v1/StripePaymentCheckoutAction.js
@@ -114,9 +114,9 @@ class StripePaymentCheckoutAction extends Component {
   };
 
   static defaultProps = {
-    billingAddressTitleText: "Billing Address"
+    billingAddressTitleText: "Billing Address",
     onReadyForSaveChange() { },
-    secureCaptionText: "Your Information is private and secure.",
+    secureCaptionText: "Your Information is private and secure."
   };
 
   state = {


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
StripePaymentCheckoutAction now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `billingAddressTitleText` to `<StripePaymentCheckoutAction />` 
2. Add the value `"test"` to `billingAddressTitleText`
3. Button should display "test" when test is given as a value to the prop. When the prop `billingAddressTitleText` is not added, it should default to the values given in default props

## Added props:
```
billingAddressTitleText: PropTypes.string,
secureCaptionText: PropTypes.string,
```
