### PR TITLE
feat: added text overrides on StripePaymentInput

### DIFF
--- a/package/src/components/StripePaymentInput/v1/StripePaymentInput.js
+++ b/package/src/components/StripePaymentInput/v1/StripePaymentInput.js
@@ -60,12 +60,17 @@ class StripePaymentInput extends Component {
      * method is called. The object may have `data`, `displayName`,
      * and `amount` properties.
      */
-    onSubmit: PropTypes.func
+    onSubmit: PropTypes.func,
+     /**
+     * The text for the "Your Information is private and secure." caption text.
+     */
+    secureCaptionText: PropTypes.string,
   };
 
   static defaultProps = {
     onReadyForSaveChange() {},
-    onSubmit() {}
+    onSubmit() {},
+    secureCaptionText: "Your Information is private and secure.",
   };
 
   componentDidMount() {
@@ -95,7 +100,7 @@ class StripePaymentInput extends Component {
   }
 
   render() {
-    const { className, components: { iconLock, StripeForm } } = this.props;
+    const { className, components: { iconLock, StripeForm }, secureCaptionText } = this.props;
 
     return (
       <div className={className}>
@@ -104,7 +109,7 @@ class StripePaymentInput extends Component {
           stripeRef={(stripe) => { this._stripe = stripe; }}
         />
         <SecureCaption>
-          <IconLockSpan>{iconLock}</IconLockSpan> <Span>Your Information is private and secure.</Span>
+          <IconLockSpan>{iconLock}</IconLockSpan> <Span>{secureCaptionText}</Span>
         </SecureCaption>
       </div>
     );


### PR DESCRIPTION
Signed-off-by: Haris Spahija <haris.spahija@pon.com>

Part of: #409 
Impact: **minor**  
Type: **feature**

## Component
StripePaymentInput now has overrides when i18next will be implemented (see #409)

## Breaking changes
No breaking chances, all added fields are optional

## Testing
1. Add a new prop `secureCaptionText` to `<StripePaymentInput />` 
2. Add the value `"test"` to `secureCaptionText`
3. Button should display "test" when test is given as a value to the prop. When the prop `secureCaptionText` is not added, it should default to the values given in default props

## Added props:
```
secureCaptionText: PropTypes.string,
```
